### PR TITLE
fix ScanImage + AddProjectMember expected return codes

### DIFF
--- a/project.go
+++ b/project.go
@@ -136,7 +136,7 @@ func (s *ProjectClient) AddProjectMember(pid int64, member MemberReq) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, fmt.Sprintf("/%d/members", pid)).
 		Send(member).
 		End()
-	return CheckResponse(errs, resp, 200)
+	return CheckResponse(errs, resp, 201)
 }
 
 // GetProjectMemberRole

--- a/repository.go
+++ b/repository.go
@@ -88,7 +88,7 @@ func (s *RepositoryClient) GetRepositoryTagManifests(repoName, tag string, versi
 func (s *RepositoryClient) ScanImage(repoName, tag string) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, fmt.Sprintf("/%s/tags/%s/scan", repoName, tag)).
 		End()
-	return CheckResponse(errs, resp, 200)
+	return CheckResponse(errs, resp, 202)
 }
 
 // GetImageDetails


### PR DESCRIPTION
```
POST ​/repositories​/{repo_name}​/tags​/{tag}​/scan
Scan the image
[...]
202 - Scan request is successfully accepted
```
```
POST ​/projects​/{project_id}​/members 
Create project member
[...]
201 - Project member created successfully
```

