### PR TITLE
Flag things in api/ as autogenerated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# go-swagger generated files
+api/ linguist-generated=true
+


### PR DESCRIPTION
Since `api/` only holds autogenerated code, we should flag it as such.