### PR TITLE
do not fetch parent replication policies

### DIFF
--- a/apiv1/client.go
+++ b/apiv1/client.go
@@ -227,8 +227,8 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 }
 
 // GetReplicationExecutionsByID wraps the GetReplicationExecutionsByID method of the replication sub-package.
-func (c *RESTClient) GetReplicationExecutionsByID(ctx context.Context, id int64) (*model.ReplicationExecution, error) {
-	return c.replication.GetReplicationExecutionsByID(ctx, id)
+func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context, id int64) (*model.ReplicationExecution, error) {
+	return c.replication.GetReplicationExecutionByID(ctx, id)
 }
 
 // System Client

--- a/apiv1/replication/replication.go
+++ b/apiv1/replication/replication.go
@@ -181,10 +181,6 @@ func (c *RESTClient) TriggerReplicationExecution(ctx context.Context, r *model.R
 		return &ErrReplicationExecutionNotProvided{}
 	}
 
-	if _, err := c.GetReplicationPolicyByID(ctx, r.PolicyID); err != nil {
-		return &ErrReplicationExecutionReplicationPolicyIDNotFound{}
-	}
-
 	_, err := c.Client.Products.PostReplicationExecutions(
 		&products.PostReplicationExecutionsParams{
 			Execution: r,
@@ -216,11 +212,9 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 	return resp.Payload, nil
 }
 
-func (c *RESTClient) GetReplicationExecutionsByID(ctx context.Context,
+// GetReplicationExecutionByID returns a replication execution specified by ID.
+func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context,
 	id int64) (*model.ReplicationExecution, error) {
-	if _, err := c.GetReplicationPolicyByID(ctx, id); err != nil {
-		return nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{}
-	}
 
 	resp, err := c.Client.Products.GetReplicationExecutionsID(
 		&products.GetReplicationExecutionsIDParams{

--- a/apiv1/replication/replication.go
+++ b/apiv1/replication/replication.go
@@ -194,9 +194,6 @@ func (c *RESTClient) TriggerReplicationExecution(ctx context.Context, r *model.R
 // Specifying the property "policy_id" will return executions of the specified policy.
 func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 	r *model.ReplicationExecution) ([]*model.ReplicationExecution, error) {
-	if _, err := c.GetReplicationPolicyByID(ctx, r.PolicyID); err != nil {
-		return nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{}
-	}
 
 	resp, err := c.Client.Products.GetReplicationExecutions(
 		&products.GetReplicationExecutionsParams{

--- a/apiv1/replication/replication_errors.go
+++ b/apiv1/replication/replication_errors.go
@@ -43,10 +43,6 @@ const (
 	// caused by a missing replication execution object
 	ErrReplicationExecutionNotProvidedMsg = "no replication execution provided"
 
-	// ErrReplicationExecutionMissingIDMsg describes an error
-	// caused by the replication ID of a replication execution object not being found on the server side
-	ErrReplicationExecutionReplicationPolicyIDNotFoundMsg = "no replication policy found for specified id"
-
 	// ErrReplicationExecutionReplicationIDMismatchMsg describes an error
 	// caused by an ID mismatch of the desired replication execution and an existing replication
 	ErrReplicationExecutionReplicationIDMismatchMsg = "received replication execution id doesn't match"
@@ -131,13 +127,6 @@ type ErrReplicationExecutionNotProvided struct{}
 // Error returns the error message.
 func (e *ErrReplicationExecutionNotProvided) Error() string {
 	return ErrReplicationExecutionNotProvidedMsg
-}
-
-type ErrReplicationExecutionReplicationPolicyIDNotFound struct{}
-
-// Error returns the error message.
-func (e *ErrReplicationExecutionReplicationPolicyIDNotFound) Error() string {
-	return ErrReplicationExecutionReplicationPolicyIDNotFoundMsg
 }
 
 type ErrReplicationExecutionReplicationIDMismatch struct{}

--- a/apiv1/replication/replication_test.go
+++ b/apiv1/replication/replication_test.go
@@ -659,27 +659,6 @@ func TestRESTClient_GetReplicationExecutions_ReplicationIDNotFound(t *testing.T)
 	p.AssertExpectations(t)
 }
 
-func TestRESTClient_TriggerReplicationExecution_ReplicationIDNotFound(t *testing.T) {
-	ctx := context.Background()
-
-	p := &mocks.MockClientService{}
-
-	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{})
-
-	err := cl.TriggerReplicationExecution(ctx, replExec)
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
 func TestRESTClient_TriggerReplicationExecution(t *testing.T) {
 	ctx := context.Background()
 	destRegistry := &model.Registry{ID: 1, Name: "reg1"}
@@ -709,12 +688,6 @@ func TestRESTClient_TriggerReplicationExecution(t *testing.T) {
 		Context: ctx,
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		&products.GetReplicationPoliciesOK{Payload: []*model.ReplicationPolicy{replication}}, nil)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
 
 	p.On("PostReplicationExecutions", &products.PostReplicationExecutionsParams{
 		Execution: replExec,
@@ -756,19 +729,13 @@ func TestRESTClient_GetReplicationExecutionsByID(t *testing.T) {
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
 	p.On("GetReplicationExecutionsID", &products.GetReplicationExecutionsIDParams{
 		ID:      replExec.ID,
 		Context: ctx,
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		&products.GetReplicationExecutionsIDOK{Payload: &model.ReplicationExecution{}}, nil)
 
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
+	_, err := cl.GetReplicationExecutionByID(ctx, replExec.ID)
 
 	assert.NoError(t, err)
 
@@ -782,44 +749,16 @@ func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationIllegalIDFormat(t
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
 	p.On("GetReplicationExecutionsID", &products.GetReplicationExecutionsIDParams{
 		ID:      replExec.ID,
 		Context: ctx,
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		nil, &runtime.APIError{Code: http.StatusBadRequest})
 
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
+	_, err := cl.GetReplicationExecutionByID(ctx, replExec.ID)
 
 	if assert.Error(t, err) {
 		assert.IsType(t, &ErrReplicationIllegalIDFormat{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationExecutionReplicationIDNotFound(t *testing.T) {
-	ctx := context.Background()
-
-	p := &mocks.MockClientService{}
-
-	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		nil, &ErrReplicationNotFound{})
-
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
 	}
 
 	p.AssertExpectations(t)
@@ -832,19 +771,13 @@ func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationExecutionReplicat
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
 	p.On("GetReplicationExecutionsID", &products.GetReplicationExecutionsIDParams{
 		ID:      replExec.ID,
 		Context: ctx,
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		&products.GetReplicationExecutionsIDOK{Payload: &model.ReplicationExecution{ID: 1}}, nil)
 
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
+	_, err := cl.GetReplicationExecutionByID(ctx, replExec.ID)
 
 	if assert.Error(t, err) {
 		assert.IsType(t, &ErrReplicationExecutionReplicationIDMismatch{}, err)

--- a/apiv1/replication/replication_test.go
+++ b/apiv1/replication/replication_test.go
@@ -454,6 +454,7 @@ func TestRESTClient_UpdateReplicationPolicy_ErrReplicationIDNotExists(t *testing
 	ctx := context.Background()
 
 	p := &mocks.MockClientService{}
+
 	p.On("GetReplicationPolicies", &products.GetReplicationPoliciesParams{
 		Name:    &replication.Name,
 		Context: ctx,
@@ -484,12 +485,6 @@ func TestRESTClient_GetReplicationExecutions(t *testing.T) {
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
-
 	p.On("GetReplicationExecutions",
 		mock.Anything,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
@@ -502,40 +497,12 @@ func TestRESTClient_GetReplicationExecutions(t *testing.T) {
 	p.AssertExpectations(t)
 }
 
-func TestRESTClient_GetReplicationExecutions_ErrReplicationExecutionReplicationIDNotFound(t *testing.T) {
-	ctx := context.Background()
-
-	p := &mocks.MockClientService{}
-
-	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{})
-
-	_, err := cl.GetReplicationExecutions(ctx, replExec)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
 func TestRESTClient_GetReplicationExecutions_ErrReplicationIllegalIDFormat(t *testing.T) {
 	ctx := context.Background()
 
 	p := &mocks.MockClientService{}
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
 
 	p.On("GetReplicationExecutions",
 		mock.Anything,
@@ -558,12 +525,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationUnauthorized(t *testi
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
-
 	p.On("GetReplicationExecutions",
 		mock.Anything,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
@@ -584,12 +545,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationNoPermission(t *testi
 	p := &mocks.MockClientService{}
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
 
 	p.On("GetReplicationExecutions",
 		mock.Anything,
@@ -612,12 +567,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationInternalErrors(t *tes
 
 	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
-
 	p.On("GetReplicationExecutions",
 		mock.Anything,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
@@ -627,33 +576,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationInternalErrors(t *tes
 
 	if assert.Error(t, err) {
 		assert.IsType(t, &ErrReplicationInternalErrors{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_GetReplicationExecutions_ReplicationIDNotFound(t *testing.T) {
-	replicationExecution := &model.ReplicationExecution{
-		ID:       1,
-		PolicyID: 1,
-	}
-
-	ctx := context.Background()
-
-	p := &mocks.MockClientService{}
-
-	cl := NewClient(&client.Harbor{Products: p, Transport: nil}, authInfo)
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replicationExecution.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
-	_, err := cl.GetReplicationExecutions(ctx, replicationExecution)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
 	}
 
 	p.AssertExpectations(t)
@@ -796,12 +718,6 @@ func TestErrReplicationExecutionReplicationIDMismatch_Error(t *testing.T) {
 	var e ErrReplicationExecutionReplicationIDMismatch
 
 	assert.Equal(t, ErrReplicationExecutionReplicationIDMismatchMsg, e.Error())
-}
-
-func TestErrReplicationExecutionReplicationIDNotFound_Error(t *testing.T) {
-	var e ErrReplicationExecutionReplicationPolicyIDNotFound
-
-	assert.Equal(t, ErrReplicationExecutionReplicationPolicyIDNotFoundMsg, e.Error())
 }
 
 func TestErrReplicationIllegalIDFormat_Error(t *testing.T) {

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -241,8 +241,8 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 }
 
 // GetReplicationExecutionsByID wraps the GetReplicationExecutionsByID method of the replication sub-package.
-func (c *RESTClient) GetReplicationExecutionsByID(ctx context.Context, id int64) (*model.ReplicationExecution, error) {
-	return c.replication.GetReplicationExecutionsByID(ctx, id)
+func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context, id int64) (*model.ReplicationExecution, error) {
+	return c.replication.GetReplicationExecutionByID(ctx, id)
 }
 
 // System Client

--- a/apiv2/replication/replication.go
+++ b/apiv2/replication/replication.go
@@ -42,7 +42,7 @@ type Client interface {
 	UpdateReplicationPolicy(ctx context.Context, r *model.ReplicationPolicy) error
 	TriggerReplicationExecution(ctx context.Context, r *model.ReplicationExecution) error
 	GetReplicationExecutions(ctx context.Context, r *model.ReplicationExecution) ([]*model.ReplicationExecution, error)
-	GetReplicationExecutionsByID(ctx context.Context,
+	GetReplicationExecutionByID(ctx context.Context,
 		r *model.ReplicationExecution) (*model.ReplicationExecution, error)
 }
 
@@ -185,10 +185,6 @@ func (c *RESTClient) TriggerReplicationExecution(ctx context.Context, r *model.R
 		return &ErrReplicationExecutionNotProvided{}
 	}
 
-	if _, err := c.GetReplicationPolicyByID(ctx, r.PolicyID); err != nil {
-		return &ErrReplicationExecutionReplicationPolicyIDNotFound{}
-	}
-
 	_, err := c.LegacyClient.Products.PostReplicationExecutions(
 		&products.PostReplicationExecutionsParams{
 			Execution: r,
@@ -202,9 +198,6 @@ func (c *RESTClient) TriggerReplicationExecution(ctx context.Context, r *model.R
 // Specifying the property "policy_id" will return executions of the specified policy.
 func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 	r *model.ReplicationExecution) ([]*model.ReplicationExecution, error) {
-	if _, err := c.GetReplicationPolicyByID(ctx, r.PolicyID); err != nil {
-		return nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{}
-	}
 
 	resp, err := c.LegacyClient.Products.GetReplicationExecutions(
 		&products.GetReplicationExecutionsParams{
@@ -220,11 +213,9 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 	return resp.Payload, nil
 }
 
-func (c *RESTClient) GetReplicationExecutionsByID(ctx context.Context,
+// GetReplicationExecutionByID returns a replication execution specified by ID.
+func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context,
 	id int64) (*model.ReplicationExecution, error) {
-	if _, err := c.GetReplicationPolicyByID(ctx, id); err != nil {
-		return nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{}
-	}
 
 	resp, err := c.LegacyClient.Products.GetReplicationExecutionsID(
 		&products.GetReplicationExecutionsIDParams{

--- a/apiv2/replication/replication_errors.go
+++ b/apiv2/replication/replication_errors.go
@@ -43,10 +43,6 @@ const (
 	// caused by a missing replication execution object
 	ErrReplicationExecutionNotProvidedMsg = "no replication execution provided"
 
-	// ErrReplicationExecutionMissingIDMsg describes an error
-	// caused by the replication ID of a replication execution object not being found on the server side
-	ErrReplicationExecutionReplicationPolicyIDNotFoundMsg = "no replication policy found for specified id"
-
 	// ErrReplicationExecutionReplicationIDMismatchMsg describes an error
 	// caused by an ID mismatch of the desired replication execution and an existing replication
 	ErrReplicationExecutionReplicationIDMismatchMsg = "received replication execution id doesn't match"
@@ -131,13 +127,6 @@ type ErrReplicationExecutionNotProvided struct{}
 // Error returns the error message.
 func (e *ErrReplicationExecutionNotProvided) Error() string {
 	return ErrReplicationExecutionNotProvidedMsg
-}
-
-type ErrReplicationExecutionReplicationPolicyIDNotFound struct{}
-
-// Error returns the error message.
-func (e *ErrReplicationExecutionReplicationPolicyIDNotFound) Error() string {
-	return ErrReplicationExecutionReplicationPolicyIDNotFoundMsg
 }
 
 type ErrReplicationExecutionReplicationIDMismatch struct{}

--- a/apiv2/replication/replication_test.go
+++ b/apiv2/replication/replication_test.go
@@ -581,12 +581,6 @@ func TestRESTClient_GetReplicationExecutions(t *testing.T) {
 
 	ctx := context.Background()
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
-
 	p.On("GetReplicationExecutions",
 		mock.Anything,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
@@ -595,31 +589,6 @@ func TestRESTClient_GetReplicationExecutions(t *testing.T) {
 	_, err := cl.GetReplicationExecutions(ctx, replExec)
 
 	assert.NoError(t, err)
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_GetReplicationExecutions_ErrReplicationExecutionReplicationIDNotFound(t *testing.T) {
-	p := &mocks.MockProductsClientService{}
-
-	legacyClient := BuildLegacyClientWithMock(p)
-	v2Client := BuildV2ClientWithMocks()
-
-	cl := NewClient(legacyClient, v2Client, authInfo)
-
-	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{})
-
-	_, err := cl.GetReplicationExecutions(ctx, replExec)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
-	}
 
 	p.AssertExpectations(t)
 }
@@ -633,12 +602,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationIllegalIDFormat(t *te
 	cl := NewClient(legacyClient, v2Client, authInfo)
 
 	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
 
 	p.On("GetReplicationExecutions",
 		mock.Anything,
@@ -664,12 +627,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationUnauthorized(t *testi
 
 	ctx := context.Background()
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
-
 	p.On("GetReplicationExecutions",
 		mock.Anything,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
@@ -693,12 +650,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationNoPermission(t *testi
 	cl := NewClient(legacyClient, v2Client, authInfo)
 
 	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
 
 	p.On("GetReplicationExecutions",
 		mock.Anything,
@@ -724,12 +675,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationInternalErrors(t *tes
 
 	ctx := context.Background()
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replication.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: replication}, nil)
-
 	p.On("GetReplicationExecutions",
 		mock.Anything,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
@@ -739,60 +684,6 @@ func TestRESTClient_GetReplicationExecutions_ErrReplicationInternalErrors(t *tes
 
 	if assert.Error(t, err) {
 		assert.IsType(t, &ErrReplicationInternalErrors{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_GetReplicationExecutions_ReplicationIDNotFound(t *testing.T) {
-	p := &mocks.MockProductsClientService{}
-
-	legacyClient := BuildLegacyClientWithMock(p)
-	v2Client := BuildV2ClientWithMocks()
-
-	cl := NewClient(legacyClient, v2Client, authInfo)
-
-	replicationExecution := &model.ReplicationExecution{
-		ID:       1,
-		PolicyID: 1,
-	}
-
-	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replicationExecution.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
-	_, err := cl.GetReplicationExecutions(ctx, replicationExecution)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_TriggerReplicationExecution_ReplicationIDNotFound(t *testing.T) {
-	p := &mocks.MockProductsClientService{}
-
-	legacyClient := BuildLegacyClientWithMock(p)
-	v2Client := BuildV2ClientWithMocks()
-
-	cl := NewClient(legacyClient, v2Client, authInfo)
-
-	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		nil, &ErrReplicationExecutionReplicationPolicyIDNotFound{})
-
-	err := cl.TriggerReplicationExecution(ctx, replExec)
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
 	}
 
 	p.AssertExpectations(t)
@@ -831,12 +722,6 @@ func TestRESTClient_TriggerReplicationExecution(t *testing.T) {
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		&products.GetReplicationPoliciesOK{Payload: []*model.ReplicationPolicy{replication}}, nil)
 
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
 	p.On("PostReplicationExecutions", &products.PostReplicationExecutionsParams{
 		Execution: replExec,
 		Context:   ctx,
@@ -873,7 +758,7 @@ func TestRESTClient_TriggerReplicationExecution_ErrReplicationExecutionNotProvid
 	}
 }
 
-func TestRESTClient_GetReplicationExecutionsByID(t *testing.T) {
+func TestRESTClient_GetReplicationExecutionByID(t *testing.T) {
 	p := &mocks.MockProductsClientService{}
 
 	legacyClient := BuildLegacyClientWithMock(p)
@@ -882,12 +767,6 @@ func TestRESTClient_GetReplicationExecutionsByID(t *testing.T) {
 	cl := NewClient(legacyClient, v2Client, authInfo)
 
 	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
 
 	p.On("GetReplicationExecutionsID", &products.GetReplicationExecutionsIDParams{
 		ID:      replExec.ID,
@@ -895,14 +774,14 @@ func TestRESTClient_GetReplicationExecutionsByID(t *testing.T) {
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		&products.GetReplicationExecutionsIDOK{Payload: &model.ReplicationExecution{}}, nil)
 
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
+	_, err := cl.GetReplicationExecutionByID(ctx, replExec.ID)
 
 	assert.NoError(t, err)
 
 	p.AssertExpectations(t)
 }
 
-func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationIllegalIDFormat(t *testing.T) {
+func TestRESTClient_GetReplicationExecutionByID_ErrReplicationIllegalIDFormat(t *testing.T) {
 	p := &mocks.MockProductsClientService{}
 
 	legacyClient := BuildLegacyClientWithMock(p)
@@ -911,12 +790,6 @@ func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationIllegalIDFormat(t
 	cl := NewClient(legacyClient, v2Client, authInfo)
 
 	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
 
 	p.On("GetReplicationExecutionsID", &products.GetReplicationExecutionsIDParams{
 		ID:      replExec.ID,
@@ -924,66 +797,10 @@ func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationIllegalIDFormat(t
 	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
 		nil, &runtime.APIError{Code: http.StatusBadRequest})
 
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
+	_, err := cl.GetReplicationExecutionByID(ctx, replExec.ID)
 
 	if assert.Error(t, err) {
 		assert.IsType(t, &ErrReplicationIllegalIDFormat{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationExecutionReplicationIDNotFound(t *testing.T) {
-	p := &mocks.MockProductsClientService{}
-
-	legacyClient := BuildLegacyClientWithMock(p)
-	v2Client := BuildV2ClientWithMocks()
-
-	cl := NewClient(legacyClient, v2Client, authInfo)
-
-	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		nil, &ErrReplicationNotFound{})
-
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationPolicyIDNotFound{}, err)
-	}
-
-	p.AssertExpectations(t)
-}
-
-func TestRESTClient_GetReplicationExecutionsByID_ErrReplicationExecutionReplicationIDMismatch(t *testing.T) {
-	p := &mocks.MockProductsClientService{}
-
-	legacyClient := BuildLegacyClientWithMock(p)
-	v2Client := BuildV2ClientWithMocks()
-
-	cl := NewClient(legacyClient, v2Client, authInfo)
-
-	ctx := context.Background()
-
-	p.On("GetReplicationPoliciesID", &products.GetReplicationPoliciesIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationPoliciesIDOK{Payload: &model.ReplicationPolicy{}}, nil)
-
-	p.On("GetReplicationExecutionsID", &products.GetReplicationExecutionsIDParams{
-		ID:      replExec.ID,
-		Context: ctx,
-	}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).Return(
-		&products.GetReplicationExecutionsIDOK{Payload: &model.ReplicationExecution{ID: 1}}, nil)
-
-	_, err := cl.GetReplicationExecutionsByID(ctx, replExec.ID)
-
-	if assert.Error(t, err) {
-		assert.IsType(t, &ErrReplicationExecutionReplicationIDMismatch{}, err)
 	}
 
 	p.AssertExpectations(t)
@@ -999,12 +816,6 @@ func TestErrReplicationExecutionReplicationIDMismatch_Error(t *testing.T) {
 	var e ErrReplicationExecutionReplicationIDMismatch
 
 	assert.Equal(t, ErrReplicationExecutionReplicationIDMismatchMsg, e.Error())
-}
-
-func TestErrReplicationExecutionReplicationIDNotFound_Error(t *testing.T) {
-	var e ErrReplicationExecutionReplicationPolicyIDNotFound
-
-	assert.Equal(t, ErrReplicationExecutionReplicationPolicyIDNotFoundMsg, e.Error())
 }
 
 func TestErrReplicationIllegalIDFormat_Error(t *testing.T) {


### PR DESCRIPTION
 when operating on replication executions, do not fetch their parent replication policies