### PR TITLE
Add methods to list, create, update and delete robot accounts

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -186,6 +186,16 @@ func (c *RESTClient) AddProjectRobot(ctx context.Context, p *modelv2.Project, ro
 	return c.project.AddProjectRobot(ctx, p, robot)
 }
 
+// UpdateProjectRobot wraps the UpdateProjectRobot method of the project sub-package.
+func (c *RESTClient) UpdateProjectRobot(ctx context.Context, p *modelv2.Project, robotID int, robot *model.RobotAccountUpdate) error {
+	return c.project.UpdateProjectRobot(ctx, p, robotID, robot)
+}
+
+// DeleteProjectRobot wraps the DeleteProjectRobot method of the project sub-package.
+func (c *RESTClient) DeleteProjectRobot(ctx context.Context, p *modelv2.Project, robotID int) error {
+	return c.project.DeleteProjectRobot(ctx, p, robotID)
+}
+
 // Registry Client
 
 // NewRegistry wraps the NewRegistry method of the registry sub-package.

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -2,10 +2,11 @@ package apiv2
 
 import (
 	"context"
-	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
-	"github.com/mittwald/goharbor-client/v3/apiv2/retention"
 	"net/url"
 	"strings"
+
+	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
+	"github.com/mittwald/goharbor-client/v3/apiv2/retention"
 
 	"github.com/go-openapi/runtime"
 	runtimeclient "github.com/go-openapi/runtime/client"
@@ -173,6 +174,16 @@ func (c *RESTClient) UpdateProjectMetadata(ctx context.Context, p *modelv2.Proje
 // DeleteProjectMetadataValue wraps the DeleteProjectMetadataValue method of the registry sub-package.
 func (c *RESTClient) DeleteProjectMetadataValue(ctx context.Context, p *modelv2.Project, key project.MetadataKey) error {
 	return c.project.DeleteProjectMetadataValue(ctx, p, key)
+}
+
+// ListProjectRobots wraps the ListProjectRobots method of the project sub-package.
+func (c *RESTClient) ListProjectRobots(ctx context.Context, p *modelv2.Project) ([]*model.RobotAccount, error) {
+	return c.project.ListProjectRobots(ctx, p)
+}
+
+// AddProjectRobot wraps the AddProjectRobot method of the project sub-package.
+func (c *RESTClient) AddProjectRobot(ctx context.Context, p *modelv2.Project, robot *model.RobotAccountCreate) (string, error) {
+	return c.project.AddProjectRobot(ctx, p, robot)
 }
 
 // Registry Client

--- a/apiv2/project/project.go
+++ b/apiv2/project/project.go
@@ -561,15 +561,54 @@ func (c *RESTClient) AddProjectRobot(ctx context.Context, p *modelv2.Project, ro
 
 	resp, err := c.LegacyClient.Products.PostProjectsProjectIDRobots(
 		&products.PostProjectsProjectIDRobotsParams{
-			Robot:      robot,
-			ProjectID:  int64(p.ProjectID),
-			Context:    ctx,
+			Robot:     robot,
+			ProjectID: int64(p.ProjectID),
+			Context:   ctx,
 		}, c.AuthInfo)
 	if err != nil {
 		return "", handleSwaggerProjectErrors(err)
 	}
 
 	return resp.Payload.Token, nil
+}
+
+// UpdateProjectRobot updates a robot account in project p.
+func (c *RESTClient) UpdateProjectRobot(ctx context.Context, p *modelv2.Project, robotID int, robot *model.RobotAccountUpdate) error {
+	if p == nil {
+		return &ErrProjectNotProvided{}
+	}
+
+	_, err := c.LegacyClient.Products.PutProjectsProjectIDRobotsRobotID(
+		&products.PutProjectsProjectIDRobotsRobotIDParams{
+			ProjectID: int64(p.ProjectID),
+			Robot:     robot,
+			RobotID:   int64(robotID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerProjectErrors(err)
+	}
+
+	return nil
+}
+
+// DeleteProjectRobot deletes a robot account from project p.
+func (c *RESTClient) DeleteProjectRobot(ctx context.Context, p *modelv2.Project, robotID int) error {
+	if p == nil {
+		return &ErrProjectNotProvided{}
+	}
+
+	_, err := c.LegacyClient.Products.DeleteProjectsProjectIDRobotsRobotID(
+		&products.DeleteProjectsProjectIDRobotsRobotIDParams{
+			ProjectID: int64(p.ProjectID),
+			RobotID:   int64(robotID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerProjectErrors(err)
+	}
+
+	return nil
 }
 
 // projectExists returns true, if p matches a project on server side.

--- a/apiv2/project/project.go
+++ b/apiv2/project/project.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"errors"
+
 	projectapi "github.com/mittwald/goharbor-client/v3/apiv2/internal/api/client/project"
 
 	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
@@ -532,6 +533,43 @@ func (c *RESTClient) DeleteProjectMetadataValue(ctx context.Context, p *modelv2.
 		}, c.AuthInfo)
 
 	return handleSwaggerProjectErrors(err)
+}
+
+// ListProjectRobots returns a list of all robot accounts in project p.
+func (c *RESTClient) ListProjectRobots(ctx context.Context, p *modelv2.Project) ([]*model.RobotAccount, error) {
+	if p == nil {
+		return nil, &ErrProjectNotProvided{}
+	}
+
+	resp, err := c.LegacyClient.Products.GetProjectsProjectIDRobots(
+		&products.GetProjectsProjectIDRobotsParams{
+			ProjectID: int64(p.ProjectID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerProjectErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// AddProjectRobot adds a robot account to project p and returns the token.
+func (c *RESTClient) AddProjectRobot(ctx context.Context, p *modelv2.Project, robot *model.RobotAccountCreate) (string, error) {
+	if p == nil {
+		return "", &ErrProjectNotProvided{}
+	}
+
+	resp, err := c.LegacyClient.Products.PostProjectsProjectIDRobots(
+		&products.PostProjectsProjectIDRobotsParams{
+			Robot:      robot,
+			ProjectID:  int64(p.ProjectID),
+			Context:    ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return "", handleSwaggerProjectErrors(err)
+	}
+
+	return resp.Payload.Token, nil
 }
 
 // projectExists returns true, if p matches a project on server side.


### PR DESCRIPTION
For an integration with other systems (e.g. building images for projects in GitLab in our case) it is desirable to automate creation of robot accounts, so I added the generated Swagger stubs to the client.