### PR TITLE
Fake client

### DIFF
--- a/harbor.go
+++ b/harbor.go
@@ -57,7 +57,7 @@ type Search struct {
 // display order.
 //
 // Harbor API docs: https://github.com/vmware/harbor/blob/release-1.4.0/docs/swagger.yaml#L17
-func (c *Client) Search() (Search, *gorequest.Response, []error) {
+func (c *RestClient) Search() (Search, *gorequest.Response, []error) {
 	var search Search
 	resp, _, errs := c.NewRequest(gorequest.GET, "search").
 		EndStruct(&search)
@@ -81,7 +81,7 @@ type StatisticMap struct {
 
 // GetStatistics
 // Get project and repository statistics
-func (c *Client) GetStatistics() (StatisticMap, *gorequest.Response, []error) {
+func (c *RestClient) GetStatistics() (StatisticMap, *gorequest.Response, []error) {
 	var statistics StatisticMap
 	resp, _, errs := c.NewRequest(gorequest.GET, "statistics").
 		EndStruct(&statistics)

--- a/project.go
+++ b/project.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 )
 
-// Implementations of ProjectClient handle communication with
+// ProjectClient abstracts away the communication implementation of
 // project related methods of Harbor.
 type ProjectClient interface {
 	// ListProjects returns all projects created by Harbor,

--- a/project_types.go
+++ b/project_types.go
@@ -1,6 +1,8 @@
 package harbor
 
-import "time"
+import (
+	"time"
+)
 
 // To ensure type-safe queries to the harbor API,
 // the following typings include typings from the upstream sources:

--- a/registry.go
+++ b/registry.go
@@ -5,23 +5,46 @@ import (
 	"github.com/parnurzeal/gorequest"
 )
 
-// RegistryClient handles communication with the registry related methods of the Harbor API
-type RegistryClient struct {
-	*Client
+// Implementations of RegistryClient handle communication with
+// registry related methods of Harbor.
+type RegistryClient interface {
+	// Create a new registry.
+	CreateRegistry(r Registry) error
+
+	// List all registries.
+	ListRegistries(name string) ([]Registry, error)
+
+	// Get a registry by id.
+	GetRegistryByID(id int64) (Registry, error)
+
+	// Get information about a registry by id.
+	GetRegistryInfoByID(id int64) (RegistryInfo, error)
+
+	// delete a registry by id.
+	DeleteRegistryByID(id int64) error
+
+	// update a registry by id.
+	UpdateRegistryByID(r Registry) error
+
+	// ping a registry and return it's health status.
+	PingRegistry(r Registry) error
 }
 
-// CreateRegistry
-// Create a registry
-func (s *RegistryClient) CreateRegistry(r Registry) error {
+// RestRegistryClient implements the RegistryClient interface by communicating via Rest api.
+type RestRegistryClient struct {
+	*RestClient
+}
+
+// CreateRegistry satisfies the RegistryClient interface.
+func (s *RestRegistryClient) CreateRegistry(r Registry) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, "").
 		Send(r).
 		End()
 	return CheckResponse(errs, resp, 201)
 }
 
-// ListRegistries
-// Get a list of registries
-func (s *RegistryClient) ListRegistries(name string) ([]Registry, error) {
+// ListRegistries satisfies the RegistryClient interface.
+func (s *RestRegistryClient) ListRegistries(name string) ([]Registry, error) {
 	var r []Registry
 	resp, _, errs := s.NewRequest(gorequest.GET, "").
 		Query(map[string]string{"name": name}).
@@ -29,44 +52,39 @@ func (s *RegistryClient) ListRegistries(name string) ([]Registry, error) {
 	return r, CheckResponse(errs, resp, 200)
 }
 
-// GetRegistryByID
-// Get a registry by ID
-func (s *RegistryClient) GetRegistryByID(id int64) (Registry, error) {
+// GetRegistryByID satisfies the RegistryClient interface.
+func (s *RestRegistryClient) GetRegistryByID(id int64) (Registry, error) {
 	var v Registry
 	resp, _, errs := s.NewRequest(gorequest.GET, "/"+I64toA(id)).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
 
-// GetRegistryInfoByID
-// Get a registry's info by ID
-func (s *RegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
+// GetRegistryInfoByID satisfies the RegistryClient interface.
+func (s *RestRegistryClient) GetRegistryInfoByID(id int64) (RegistryInfo, error) {
 	var v RegistryInfo
 	resp, _, errs := s.NewRequest(gorequest.GET,fmt.Sprintf("/%d/info", id)).
 		EndStruct(&v)
 	return v, CheckResponse(errs, resp, 200)
 }
 
-// DeleteRegistryByID
-// Delete a registry by ID
-func (s *RegistryClient) DeleteRegistryByID(id int64) error {
+// DeleteRegistryByID satisfies the RegistryClient interface.
+func (s *RestRegistryClient) DeleteRegistryByID(id int64) error {
 	resp, _, errs := s.NewRequest(gorequest.DELETE, "/"+I64toA(id)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
 
-// UpdateRegistryByID
-// Update a registry by ID
-func (s *RegistryClient) UpdateRegistryByID(r Registry) error {
+// UpdateRegistryByID satisfies the RegistryClient interface.
+func (s *RestRegistryClient) UpdateRegistryByID(r Registry) error {
 	resp, _, errs := s.NewRequest(gorequest.PUT,"/"+I64toA(r.ID)).
 		Send(r).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
 
-// PingRegistry
-// Ping a registry and return it's health status
-func (s *RegistryClient) PingRegistry(r Registry) error {
+// PingRegistry satisfies the RegistryClient interface.
+func (s *RestRegistryClient) PingRegistry(r Registry) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, "/ping").
 		Send(r).
 		End()

--- a/registry.go
+++ b/registry.go
@@ -5,7 +5,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 )
 
-// Implementations of RegistryClient handle communication with
+// RegistryClient abstracts away the communication implementation of
 // registry related methods of Harbor.
 type RegistryClient interface {
 	// Create a new registry.

--- a/replication.go
+++ b/replication.go
@@ -4,23 +4,52 @@ import (
 	"github.com/parnurzeal/gorequest"
 )
 
-// ReplicationClient handles communication with the replication related methods of the Harbor API
-type ReplicationClient struct {
-	*Client
+// Implementations of ReplicationClient handle communication with
+// the replication related methods of Harbor.
+type ReplicationClient interface {
+	// List all replication adapters.
+	ListReplicationAdapters() ([]string, error)
+
+	// List all replication policies.
+	ListReplicationPolicies(name string) ([]ReplicationPolicy, error)
+
+	// Retrieves a replication policy by id.
+	GetReplicationPolicyByID(id int64) (ReplicationPolicy, error)
+
+	// Update a replication policy by id.
+	UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error
+
+	// Delete a replication policy by id.
+	DeleteReplicationPolicyByID(id int64) error
+
+	// Create a replication policy by id.
+	CreateReplicationPolicy(rp ReplicationPolicy) error
+
+	// Get a replication execution by id.
+	GetReplicationExecutionsByID(id int64) (ReplicationExecution, error)
+
+	// Trigger a new replication execution.
+	TriggerReplicationExecution(e ReplicationExecution) error
+
+	// Get a replication execution by policy id.
+	GetReplicationExecutions(policyID int64) ([]ReplicationExecution, error)
 }
 
-// ListReplicationAdapters
-// Get all replication adapters
-func (s *ReplicationClient) ListReplicationAdapters() ([]string, error) {
+// RestReplicationClient satisfies the ReplicationClient interface by communicating via Rest api.
+type RestReplicationClient struct {
+	*RestClient
+}
+
+// ListReplicationAdapters satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) ListReplicationAdapters() ([]string, error) {
 	var r []string
 	resp, _, errs := s.NewRequest(gorequest.GET, "/adapters").
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
 
-// ListReplicationPolicies
-// Get an array of matching replication policies
-func (s *ReplicationClient) ListReplicationPolicies(name string) ([]ReplicationPolicy, error) {
+// ListReplicationPolicies satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) ListReplicationPolicies(name string) ([]ReplicationPolicy, error) {
 	var rp []ReplicationPolicy
 	resp, _, errs := s.NewRequest(gorequest.GET, "/policies").
 		Query(map[string]string{"name": name}).
@@ -28,62 +57,55 @@ func (s *ReplicationClient) ListReplicationPolicies(name string) ([]ReplicationP
 	return rp, CheckResponse(errs, resp, 200)
 }
 
-// GetReplicationPolicies
-// Get a replication policy by ID
-func (s *ReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
+// GetReplicationPolicyByID satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) GetReplicationPolicyByID(id int64) (ReplicationPolicy, error) {
 	var r ReplicationPolicy
 	resp, _, errs := s.NewRequest(gorequest.GET, "/policies/"+I64toA(id)).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
 
-// UpdateReplicationPolicyByID
-// Update a replication policy by ID
-func (s *ReplicationClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
+// UpdateReplicationPolicyByID satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) UpdateReplicationPolicyByID(id int64, policy ReplicationPolicy) error {
 	resp, _, errs := s.NewRequest(gorequest.PUT, "/policies/"+I64toA(id)).
 		Send(policy).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
 
-// DeleteReplicationPolicyByID
-// Delete a replication policy by ID
-func (s *ReplicationClient) DeleteReplicationPolicyByID(id int64) error {
+// DeleteReplicationPolicyByID satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) DeleteReplicationPolicyByID(id int64) error {
 	resp, _, errs := s.NewRequest(gorequest.DELETE, "/policies/"+I64toA(id)).
 		End()
 	return CheckResponse(errs, resp, 200)
 }
 
-// CreateReplicationPolicy
-// Create a replication policy
-func (s *ReplicationClient) CreateReplicationPolicy(rp ReplicationPolicy) error {
+// CreateReplicationPolicy satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) CreateReplicationPolicy(rp ReplicationPolicy) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, "/policies").
 		Send(rp).
 		End()
 	return CheckResponse(errs, resp, 201)
 }
 
-// GetReplicationExecutionsByID
-// Get replication executions filtered by replication ID
-func (s *ReplicationClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
+// GetReplicationExecutionsByID satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) GetReplicationExecutionsByID(id int64) (ReplicationExecution, error) {
 	var r ReplicationExecution
 	resp, _, errs := s.NewRequest(gorequest.GET, "/executions/"+I64toA(id)).
 		EndStruct(&r)
 	return r, CheckResponse(errs, resp, 200)
 }
 
-// TriggerReplicationExecution
-// Trigger a replication execution
-func (s *ReplicationClient) TriggerReplicationExecution(e ReplicationExecution) error {
+// TriggerReplicationExecution satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) TriggerReplicationExecution(e ReplicationExecution) error {
 	resp, _, errs := s.NewRequest(gorequest.POST, "/executions").
 		Send(e).
 		End()
 	return CheckResponse(errs, resp, 201)
 }
 
-// GetReplicationPolicies
-// Get an array of matching replication policies
-func (s *ReplicationClient) GetReplicationExecutions(policyID int64) ([]ReplicationExecution, error) {
+// GetReplicationExecutions satisfies the ReplicationClient interface.
+func (s *RestReplicationClient) GetReplicationExecutions(policyID int64) ([]ReplicationExecution, error) {
 	var r []ReplicationExecution
 	resp, _, errs := s.NewRequest(gorequest.GET, "/executions/").
 		Query(map[string]string{"policy_id": I64toA(policyID)}).

--- a/replication.go
+++ b/replication.go
@@ -4,8 +4,8 @@ import (
 	"github.com/parnurzeal/gorequest"
 )
 
-// Implementations of ReplicationClient handle communication with
-// the replication related methods of Harbor.
+// ReplicationClient abstracts away the communication implementation of
+// replication related methods of Harbor.
 type ReplicationClient interface {
 	// List all replication adapters.
 	ListReplicationAdapters() ([]string, error)

--- a/repository.go
+++ b/repository.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 )
 
-// Implementations of RepositoryClient handle communication with
+// RepositoryClient abstracts away the communication implementation of
 // repository related methods of Harbor.
 type RepositoryClient interface {
 	// ListRepository lists repositories filtered by the

--- a/user.go
+++ b/user.go
@@ -5,8 +5,8 @@ import (
 	"github.com/parnurzeal/gorequest"
 )
 
-// Implementations of UserClient handle communication with
-// the replication related methods of Harbor.
+// UserClient abstracts away the communication implementation of
+// user related methods of Harbor.
 type UserClient interface {
 	// SearchUser searches for a user by name.
 	SearchUser(usr UserMember) (UserSearchResults, error)


### PR DESCRIPTION
**This is work in progress!**

Implement a fake client, which can be used for unit tests.
It will, for the most part, behave like the real client but without any communication to a Harbor API instance.

As a basis for creating a second kind of `Client`, both `Client` and the new `FakeClient` should implement an interface. I chose to rename `Client` to `RestClient` and used `Client` as the interface name. The same goes for every subclient like `ReplicationClient` -> `RestReplicationClient` and so on.

Methods implementing CRUD operations like `Replication.GetReplicationPolicyByID` or `Repository.DeleteRepositoryTag` are applied on objects stored inside the fake-clients structs. More complex operations, which involves Harbor internal logic, like `Replication.GetRepositorySignature` will not be emulated acurately, since this would blow up code of this client and is rarely needed in unit test scenarios. If this is the case, then a mocked client with expected results may be better.