### PR TITLE
use the correct upstream type for replication policies

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -32,7 +32,7 @@ func (s *ReplicationClient) ListReplicationPolicies(name string) ([]ReplicationP
 // Get a replication policy by ID
 func (s *ReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
 	var r ReplicationPolicy
-	resp, _, errs := s.NewRequest(gorequest.GET,"/policies"+I64toA(id)).
+	resp, _, errs := s.NewRequest(gorequest.GET, "/policies"+I64toA(id)).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
@@ -40,7 +40,7 @@ func (s *ReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolic
 // UpdateReplicationPolicyByID
 // Update a replication policy by ID
 func (s *ReplicationClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
-	resp, _, errs := s.NewRequest(gorequest.PUT,"/policies/"+I64toA(id)).
+	resp, _, errs := s.NewRequest(gorequest.PUT, "/policies/"+I64toA(id)).
 		Send(policy).
 		End()
 	return CheckResponse(errs, resp, 200)
@@ -67,7 +67,7 @@ func (s *ReplicationClient) CreateReplicationPolicy(rp ReplicationPolicy) error 
 // Get replication executions filtered by replication ID
 func (s *ReplicationClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
 	var r ReplicationExecution
-	resp, _, errs := s.NewRequest(gorequest.GET,"/executions/"+I64toA(id)).
+	resp, _, errs := s.NewRequest(gorequest.GET, "/executions/"+I64toA(id)).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
@@ -85,7 +85,7 @@ func (s *ReplicationClient) TriggerReplicationExecution(e ReplicationExecution) 
 // Get an array of matching replication policies
 func (s *ReplicationClient) GetReplicationExecutions(policyID int64) ([]ReplicationExecution, error) {
 	var r []ReplicationExecution
-	resp, _, errs := s.NewRequest(gorequest.GET,"/executions/").
+	resp, _, errs := s.NewRequest(gorequest.GET, "/executions/").
 		Query(map[string]string{"policy_id": I64toA(policyID)}).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)

--- a/replication_types.go
+++ b/replication_types.go
@@ -22,20 +22,48 @@ type ReplicationExecution struct {
 	EndTime    time.Time   `orm:"column(end_time)" json:"end_time"`
 }
 
-// ReplicationPolicy is the model for a ng replication policy.
+// ReplicationPolicy defines the structure of a replication policy
 type ReplicationPolicy struct {
-	ID                int64     `orm:"pk;auto;column(id)" json:"id"`
-	Name              string    `orm:"column(name)" json:"name"`
-	Description       string    `orm:"column(description)" json:"description"`
-	Creator           string    `orm:"column(creator)" json:"creator"`
-	SrcRegistryID     int64     `orm:"column(src_registry_id)" json:"src_registry_id"`
-	DestRegistryID    int64     `orm:"column(dest_registry_id)" json:"dest_registry_id"`
-	DestNamespace     string    `orm:"column(dest_namespace)" json:"dest_namespace"`
-	Override          bool      `orm:"column(override)" json:"override"`
-	Enabled           bool      `orm:"column(enabled)" json:"enabled"`
-	Trigger           string    `orm:"column(trigger)" json:"trigger"`
-	Filters           string    `orm:"column(filters)" json:"filters"`
-	ReplicateDeletion bool      `orm:"column(replicate_deletion)" json:"replicate_deletion"`
-	CreationTime      time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
-	UpdateTime        time.Time `orm:"column(update_time);auto_now" json:"update_time"`
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Creator     string `json:"creator"`
+	// source
+	SrcRegistry *Registry `json:"src_registry"`
+	// destination
+	DestRegistry *Registry `json:"dest_registry"`
+	// Only support two dest namespace modes:
+	// Put all the src resources to the one single dest namespace
+	// or keep namespaces same with the source ones (under this case,
+	// the DestNamespace should be set to empty)
+	DestNamespace string `json:"dest_namespace"`
+	// Filters
+	Filters []*Filter `json:"filters"`
+	// Trigger
+	Trigger *Trigger `json:"trigger"`
+	// Settings
+	Deletion bool `json:"deletion"`
+	// If override the image tag
+	Override bool `json:"override"`
+	// Operations
+	Enabled      bool      `json:"enabled"`
+	CreationTime time.Time `json:"creation_time"`
+	UpdateTime   time.Time `json:"update_time"`
+}
+
+// Filter holds the info of the filter
+type Filter struct {
+	Type  FilterType  `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+// Trigger holds info for a trigger
+type Trigger struct {
+	Type     TriggerType      `json:"type"`
+	Settings *TriggerSettings `json:"trigger_settings"`
+}
+
+// TriggerSettings holds the settings of a trigger
+type TriggerSettings struct {
+	Cron string `json:"cron"`
 }


### PR DESCRIPTION
This has been mistakenly imported from`/harbor/src/replication/dao/models/policy.go`.
Correct source is `/harbor/src/replication/model/policy.go`

