### PR TITLE
Add registries & replications client, licensing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 A Harbor API client enabling Go programs to perform CRUD operations on [goharbor](https://github.com/goharbor/harbor) users and projects
 
+This library is build upon `goharbor/v1.10.2`, and utilizes typings from the upstream source [goharbor/harbor](https://github.com/goharbor/harbor), available under the 
+[Apache 2 license](https://github.com/goharbor/harbor/blob/master/LICENSE)
+
+The initial project is a fork of [TimeBye/go-harbor](https://github.com/TimeBye/go-harbor) and available under the MIT License
+ 
 [![GitHub license](https://img.shields.io/github/license/mittwald/goharbor-client.svg)](https://github.com/mittwald/goharbor-client/blob/master/LICENSE)
 
-This library is build upon `goharbor/v1.10.2`
 
 ## Usage
 
@@ -13,38 +17,47 @@ access different parts of the Harbor API.
 
 ```go
 package main
-
 import (
-    "errors"
-    "fmt"
-    "github.com/mittwald/goharbor-client"
+	"errors"
+	"fmt"
+	harbor "github.com/mittwald/goharbor-client"
 )
 
 func main() {
-    client, err := harbor.NewClient("url", "username", "password")
-    if err != nil {
-        panic(err)
-    }
+	client, err := harbor.NewClient("url", "username", "password")
+	if err != nil {
+		panic(err)
+	}
 
-    // Projects
-    projects, err := client.Projects().ListProjects(harbor.ListProjectOptions{})
-    if err != nil {
-        var e *harbor.StatusCodeError
-        if errors.As(err, &e) {
-            // handle status code error
-            fmt.Printf("request failed with status code: %d", e.StatusCode)
-        } else {
-            panic(err)
-        }
-    }
-    
-    for _, p := range projects {
-        fmt.Println(p.Name)
-    }
-    
-    // Users
-    users, err := client.Users().ListUsers()
-    // ...
+	// Projects
+	projects, err := client.Projects().ListProjects(harbor.ListProjectsOptions{})
+	if err != nil {
+		var e *harbor.StatusCodeError
+		if errors.As(err, &e) {
+			// handle status code error
+			fmt.Printf("request failed with status code: %d", e.StatusCode)
+		} else {
+			panic(err)
+		}
+	}
+
+	for _, p := range projects {
+		fmt.Println(p.Name)
+	}
+	
+	// Users
+	users, err := client.Users().ListUsers()
+	// ...
+
+	// Replications
+	replications, err := client.Replications().GetReplicationExecutionsByID(1)
+	//
+	
+	// Registries
+	registries, err := client.Registries().GetRegistryByID(1)
+	//
+
+	...
 }
 ```
 

--- a/client.go
+++ b/client.go
@@ -124,12 +124,23 @@ func (c *Client) Users() *UserClient {
 }
 
 func (c *Client) Repositories() *RepositoryClient {
-	u := &RepositoryClient{Client: &Client{
+	r := &RepositoryClient{Client: &Client{
 		baseURL:  c.baseURL,
 		username: c.username,
 		password: c.password,
 	}}
 
-	u.baseURLSuffix = "repositories"
-	return u
+	r.baseURLSuffix = "repositories"
+	return r
+}
+
+func (c *Client) Registries() *RegistryClient {
+	r := &RegistryClient{Client: &Client{
+		baseURL:  c.baseURL,
+		username: c.username,
+		password: c.password,
+	}}
+
+	r.baseURLSuffix = "registries"
+	return r
 }

--- a/client.go
+++ b/client.go
@@ -102,56 +102,31 @@ func CheckResponse(errs []error, resp gorequest.Response, expected int) error {
 	return nil
 }
 
+func (c *Client) withURLSuffix(suffix string) *Client {
+	return &Client{
+		baseURL:       c.baseURL,
+		username:      c.username,
+		password:      c.password,
+		baseURLSuffix: suffix,
+	}
+}
+
 func (c *Client) Projects() *ProjectClient {
-	p := &ProjectClient{Client: &Client{
-		baseURL:  c.baseURL,
-		username: c.username,
-		password: c.password,
-	}}
-	p.baseURLSuffix = "projects"
-	return p
+	return &ProjectClient{c.withURLSuffix("projects")}
 }
 
 func (c *Client) Users() *UserClient {
-	u := &UserClient{Client: &Client{
-		baseURL:  c.baseURL,
-		username: c.username,
-		password: c.password,
-	}}
-
-	u.baseURLSuffix = "users"
-	return u
+	return &UserClient{c.withURLSuffix("users")}
 }
 
 func (c *Client) Repositories() *RepositoryClient {
-	r := &RepositoryClient{Client: &Client{
-		baseURL:  c.baseURL,
-		username: c.username,
-		password: c.password,
-	}}
-
-	r.baseURLSuffix = "repositories"
-	return r
+	return &RepositoryClient{c.withURLSuffix("repositories")}
 }
 
 func (c *Client) Registries() *RegistryClient {
-	r := &RegistryClient{Client: &Client{
-		baseURL:  c.baseURL,
-		username: c.username,
-		password: c.password,
-	}}
-
-	r.baseURLSuffix = "registries"
-	return r
+	return &RegistryClient{c.withURLSuffix("registries")}
 }
 
 func (c *Client) Replications() *ReplicationClient {
-	r := &ReplicationClient{Client: &Client{
-		baseURL:  c.baseURL,
-		username: c.username,
-		password: c.password,
-	}}
-
-	r.baseURLSuffix = "replication"
-	return r
+	return &ReplicationClient{c.withURLSuffix("replication")}
 }

--- a/client.go
+++ b/client.go
@@ -144,3 +144,14 @@ func (c *Client) Registries() *RegistryClient {
 	r.baseURLSuffix = "registries"
 	return r
 }
+
+func (c *Client) Replications() *ReplicationClient {
+	r := &ReplicationClient{Client: &Client{
+		baseURL:  c.baseURL,
+		username: c.username,
+		password: c.password,
+	}}
+
+	r.baseURLSuffix = "replication"
+	return r
+}

--- a/project.go
+++ b/project.go
@@ -37,8 +37,7 @@ func (s *ProjectClient) CheckProject(projectName string) error {
 // Return specific project details
 func (s *ProjectClient) GetProjectByID(pid int64) (Project, error) {
 	var project Project
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape("/"+I64toA(pid))).
+	resp, _, errs := s.NewRequest(gorequest.GET,"/"+I64toA(pid)).
 		EndStruct(&project)
 	return project, CheckResponse(errs, resp, 200)
 }
@@ -56,8 +55,7 @@ func (s *ProjectClient) CreateProject(p ProjectRequest) error {
 // UpdateProject
 // Update the properties of a project
 func (s *ProjectClient) UpdateProject(pid int64, p Project) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape("/"+I64toA(pid))).
+	resp, _, errs := s.NewRequest(gorequest.PUT,"/"+I64toA(pid)).
 		Send(p).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -66,8 +64,7 @@ func (s *ProjectClient) UpdateProject(pid int64, p Project) error {
 // DeleteProject
 // Delete a project by project ID
 func (s *ProjectClient) DeleteProject(pid int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape("/"+I64toA(pid))).
+	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(pid)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -77,8 +74,7 @@ func (s *ProjectClient) DeleteProject(pid int64) error {
 func (s *ProjectClient) GetProjectLogByID(pid int64, opt ListLogOptions) ([]AccessLog, error) {
 	var accessLog []AccessLog
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%d/logs", pid))).
+		fmt.Sprintf("/%d/logs", pid)).
 		Query(opt).
 		EndStruct(&accessLog)
 	return accessLog, CheckResponse(errs, resp, 200)
@@ -89,8 +85,7 @@ func (s *ProjectClient) GetProjectLogByID(pid int64, opt ListLogOptions) ([]Acce
 func (s *ProjectClient) GetProjectMetadata(pid int64) (map[string]string, error) {
 	var metadata map[string]string
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%d/metedatas", pid))).
+		fmt.Sprintf("/%d/metedatas", pid)).
 		EndStruct(&metadata)
 	return metadata, CheckResponse(errs, resp, 200)
 }
@@ -99,8 +94,7 @@ func (s *ProjectClient) GetProjectMetadata(pid int64) (map[string]string, error)
 // Add metadata to a project
 func (s *ProjectClient) AddProjectMetadata(pid int64, metadata map[string]string) error {
 	resp, _, errs := s.NewRequest(gorequest.POST,
-		url.PathEscape(
-			fmt.Sprintf("/%d/metadatas", pid))).
+		fmt.Sprintf("/%d/metadatas", pid)).
 		Send(metadata).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -111,8 +105,7 @@ func (s *ProjectClient) AddProjectMetadata(pid int64, metadata map[string]string
 func (s *ProjectClient) GetProjectMetadataSingle(pid int64, specified string) (map[string]string, error) {
 	var metadata map[string]string
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%d/metadatas/%s", pid, specified))).
+		fmt.Sprintf("/%d/metadatas/%s", pid, url.PathEscape(specified))).
 		EndStruct(&metadata)
 	return metadata, CheckResponse(errs, resp, 200)
 }
@@ -121,8 +114,7 @@ func (s *ProjectClient) GetProjectMetadataSingle(pid int64, specified string) (m
 // Update the metadata of a project
 func (s *ProjectClient) UpdateProjectMetadataSingle(pid int64, metadataName string) error {
 	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape(
-			fmt.Sprintf("/%d/metadatas/%s", pid, metadataName))).
+		fmt.Sprintf("/%d/metadatas/%s", pid, url.PathEscape(metadataName))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -131,8 +123,7 @@ func (s *ProjectClient) UpdateProjectMetadataSingle(pid int64, metadataName stri
 // Delete a specified metadata value of a project
 func (s *ProjectClient) DeleteProjectMetadataSingle(pid int64, metadataName string) error {
 	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape(
-			fmt.Sprintf("/%d/metadatas/%s", pid, metadataName))).
+		fmt.Sprintf("/%d/metadatas/%s", pid, url.PathEscape(metadataName))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -142,8 +133,7 @@ func (s *ProjectClient) DeleteProjectMetadataSingle(pid int64, metadataName stri
 func (s *ProjectClient) GetProjectMembers(pid int64) ([]Member, error) {
 	var mem []Member
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%d/members", pid))).
+		fmt.Sprintf("/%d/members", pid)).
 		EndStruct(&mem)
 	return mem, CheckResponse(errs, resp, 200)
 }
@@ -152,8 +142,7 @@ func (s *ProjectClient) GetProjectMembers(pid int64) ([]Member, error) {
 // Add a project member to a project
 func (s *ProjectClient) AddProjectMember(pid int64, member MemberReq) error {
 	resp, _, errs := s.NewRequest(gorequest.POST,
-		url.PathEscape(
-			fmt.Sprintf("/%d/members", pid))).
+		fmt.Sprintf("/%d/members", pid)).
 		Send(member).
 		End()
 	return CheckResponse(errs, resp, 201)
@@ -164,8 +153,7 @@ func (s *ProjectClient) AddProjectMember(pid int64, member MemberReq) error {
 func (s *ProjectClient) GetProjectMember(pid, mid int64) (Role, error) {
 	var role Role
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%d/members/%d", pid, mid))).
+		fmt.Sprintf("/%d/members/%d", pid, mid)).
 		EndStruct(&role)
 	return role, CheckResponse(errs, resp, 200)
 }
@@ -174,8 +162,7 @@ func (s *ProjectClient) GetProjectMember(pid, mid int64) (Role, error) {
 // Update a project member
 func (s *ProjectClient) UpdateProjectMember(pid, mid int64, role RoleRequest) error {
 	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape(
-			fmt.Sprintf("/%d/members/%d", pid, mid))).
+		fmt.Sprintf("/%d/members/%d", pid, mid)).
 		Send(role).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -185,8 +172,7 @@ func (s *ProjectClient) UpdateProjectMember(pid, mid int64, role RoleRequest) er
 // Delete a project member
 func (s *ProjectClient) DeleteProjectMember(pid, mid int64) error {
 	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape(
-			fmt.Sprintf("/%d/members/%d", pid, mid))).
+		fmt.Sprintf("/%d/members/%d", pid, mid)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }

--- a/project.go
+++ b/project.go
@@ -3,6 +3,7 @@ package harbor
 import (
 	"fmt"
 	"github.com/parnurzeal/gorequest"
+	"net/url"
 )
 
 // ProjectClient handles communication with the project related methods of the Harbor API.
@@ -36,7 +37,8 @@ func (s *ProjectClient) CheckProject(projectName string) error {
 // Return specific project details
 func (s *ProjectClient) GetProjectByID(pid int64) (Project, error) {
 	var project Project
-	resp, _, errs := s.NewRequest(gorequest.GET, "/"+I64toA(pid)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape("/"+I64toA(pid))).
 		EndStruct(&project)
 	return project, CheckResponse(errs, resp, 200)
 }
@@ -54,7 +56,8 @@ func (s *ProjectClient) CreateProject(p ProjectRequest) error {
 // UpdateProject
 // Update the properties of a project
 func (s *ProjectClient) UpdateProject(pid int64, p Project) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, "/"+I64toA(pid)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape("/"+I64toA(pid))).
 		Send(p).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -63,7 +66,8 @@ func (s *ProjectClient) UpdateProject(pid int64, p Project) error {
 // DeleteProject
 // Delete a project by project ID
 func (s *ProjectClient) DeleteProject(pid int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(pid)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape("/"+I64toA(pid))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -72,7 +76,9 @@ func (s *ProjectClient) DeleteProject(pid int64) error {
 // Get access logs of a project with user-specified filter operations and date time ranges
 func (s *ProjectClient) GetProjectLogByID(pid int64, opt ListLogOptions) ([]AccessLog, error) {
 	var accessLog []AccessLog
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/logs", pid)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%d/logs", pid))).
 		Query(opt).
 		EndStruct(&accessLog)
 	return accessLog, CheckResponse(errs, resp, 200)
@@ -82,7 +88,9 @@ func (s *ProjectClient) GetProjectLogByID(pid int64, opt ListLogOptions) ([]Acce
 // Get the metadata of a project
 func (s *ProjectClient) GetProjectMetadata(pid int64) (map[string]string, error) {
 	var metadata map[string]string
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/metedatas", pid)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%d/metedatas", pid))).
 		EndStruct(&metadata)
 	return metadata, CheckResponse(errs, resp, 200)
 }
@@ -90,7 +98,9 @@ func (s *ProjectClient) GetProjectMetadata(pid int64) (map[string]string, error)
 // AddProjectMetadata
 // Add metadata to a project
 func (s *ProjectClient) AddProjectMetadata(pid int64, metadata map[string]string) error {
-	resp, _, errs := s.NewRequest(gorequest.POST, fmt.Sprintf("/%d/metadatas", pid)).
+	resp, _, errs := s.NewRequest(gorequest.POST,
+		url.PathEscape(
+			fmt.Sprintf("/%d/metadatas", pid))).
 		Send(metadata).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -100,7 +110,9 @@ func (s *ProjectClient) AddProjectMetadata(pid int64, metadata map[string]string
 // Get the specified metadata value of a project
 func (s *ProjectClient) GetProjectMetadataSingle(pid int64, specified string) (map[string]string, error) {
 	var metadata map[string]string
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/metadatas/%s", pid, specified)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%d/metadatas/%s", pid, specified))).
 		EndStruct(&metadata)
 	return metadata, CheckResponse(errs, resp, 200)
 }
@@ -108,7 +120,9 @@ func (s *ProjectClient) GetProjectMetadataSingle(pid int64, specified string) (m
 // UpdateProjectMetadata
 // Update the metadata of a project
 func (s *ProjectClient) UpdateProjectMetadataSingle(pid int64, metadataName string) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, fmt.Sprintf("/%d/metadatas/%s", pid, metadataName)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape(
+			fmt.Sprintf("/%d/metadatas/%s", pid, metadataName))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -116,7 +130,9 @@ func (s *ProjectClient) UpdateProjectMetadataSingle(pid int64, metadataName stri
 // DeleteProjectMetadata
 // Delete a specified metadata value of a project
 func (s *ProjectClient) DeleteProjectMetadataSingle(pid int64, metadataName string) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, fmt.Sprintf("/%d/metadatas/%s", pid, metadataName)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape(
+			fmt.Sprintf("/%d/metadatas/%s", pid, metadataName))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -125,7 +141,9 @@ func (s *ProjectClient) DeleteProjectMetadataSingle(pid int64, metadataName stri
 // Get members of the specified project
 func (s *ProjectClient) GetProjectMembers(pid int64) ([]Member, error) {
 	var mem []Member
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/members", pid)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%d/members", pid))).
 		EndStruct(&mem)
 	return mem, CheckResponse(errs, resp, 200)
 }
@@ -133,7 +151,9 @@ func (s *ProjectClient) GetProjectMembers(pid int64) ([]Member, error) {
 // AddProjectMember
 // Add a project member to a project
 func (s *ProjectClient) AddProjectMember(pid int64, member MemberReq) error {
-	resp, _, errs := s.NewRequest(gorequest.POST, fmt.Sprintf("/%d/members", pid)).
+	resp, _, errs := s.NewRequest(gorequest.POST,
+		url.PathEscape(
+			fmt.Sprintf("/%d/members", pid))).
 		Send(member).
 		End()
 	return CheckResponse(errs, resp, 201)
@@ -143,7 +163,9 @@ func (s *ProjectClient) AddProjectMember(pid int64, member MemberReq) error {
 // Get the role of a project member
 func (s *ProjectClient) GetProjectMember(pid, mid int64) (Role, error) {
 	var role Role
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/members/%d", pid, mid)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%d/members/%d", pid, mid))).
 		EndStruct(&role)
 	return role, CheckResponse(errs, resp, 200)
 }
@@ -151,7 +173,9 @@ func (s *ProjectClient) GetProjectMember(pid, mid int64) (Role, error) {
 // UpdateProjectMember
 // Update a project member
 func (s *ProjectClient) UpdateProjectMember(pid, mid int64, role RoleRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, fmt.Sprintf("/%d/members/%d", pid, mid)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape(
+			fmt.Sprintf("/%d/members/%d", pid, mid))).
 		Send(role).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -160,7 +184,9 @@ func (s *ProjectClient) UpdateProjectMember(pid, mid int64, role RoleRequest) er
 // DeleteProjectMember
 // Delete a project member
 func (s *ProjectClient) DeleteProjectMember(pid, mid int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, fmt.Sprintf("/%d/members/%d", pid, mid)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape(
+			fmt.Sprintf("/%d/members/%d", pid, mid))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }

--- a/project_types.go
+++ b/project_types.go
@@ -2,6 +2,10 @@ package harbor
 
 import "time"
 
+// To ensure type-safe queries to the harbor API,
+// the following typings include typings from the upstream sources:
+// https://github.com/goharbor/harbor/src/common/models/
+
 // AccessLog holds the information of log entries
 type AccessLog struct {
 	LogID     int       `json:"log_id"`

--- a/registry.go
+++ b/registry.go
@@ -3,6 +3,7 @@ package harbor
 import (
 	"fmt"
 	"github.com/parnurzeal/gorequest"
+	"net/url"
 )
 
 // RegistryClient handles communication with the registry related methods of the Harbor API
@@ -24,7 +25,9 @@ func (s *RegistryClient) GetRegistryByID(id int64) (Registry, error) {
 // Get a registry's info by ID
 func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
 	var v RegistryInfo
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/info", id)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%d/info", id))).
 		Query(id).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
@@ -33,7 +36,8 @@ func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
 // DeleteRegistryByID
 // Delete a registry by ID
 func (s *RegistryClient) DeleteRegistryByID(id int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(id)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape("/"+I64toA(id))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -41,7 +45,8 @@ func (s *RegistryClient) DeleteRegistryByID(id int64) error {
 // UpdateRegistryByID
 // Update a registry by ID
 func (s *RegistryClient) UpdateRegistryByID(registryName string, r Registry) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, "/"+registryName).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape("/"+registryName)).
 		Send(r).
 		End()
 	return CheckResponse(errs, resp, 200)

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,54 @@
+package harbor
+
+import "github.com/parnurzeal/gorequest"
+
+// RegistryClient handles communication with the registry related methods of the Harbor API
+type RegistryClient struct {
+	*Client
+}
+
+// GetRegistryByID
+// Get a registry by ID
+func (s *RegistryClient) GetRegistryByID(id int64) (Registry, error) {
+	var v Registry
+	resp, _, errs := s.NewRequest(gorequest.GET, "").
+		Query(id).
+		EndStruct(&v)
+	return v, CheckResponse(errs, resp, 200)
+}
+
+// GetRegistryInfoByID
+// Get a registry's info by ID
+func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
+	var v RegistryInfo
+	resp, _, errs := s.NewRequest(gorequest.GET, "").
+		Query(id).
+		EndStruct(&v)
+	return v, CheckResponse(errs, resp, 200)
+}
+
+// DeleteRegistryByID
+// Delete a registry by ID
+func (s *RegistryClient) DeleteRegistryByID(id int64) error {
+	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(id)).
+		End()
+	return CheckResponse(errs, resp, 200)
+}
+
+// UpdateRegistryByID
+// Update a registry by ID
+func (s *RegistryClient) UpdateRegistryByID(registryName string, r Registry) error {
+	resp, _, errs := s.NewRequest(gorequest.PUT, "/"+registryName).
+		Send(r).
+		End()
+	return CheckResponse(errs, resp, 200)
+}
+
+// PingRegistry
+// Ping a registry and return it's health status
+func (s *RegistryClient) PingRegistry(r Registry) error {
+	resp, _, errs := s.NewRequest(gorequest.POST, "").
+		Send(r).
+		End()
+	return CheckResponse(errs, resp, 200)
+}

--- a/registry.go
+++ b/registry.go
@@ -1,6 +1,9 @@
 package harbor
 
-import "github.com/parnurzeal/gorequest"
+import (
+	"fmt"
+	"github.com/parnurzeal/gorequest"
+)
 
 // RegistryClient handles communication with the registry related methods of the Harbor API
 type RegistryClient struct {
@@ -21,7 +24,7 @@ func (s *RegistryClient) GetRegistryByID(id int64) (Registry, error) {
 // Get a registry's info by ID
 func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
 	var v RegistryInfo
-	resp, _, errs := s.NewRequest(gorequest.GET, "").
+	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%d/info", id)).
 		Query(id).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
@@ -47,7 +50,7 @@ func (s *RegistryClient) UpdateRegistryByID(registryName string, r Registry) err
 // PingRegistry
 // Ping a registry and return it's health status
 func (s *RegistryClient) PingRegistry(r Registry) error {
-	resp, _, errs := s.NewRequest(gorequest.POST, "").
+	resp, _, errs := s.NewRequest(gorequest.POST, "/ping").
 		Send(r).
 		End()
 	return CheckResponse(errs, resp, 200)

--- a/registry.go
+++ b/registry.go
@@ -25,9 +25,7 @@ func (s *RegistryClient) GetRegistryByID(id int64) (Registry, error) {
 // Get a registry's info by ID
 func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
 	var v RegistryInfo
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%d/info", id))).
+	resp, _, errs := s.NewRequest(gorequest.GET,fmt.Sprintf("/%d/info", id)).
 		Query(id).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
@@ -36,8 +34,7 @@ func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
 // DeleteRegistryByID
 // Delete a registry by ID
 func (s *RegistryClient) DeleteRegistryByID(id int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape("/"+I64toA(id))).
+	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(id)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -45,8 +42,7 @@ func (s *RegistryClient) DeleteRegistryByID(id int64) error {
 // UpdateRegistryByID
 // Update a registry by ID
 func (s *RegistryClient) UpdateRegistryByID(registryName string, r Registry) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape("/"+registryName)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,"/"+url.PathEscape(registryName)).
 		Send(r).
 		End()
 	return CheckResponse(errs, resp, 200)

--- a/registry_types.go
+++ b/registry_types.go
@@ -2,6 +2,10 @@ package harbor
 
 import "time"
 
+// To ensure type-safe queries to the harbor API,
+// the following typings include typings from the upstream sources:
+// https://github.com/goharbor/harbor/src/replication/dao/models/
+
 // const definition
 const (
 	RegistryTypeHarbor           RegistryType = "harbor"

--- a/registry_types.go
+++ b/registry_types.go
@@ -1,0 +1,133 @@
+package harbor
+
+import "time"
+
+// const definition
+const (
+	RegistryTypeHarbor           RegistryType = "harbor"
+	RegistryTypeDockerHub        RegistryType = "docker-hub"
+	RegistryTypeDockerRegistry   RegistryType = "docker-registry"
+	RegistryTypeHuawei           RegistryType = "huawei-SWR"
+	RegistryTypeGoogleGcr        RegistryType = "google-gcr"
+	RegistryTypeAwsEcr           RegistryType = "aws-ecr"
+	RegistryTypeAzureAcr         RegistryType = "azure-acr"
+	RegistryTypeAliAcr           RegistryType = "ali-acr"
+	RegistryTypeJfrogArtifactory RegistryType = "jfrog-artifactory"
+	RegistryTypeQuayio           RegistryType = "quay-io"
+	RegistryTypeGitLab           RegistryType = "gitlab"
+
+	RegistryTypeHelmHub RegistryType = "helm-hub"
+
+	FilterStyleTypeText  = "input"
+	FilterStyleTypeRadio = "radio"
+	FilterStyleTypeList  = "list"
+)
+
+// RegistryType indicates the type of registry
+type RegistryType string
+
+// CredentialType represents the supported credential types
+// e.g: u/p, OAuth token
+type CredentialType string
+
+// Credential keeps the access key and/or secret for the related registry
+type Credential struct {
+	// Type of the credential
+	Type CredentialType `json:"type"`
+	// The key of the access account, for OAuth token, it can be empty
+	AccessKey string `json:"access_key"`
+	// The secret or password for the key
+	AccessSecret string `json:"access_secret"`
+}
+
+// Registry keeps the related info of registry
+// Data required for the secure access way is not contained here.
+// DAO layer is not considered here
+type Registry struct {
+	ID          int64        `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Type        RegistryType `json:"type"`
+	URL         string       `json:"url"`
+	// TokenServiceURL is only used for local harbor instance to
+	// avoid the requests passing through the external proxy for now
+	TokenServiceURL string      `json:"token_service_url"`
+	Credential      *Credential `json:"credential"`
+	Insecure        bool        `json:"insecure"`
+	Status          string      `json:"status"`
+	CreationTime    time.Time   `json:"creation_time"`
+	UpdateTime      time.Time   `json:"update_time"`
+}
+
+// RegistryQuery defines the query conditions for listing registries
+type RegistryQuery struct {
+	// Name is name of the registry to query
+	Name string
+	// Pagination specifies the pagination
+	Pagination *Pagination
+}
+
+// FilterType represents the type info of the filter.
+type FilterType string
+
+// FilterStyle ...
+type FilterStyle struct {
+	Type   FilterType `json:"type"`
+	Style  string     `json:"style"`
+	Values []string   `json:"values,omitempty"`
+}
+
+// EndpointPattern ...
+type EndpointPattern struct {
+	EndpointType EndpointType `json:"endpoint_type"`
+	Endpoints    []*Endpoint  `json:"endpoints"`
+}
+
+// EndpointType ..
+type EndpointType string
+
+// Endpoint ...
+type Endpoint struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// RegistryInfo provides base info and capability declarations of the registry
+type RegistryInfo struct {
+	Type                     RegistryType   `json:"type"`
+	Description              string         `json:"description"`
+	SupportedResourceTypes   []ResourceType `json:"-"`
+	SupportedResourceFilters []*FilterStyle `json:"supported_resource_filters"`
+	SupportedTriggers        []TriggerType  `json:"supported_triggers"`
+}
+
+// TriggerType represents the type of trigger.
+type TriggerType string
+
+// ResourceType represents the type of the resource
+type ResourceType string
+
+// ResourceMetadata of resource
+type ResourceMetadata struct {
+	Repository *Repository `json:"repository"`
+	Vtags      []string    `json:"v_tags"`
+	Labels     []string    `json:"labels"`
+}
+
+// Repository info of the resource
+type Repository struct {
+	Name     string                 `json:"name"`
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+// Resource represents the general replicating content
+type Resource struct {
+	Type         ResourceType           `json:"type"`
+	Metadata     *ResourceMetadata      `json:"metadata"`
+	Registry     *Registry              `json:"registry"`
+	ExtendedInfo map[string]interface{} `json:"extended_info"`
+	// Indicate if the resource is a deleted resource
+	Deleted bool `json:"deleted"`
+	// indicate whether the resource can be overridden
+	Override bool `json:"override"`
+}

--- a/replication.go
+++ b/replication.go
@@ -1,0 +1,91 @@
+package harbor
+
+import "github.com/parnurzeal/gorequest"
+
+// ReplicationClient handles communication with the replication related methods of the Harbor API
+type ReplicationClient struct {
+	*Client
+}
+
+// ListReplicationAdapters
+// Get all replication adapters
+func (s *RepositoryClient) ListReplicationAdapters() ([]string, error) {
+	var r []string
+	resp, _, errs := s.NewRequest(gorequest.GET, "/adapters").
+		EndStruct(&r)
+	return r, CheckResponse(errs, resp, 200)
+}
+
+// GetReplicationPolicies
+// Get an array of matching replication policies
+func (s *RepositoryClient) GetReplicationPolicies(name string) ([]ReplicationPolicy, error) {
+	var rp []ReplicationPolicy
+	resp, _, errs := s.NewRequest(gorequest.GET, "/policies").
+		Query(name).
+		EndStruct(&rp)
+	return rp, CheckResponse(errs, resp, 200)
+}
+
+
+// GetReplicationPolicies
+// Get a replication policy by ID
+func (s *RepositoryClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
+	var r ReplicationPolicy
+	resp, _, errs := s.NewRequest(gorequest.GET, "/policies"+I64toA(id)).
+		EndStruct(&r)
+	return r, CheckResponse(errs, resp, 200)
+}
+
+// UpdateReplicationPolicyByID
+// Update a replication policy by ID
+func (s *RepositoryClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
+	resp, _, errs := s.NewRequest(gorequest.PUT, "/policies"+I64toA(id)).
+		Send(policy).
+		End()
+	return CheckResponse(errs, resp, 200)
+}
+
+// DeleteReplicationPolicyByID
+// Delete a replication policy by ID
+func (s *RepositoryClient) DeleteReplicationPolicyByID(id int64) error {
+	resp, _, errs := s.NewRequest(gorequest.DELETE, "/policies"+I64toA(id)).
+		End()
+	return CheckResponse(errs, resp, 200)
+}
+
+// CreateReplicationPolicy
+// Create a replication policy
+func (s *RepositoryClient) CreateReplicationPolicy(rp ReplicationPolicy) error {
+	resp, _, errs := s.NewRequest(gorequest.POST, "/policies").
+		Send(rp).
+		End()
+	return CheckResponse(errs, resp, 201)
+}
+
+// GetReplicationExecutionsByID
+// Get replication executions filtered by replication ID
+func (s *RepositoryClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
+	var r ReplicationExecution
+	resp, _, errs := s.NewRequest(gorequest.GET, "/executions/"+I64toA(id)).
+		EndStruct(&r)
+	return r, CheckResponse(errs, resp, 200)
+}
+
+// TriggerReplicationExecution
+// Trigger a replication execution
+func (s *RepositoryClient) TriggerReplicationExecution(e ReplicationExecution) error {
+	resp, _, errs := s.NewRequest(gorequest.POST, "/executions").
+		Send(e).
+		End()
+	return CheckResponse(errs, resp, 201)
+}
+
+// GetReplicationPolicies
+// Get an array of matching replication policies
+func (s *RepositoryClient) GetReplicationExecutions(policyID int64, name string) ([]ReplicationExecution, error) {
+	var r []ReplicationExecution
+	resp, _, errs := s.NewRequest(gorequest.GET, "/policies").
+		Query(name).
+		EndStruct(&r)
+	return r, CheckResponse(errs, resp, 200)
+}

--- a/replication.go
+++ b/replication.go
@@ -2,7 +2,6 @@ package harbor
 
 import (
 	"github.com/parnurzeal/gorequest"
-	"net/url"
 )
 
 // ReplicationClient handles communication with the replication related methods of the Harbor API
@@ -33,8 +32,7 @@ func (s *ReplicationClient) GetReplicationPolicies(name string) ([]ReplicationPo
 // Get a replication policy by ID
 func (s *ReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
 	var r ReplicationPolicy
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape("/policies"+I64toA(id))).
+	resp, _, errs := s.NewRequest(gorequest.GET,"/policies"+I64toA(id)).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
@@ -42,8 +40,7 @@ func (s *ReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolic
 // UpdateReplicationPolicyByID
 // Update a replication policy by ID
 func (s *ReplicationClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape("/policies/"+I64toA(id))).
+	resp, _, errs := s.NewRequest(gorequest.PUT,"/policies/"+I64toA(id)).
 		Send(policy).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -52,8 +49,7 @@ func (s *ReplicationClient) UpdateReplicationPolicyByID(id int64, policy Replica
 // DeleteReplicationPolicyByID
 // Delete a replication policy by ID
 func (s *ReplicationClient) DeleteReplicationPolicyByID(id int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape("/policies/"+I64toA(id))).
+	resp, _, errs := s.NewRequest(gorequest.DELETE, "/policies/"+I64toA(id)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -71,8 +67,7 @@ func (s *ReplicationClient) CreateReplicationPolicy(rp ReplicationPolicy) error 
 // Get replication executions filtered by replication ID
 func (s *ReplicationClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
 	var r ReplicationExecution
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape("/executions/"+I64toA(id))).
+	resp, _, errs := s.NewRequest(gorequest.GET,"/executions/"+I64toA(id)).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
@@ -90,8 +85,7 @@ func (s *ReplicationClient) TriggerReplicationExecution(e ReplicationExecution) 
 // Get an array of matching replication policies
 func (s *ReplicationClient) GetReplicationExecutions(policyID int64, name string) ([]ReplicationExecution, error) {
 	var r []ReplicationExecution
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape("/executions/"+I64toA(policyID))).
+	resp, _, errs := s.NewRequest(gorequest.GET,"/executions/"+I64toA(policyID)).
 		Query(name).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)

--- a/replication.go
+++ b/replication.go
@@ -1,6 +1,9 @@
 package harbor
 
-import "github.com/parnurzeal/gorequest"
+import (
+	"github.com/parnurzeal/gorequest"
+	"net/url"
+)
 
 // ReplicationClient handles communication with the replication related methods of the Harbor API
 type ReplicationClient struct {
@@ -9,7 +12,7 @@ type ReplicationClient struct {
 
 // ListReplicationAdapters
 // Get all replication adapters
-func (s *RepositoryClient) ListReplicationAdapters() ([]string, error) {
+func (s *ReplicationClient) ListReplicationAdapters() ([]string, error) {
 	var r []string
 	resp, _, errs := s.NewRequest(gorequest.GET, "/adapters").
 		EndStruct(&r)
@@ -18,7 +21,7 @@ func (s *RepositoryClient) ListReplicationAdapters() ([]string, error) {
 
 // GetReplicationPolicies
 // Get an array of matching replication policies
-func (s *RepositoryClient) GetReplicationPolicies(name string) ([]ReplicationPolicy, error) {
+func (s *ReplicationClient) GetReplicationPolicies(name string) ([]ReplicationPolicy, error) {
 	var rp []ReplicationPolicy
 	resp, _, errs := s.NewRequest(gorequest.GET, "/policies").
 		Query(name).
@@ -26,20 +29,21 @@ func (s *RepositoryClient) GetReplicationPolicies(name string) ([]ReplicationPol
 	return rp, CheckResponse(errs, resp, 200)
 }
 
-
 // GetReplicationPolicies
 // Get a replication policy by ID
-func (s *RepositoryClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
+func (s *ReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
 	var r ReplicationPolicy
-	resp, _, errs := s.NewRequest(gorequest.GET, "/policies"+I64toA(id)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape("/policies"+I64toA(id))).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
 
 // UpdateReplicationPolicyByID
 // Update a replication policy by ID
-func (s *RepositoryClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, "/policies"+I64toA(id)).
+func (s *ReplicationClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape("/policies/"+I64toA(id))).
 		Send(policy).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -47,15 +51,16 @@ func (s *RepositoryClient) UpdateReplicationPolicyByID(id int64, policy Replicat
 
 // DeleteReplicationPolicyByID
 // Delete a replication policy by ID
-func (s *RepositoryClient) DeleteReplicationPolicyByID(id int64) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, "/policies"+I64toA(id)).
+func (s *ReplicationClient) DeleteReplicationPolicyByID(id int64) error {
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape("/policies/"+I64toA(id))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
 
 // CreateReplicationPolicy
 // Create a replication policy
-func (s *RepositoryClient) CreateReplicationPolicy(rp ReplicationPolicy) error {
+func (s *ReplicationClient) CreateReplicationPolicy(rp ReplicationPolicy) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, "/policies").
 		Send(rp).
 		End()
@@ -64,16 +69,17 @@ func (s *RepositoryClient) CreateReplicationPolicy(rp ReplicationPolicy) error {
 
 // GetReplicationExecutionsByID
 // Get replication executions filtered by replication ID
-func (s *RepositoryClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
+func (s *ReplicationClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
 	var r ReplicationExecution
-	resp, _, errs := s.NewRequest(gorequest.GET, "/executions/"+I64toA(id)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape("/executions/"+I64toA(id))).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
 
 // TriggerReplicationExecution
 // Trigger a replication execution
-func (s *RepositoryClient) TriggerReplicationExecution(e ReplicationExecution) error {
+func (s *ReplicationClient) TriggerReplicationExecution(e ReplicationExecution) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, "/executions").
 		Send(e).
 		End()
@@ -82,9 +88,10 @@ func (s *RepositoryClient) TriggerReplicationExecution(e ReplicationExecution) e
 
 // GetReplicationPolicies
 // Get an array of matching replication policies
-func (s *RepositoryClient) GetReplicationExecutions(policyID int64, name string) ([]ReplicationExecution, error) {
+func (s *ReplicationClient) GetReplicationExecutions(policyID int64, name string) ([]ReplicationExecution, error) {
 	var r []ReplicationExecution
-	resp, _, errs := s.NewRequest(gorequest.GET, "/policies").
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape("/executions/"+I64toA(policyID))).
 		Query(name).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)

--- a/replication_types.go
+++ b/replication_types.go
@@ -1,0 +1,37 @@
+package harbor
+
+import "time"
+
+// ReplicationExecution holds information about one replication execution.
+type ReplicationExecution struct {
+	ID         int64       `orm:"pk;auto;column(id)" json:"id"`
+	PolicyID   int64       `orm:"column(policy_id)" json:"policy_id"`
+	Status     string      `orm:"column(status)" json:"status"`
+	StatusText string      `orm:"column(status_text)" json:"status_text"`
+	Total      int         `orm:"column(total)" json:"total"`
+	Failed     int         `orm:"column(failed)" json:"failed"`
+	Succeed    int         `orm:"column(succeed)" json:"succeed"`
+	InProgress int         `orm:"column(in_progress)" json:"in_progress"`
+	Stopped    int         `orm:"column(stopped)" json:"stopped"`
+	Trigger    TriggerType `orm:"column(trigger)" json:"trigger"`
+	StartTime  time.Time   `orm:"column(start_time)" json:"start_time"`
+	EndTime    time.Time   `orm:"column(end_time)" json:"end_time"`
+}
+
+// ReplicationPolicy is the model for a ng replication policy.
+type ReplicationPolicy struct {
+	ID                int64     `orm:"pk;auto;column(id)" json:"id"`
+	Name              string    `orm:"column(name)" json:"name"`
+	Description       string    `orm:"column(description)" json:"description"`
+	Creator           string    `orm:"column(creator)" json:"creator"`
+	SrcRegistryID     int64     `orm:"column(src_registry_id)" json:"src_registry_id"`
+	DestRegistryID    int64     `orm:"column(dest_registry_id)" json:"dest_registry_id"`
+	DestNamespace     string    `orm:"column(dest_namespace)" json:"dest_namespace"`
+	Override          bool      `orm:"column(override)" json:"override"`
+	Enabled           bool      `orm:"column(enabled)" json:"enabled"`
+	Trigger           string    `orm:"column(trigger)" json:"trigger"`
+	Filters           string    `orm:"column(filters)" json:"filters"`
+	ReplicateDeletion bool      `orm:"column(replicate_deletion)" json:"replicate_deletion"`
+	CreationTime      time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime        time.Time `orm:"column(update_time);auto_now" json:"update_time"`
+}

--- a/replication_types.go
+++ b/replication_types.go
@@ -2,6 +2,10 @@ package harbor
 
 import "time"
 
+// To ensure type-safe queries to the harbor API,
+// the following typings include typings from the upstream sources:
+// https://github.com/goharbor/harbor/src/replication/dao/models/
+
 // ReplicationExecution holds information about one replication execution.
 type ReplicationExecution struct {
 	ID         int64       `orm:"pk;auto;column(id)" json:"id"`

--- a/repository.go
+++ b/repository.go
@@ -24,9 +24,7 @@ func (s *RepositoryClient) ListRepository(opt *RepositoryQuery) ([]RepoRecord, e
 // DeleteRepository
 // Delete a repository
 func (s *RepositoryClient) DeleteRepository(repoName string) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape(
-			"/"+repoName)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,"/"+url.PathEscape(repoName)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -34,8 +32,7 @@ func (s *RepositoryClient) DeleteRepository(repoName string) error {
 // UpdateRepository
 // Update the description of a repository
 func (s *RepositoryClient) UpdateRepository(repoName string, d RepositoryDescription) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape("/"+repoName)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,"/"+url.PathEscape(repoName)).
 		Send(d).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -48,8 +45,7 @@ func (s *RepositoryClient) UpdateRepository(repoName string, d RepositoryDescrip
 func (s *RepositoryClient) GetRepositoryTag(repoName, tag string) (TagResp, error) {
 	var v TagResp
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%s/tags/%s", repoName, tag))).
+		fmt.Sprintf("/%s/tags/%s", url.PathEscape(repoName), url.PathEscape(tag))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -57,9 +53,8 @@ func (s *RepositoryClient) GetRepositoryTag(repoName, tag string) (TagResp, erro
 // DeleteRepositoryTag
 // Delete tags of a repository
 func (s *RepositoryClient) DeleteRepositoryTag(repoName, tag string) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape(
-			fmt.Sprintf("/%s/tags/%s", repoName, tag))).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,fmt.Sprintf("/%s/tags/%s",
+		url.PathEscape(repoName), url.PathEscape(tag))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -72,8 +67,7 @@ func (s *RepositoryClient) DeleteRepositoryTag(repoName, tag string) error {
 func (s *RepositoryClient) ListRepositoryTags(repoName string) ([]TagResp, error) {
 	var v []TagResp
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%s/tags", repoName))).
+		fmt.Sprintf("/%s/tags", url.PathEscape(repoName))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -84,11 +78,11 @@ func (s *RepositoryClient) GetRepositoryTagManifests(repoName, tag string, versi
 	var v ManifestResp
 	resp, _, errs := s.NewRequest(gorequest.GET, func() string {
 		if version == "" {
-			return url.PathEscape(
-				fmt.Sprintf("/%s/tags/%s/manifest", repoName, tag))
+			return fmt.Sprintf("/%s/tags/%s/manifest",
+				url.PathEscape(repoName), url.PathEscape(tag))
 		}
-		return url.PathEscape(
-			fmt.Sprintf("/%s/tags/%s/manifest?version=%s", repoName, tag, version))
+		return fmt.Sprintf("/%s/tags/%s/manifest?version=%s",
+				url.PathEscape(repoName), url.PathEscape(tag), url.PathEscape(version))
 	}()).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
@@ -98,9 +92,8 @@ func (s *RepositoryClient) GetRepositoryTagManifests(repoName, tag string, versi
 // Trigger the jobservice component to call the Clair API to scan the image
 // Only accessible for project admins
 func (s *RepositoryClient) ScanImage(repoName, tag string) error {
-	resp, _, errs := s.NewRequest(gorequest.POST,
-		url.PathEscape(
-			fmt.Sprintf("/%s/tags/%s/scan", repoName, tag))).
+	resp, _, errs := s.NewRequest(gorequest.POST,fmt.Sprintf("/%s/tags/%s/scan",
+		url.PathEscape(repoName), url.PathEscape(tag))).
 		End()
 	return CheckResponse(errs, resp, 202)
 }
@@ -109,9 +102,8 @@ func (s *RepositoryClient) ScanImage(repoName, tag string) error {
 // Get information from the Clair API containing vulnerability information based on the previous successful scan
 func (s *RepositoryClient) GetImageScan(repoName, tag string) ([]VulnerabilityItem, error) {
 	var v []VulnerabilityItem
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%s/tags/%s/scan", repoName, tag))).
+	resp, _, errs := s.NewRequest(gorequest.GET,fmt.Sprintf("/%s/tags/%s/scan",
+		url.PathEscape(repoName), url.PathEscape(tag))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -123,8 +115,7 @@ func (s *RepositoryClient) GetImageScan(repoName, tag string) ([]VulnerabilityIt
 func (s *RepositoryClient) GetRepositorySignature(repoName string) ([]Signature, error) {
 	var v []Signature
 	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape(
-			fmt.Sprintf("/%s/signatures", repoName))).
+		fmt.Sprintf("/%s/signatures", url.PathEscape(repoName))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -135,7 +126,7 @@ func (s *RepositoryClient) GetRepositoryTop(top interface{}) ([]RepoRecord, erro
 	var v []RepoRecord
 	resp, _, errs := s.NewRequest(gorequest.GET, func() string {
 		if t, ok := top.(int); ok {
-			return url.PathEscape(fmt.Sprintf("/top?count=%d", t))
+			return fmt.Sprintf("/top?count=%d", t)
 		}
 		return fmt.Sprintf("/top")
 	}()).

--- a/repository.go
+++ b/repository.go
@@ -3,6 +3,7 @@ package harbor
 import (
 	"fmt"
 	"github.com/parnurzeal/gorequest"
+	"net/url"
 )
 
 // RepositoryClient handles communication with the repository related methods of the Harbor API
@@ -23,7 +24,9 @@ func (s *RepositoryClient) ListRepository(opt *RepositoryQuery) ([]RepoRecord, e
 // DeleteRepository
 // Delete a repository
 func (s *RepositoryClient) DeleteRepository(repoName string) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+repoName).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape(
+			"/"+repoName)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -31,7 +34,8 @@ func (s *RepositoryClient) DeleteRepository(repoName string) error {
 // UpdateRepository
 // Update the description of a repository
 func (s *RepositoryClient) UpdateRepository(repoName string, d RepositoryDescription) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, "/"+repoName).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape("/"+repoName)).
 		Send(d).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -43,7 +47,9 @@ func (s *RepositoryClient) UpdateRepository(repoName string, d RepositoryDescrip
 // If the property is null, the image is unsigned
 func (s *RepositoryClient) GetRepositoryTag(repoName, tag string) (TagResp, error) {
 	var v TagResp
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%s/tags/%s", repoName, tag)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%s/tags/%s", repoName, tag))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -51,7 +57,9 @@ func (s *RepositoryClient) GetRepositoryTag(repoName, tag string) (TagResp, erro
 // DeleteRepositoryTag
 // Delete tags of a repository
 func (s *RepositoryClient) DeleteRepositoryTag(repoName, tag string) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, fmt.Sprintf("/%s/tags/%s", repoName, tag)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape(
+			fmt.Sprintf("/%s/tags/%s", repoName, tag))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -63,7 +71,9 @@ func (s *RepositoryClient) DeleteRepositoryTag(repoName, tag string) error {
 
 func (s *RepositoryClient) ListRepositoryTags(repoName string) ([]TagResp, error) {
 	var v []TagResp
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%s/tags", repoName)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%s/tags", repoName))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -74,9 +84,11 @@ func (s *RepositoryClient) GetRepositoryTagManifests(repoName, tag string, versi
 	var v ManifestResp
 	resp, _, errs := s.NewRequest(gorequest.GET, func() string {
 		if version == "" {
-			return fmt.Sprintf("/%s/tags/%s/manifest", repoName, tag)
+			return url.PathEscape(
+				fmt.Sprintf("/%s/tags/%s/manifest", repoName, tag))
 		}
-		return fmt.Sprintf("/%s/tags/%s/manifest?version=%s", repoName, tag, version)
+		return url.PathEscape(
+			fmt.Sprintf("/%s/tags/%s/manifest?version=%s", repoName, tag, version))
 	}()).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
@@ -86,7 +98,9 @@ func (s *RepositoryClient) GetRepositoryTagManifests(repoName, tag string, versi
 // Trigger the jobservice component to call the Clair API to scan the image
 // Only accessible for project admins
 func (s *RepositoryClient) ScanImage(repoName, tag string) error {
-	resp, _, errs := s.NewRequest(gorequest.POST, fmt.Sprintf("/%s/tags/%s/scan", repoName, tag)).
+	resp, _, errs := s.NewRequest(gorequest.POST,
+		url.PathEscape(
+			fmt.Sprintf("/%s/tags/%s/scan", repoName, tag))).
 		End()
 	return CheckResponse(errs, resp, 202)
 }
@@ -95,7 +109,9 @@ func (s *RepositoryClient) ScanImage(repoName, tag string) error {
 // Get information from the Clair API containing vulnerability information based on the previous successful scan
 func (s *RepositoryClient) GetImageScan(repoName, tag string) ([]VulnerabilityItem, error) {
 	var v []VulnerabilityItem
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%s/tags/%s/scan", repoName, tag)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%s/tags/%s/scan", repoName, tag))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -106,7 +122,9 @@ func (s *RepositoryClient) GetImageScan(repoName, tag string) ([]VulnerabilityIt
 // return an empty list with response code 200, instead of 404
 func (s *RepositoryClient) GetRepositorySignature(repoName string) ([]Signature, error) {
 	var v []Signature
-	resp, _, errs := s.NewRequest(gorequest.GET, fmt.Sprintf("/%s/signatures", repoName)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape(
+			fmt.Sprintf("/%s/signatures", repoName))).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
@@ -117,7 +135,7 @@ func (s *RepositoryClient) GetRepositoryTop(top interface{}) ([]RepoRecord, erro
 	var v []RepoRecord
 	resp, _, errs := s.NewRequest(gorequest.GET, func() string {
 		if t, ok := top.(int); ok {
-			return fmt.Sprintf("/top?count=%d", t)
+			return url.PathEscape(fmt.Sprintf("/top?count=%d", t))
 		}
 		return fmt.Sprintf("/top")
 	}()).

--- a/repository_types.go
+++ b/repository_types.go
@@ -4,6 +4,10 @@ import (
 	"time"
 )
 
+// To ensure type-safe queries to the harbor API,
+// the following typings include typings from the upstream sources:
+// https://github.com/goharbor/harbor/src/common/models/
+
 // Label holds information used for a label
 type Label struct {
 	ID           int64     `orm:"pk;auto;column(id)" json:"id"`

--- a/repository_types.go
+++ b/repository_types.go
@@ -51,7 +51,7 @@ type RepositoryQuery struct {
 	Sorting
 }
 
-// RepoRecord holds the record of an repository in DB, all the infors are from the registry notification event.
+// RepoRecord holds the record of an repository in DB, all the infos are from the registry notification event.
 type RepoRecord struct {
 	RepositoryID int64     `orm:"pk;auto;column(repository_id)" json:"repository_id"`
 	Name         string    `orm:"column(name)" json:"name"`

--- a/user.go
+++ b/user.go
@@ -3,7 +3,6 @@ package harbor
 import (
 	"fmt"
 	"github.com/parnurzeal/gorequest"
-	"net/url"
 )
 
 // UserClient handles communication with the user related methods of the Harbor API
@@ -34,8 +33,7 @@ func (s *UserClient) ListUsers() ([]User, error) {
 // Get a user's profile by ID
 func (s *UserClient) GetUser(usr UserRequest) (User, error) {
 	var u User
-	resp, _, errs := s.NewRequest(gorequest.GET,
-		url.PathEscape("/"+I64toA(usr.UserID))).
+	resp, _, errs := s.NewRequest(gorequest.GET,"/"+I64toA(usr.UserID)).
 		EndStruct(&u)
 	return u, CheckResponse(errs, resp, 200)
 }
@@ -52,8 +50,7 @@ func (s *UserClient) AddUser(usr UserRequest) error {
 // UpdateUserProfile
 // Update a user's profile
 func (s *UserClient) UpdateUserProfile(usr UserRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape("/"+I64toA(usr.UserID))).
+	resp, _, errs := s.NewRequest(gorequest.PUT,"/"+I64toA(usr.UserID)).
 		Send(usr).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -62,8 +59,7 @@ func (s *UserClient) UpdateUserProfile(usr UserRequest) error {
 // DeleteUser
 // Delete a user
 func (s *UserClient) DeleteUser(usr UserRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE,
-		url.PathEscape("/"+I64toA(usr.UserID))).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,"/"+I64toA(usr.UserID)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -71,9 +67,7 @@ func (s *UserClient) DeleteUser(usr UserRequest) error {
 // ToggleUserSysAdmin
 // Toggle administrator privileges of a user
 func (s *UserClient) ToggleUserSysAdmin(usr UserRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape(
-			fmt.Sprintf("/%d/sysadmin", usr.UserID))).
+	resp, _, errs := s.NewRequest(gorequest.PUT,fmt.Sprintf("/%d/sysadmin", usr.UserID)).
 		Send(usr.HasAdminRole).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -89,8 +83,7 @@ func (s *UserClient) UpdateUserPassword(uid int64, oldPw, newPw string) error {
 	}
 
 	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape(
-			fmt.Sprintf("/%d/password", uid))).
+		fmt.Sprintf("/%d/password", uid)).
 		Send(cp).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -104,8 +97,7 @@ func (s *UserClient) UpdateUserPasswordAsAdmin(uid int64, newPw string) error {
 	}
 
 	resp, _, errs := s.NewRequest(gorequest.PUT,
-		url.PathEscape(
-			fmt.Sprintf("/%d/password", uid))).
+		fmt.Sprintf("/%d/password", uid)).
 		Send(cp).
 		End()
 	return CheckResponse(errs, resp, 200)

--- a/user.go
+++ b/user.go
@@ -3,6 +3,7 @@ package harbor
 import (
 	"fmt"
 	"github.com/parnurzeal/gorequest"
+	"net/url"
 )
 
 // UserClient handles communication with the user related methods of the Harbor API
@@ -33,7 +34,8 @@ func (s *UserClient) ListUsers() ([]User, error) {
 // Get a user's profile by ID
 func (s *UserClient) GetUser(usr UserRequest) (User, error) {
 	var u User
-	resp, _, errs := s.NewRequest(gorequest.GET, "/"+I64toA(usr.UserID)).
+	resp, _, errs := s.NewRequest(gorequest.GET,
+		url.PathEscape("/"+I64toA(usr.UserID))).
 		EndStruct(&u)
 	return u, CheckResponse(errs, resp, 200)
 }
@@ -50,7 +52,8 @@ func (s *UserClient) AddUser(usr UserRequest) error {
 // UpdateUserProfile
 // Update a user's profile
 func (s *UserClient) UpdateUserProfile(usr UserRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, "/"+I64toA(usr.UserID)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape("/"+I64toA(usr.UserID))).
 		Send(usr).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -59,7 +62,8 @@ func (s *UserClient) UpdateUserProfile(usr UserRequest) error {
 // DeleteUser
 // Delete a user
 func (s *UserClient) DeleteUser(usr UserRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(usr.UserID)).
+	resp, _, errs := s.NewRequest(gorequest.DELETE,
+		url.PathEscape("/"+I64toA(usr.UserID))).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
@@ -67,7 +71,9 @@ func (s *UserClient) DeleteUser(usr UserRequest) error {
 // ToggleUserSysAdmin
 // Toggle administrator privileges of a user
 func (s *UserClient) ToggleUserSysAdmin(usr UserRequest) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT, fmt.Sprintf("/%d/sysadmin", usr.UserID)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape(
+			fmt.Sprintf("/%d/sysadmin", usr.UserID))).
 		Send(usr.HasAdminRole).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -82,7 +88,9 @@ func (s *UserClient) UpdateUserPassword(uid int64, oldPw, newPw string) error {
 		NewPassword: newPw,
 	}
 
-	resp, _, errs := s.NewRequest(gorequest.PUT, fmt.Sprintf("/%d/password", uid)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape(
+			fmt.Sprintf("/%d/password", uid))).
 		Send(cp).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -95,7 +103,9 @@ func (s *UserClient) UpdateUserPasswordAsAdmin(uid int64, newPw string) error {
 		NewPassword: newPw,
 	}
 
-	resp, _, errs := s.NewRequest(gorequest.PUT, fmt.Sprintf("/%d/password", uid)).
+	resp, _, errs := s.NewRequest(gorequest.PUT,
+		url.PathEscape(
+			fmt.Sprintf("/%d/password", uid))).
 		Send(cp).
 		End()
 	return CheckResponse(errs, resp, 200)

--- a/user_types.go
+++ b/user_types.go
@@ -2,6 +2,10 @@ package harbor
 
 import "time"
 
+// To ensure type-safe queries to the harbor API,
+// the following typings include typings from the upstream sources:
+// https://github.com/goharbor/harbor/src/common/models/
+
 // User holds the details of a user.
 type User struct {
 	UserID          int    `orm:"pk;auto;column(user_id)" json:"user_id"`


### PR DESCRIPTION
Add upstream typings for registries and replications as well as a coverage of the basic API routes.