### PR TITLE
prevent nil pointer dereference when accessing project metadata

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -294,8 +294,8 @@ func (c *RESTClient) ResetSystemGarbageCollection(ctx context.Context) error {
 // Retention Client
 
 // NewRetentionPolicy wraps the NewRetentionPolicy method of the retention sub-package.
-func (c *RESTClient) NewRetentionPolicy(ctx context.Context, rep *model.RetentionPolicy) error {
-	return c.retention.NewRetentionPolicy(ctx, rep)
+func (c *RESTClient) NewRetentionPolicy(ctx context.Context, ret *model.RetentionPolicy) error {
+	return c.retention.NewRetentionPolicy(ctx, ret)
 }
 
 // GetRetentionPolicyByProjectID wraps the GetRetentionPolicyByProject method of the retention sub-package.

--- a/apiv2/project/project.go
+++ b/apiv2/project/project.go
@@ -432,28 +432,11 @@ func (c *RESTClient) GetProjectMetadataValue(ctx context.Context, projectID int6
 		return "", handleSwaggerProjectErrors(err)
 	}
 
-	var result string
-
-	switch key {
-	case ProjectMetadataKeyEnableContentTrust:
-		result = *project.Metadata.EnableContentTrust
-	case ProjectMetadataKeyAutoScan:
-		result = *project.Metadata.AutoScan
-	case ProjectMetadataKeySeverity:
-		result = *project.Metadata.Severity
-	case ProjectMetadataKeyReuseSysCveAllowlist:
-		result = *project.Metadata.ReuseSysCveAllowlist
-	case ProjectMetadataKeyPublic:
-		result = project.Metadata.Public
-	case ProjectMetadataKeyPreventVul:
-		result = *project.Metadata.PreventVul
-	case ProjectMetadataKeyRetentionID:
-		result = *project.Metadata.RetentionID
-	default:
-		return "", &ErrProjectInvalidRequest{}
+	if project.Metadata == nil {
+		return "", &ErrProjectMetadataUndefined{}
 	}
 
-	return result, nil
+	return retrieveMetadataValue(key, project.Metadata)
 }
 
 // ListMetadata lists all metadata of a project

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -282,26 +282,25 @@ func (e *ErrProjectUnknownResource) Error() string {
 // Returns an empty string plus an error when encountering a nil pointer, or if the requested key k is invalid.
 func retrieveMetadataValue(k MetadataKey, m *modelv2.ProjectMetadata) (string, error) {
 	var r string
-	var sPtr *string
 
 	switch k {
 	case ProjectMetadataKeyEnableContentTrust:
-		if m.EnableContentTrust == sPtr {
+		if m.EnableContentTrust == nil {
 			return "", &ErrProjectMetadataValueEnableContentTrustUndefined{}
 		}
 		r = *m.EnableContentTrust
 	case ProjectMetadataKeyAutoScan:
-		if m.AutoScan == sPtr {
+		if m.AutoScan == nil {
 			return "", &ErrProjectMetadataValueAutoScanUndefined{}
 		}
 		r = *m.AutoScan
 	case ProjectMetadataKeySeverity:
-		if m.Severity == sPtr {
+		if m.Severity == nil {
 			return "", &ErrProjectMetadataValueSeverityUndefined{}
 		}
 		r = *m.Severity
 	case ProjectMetadataKeyReuseSysCveAllowlist:
-		if m.ReuseSysCveAllowlist == sPtr {
+		if m.ReuseSysCveAllowlist == nil {
 			return "", &ErrProjectMetadataValueReuseSysCveAllowlistUndefined{}
 		}
 		r = *m.ReuseSysCveAllowlist
@@ -311,12 +310,12 @@ func retrieveMetadataValue(k MetadataKey, m *modelv2.ProjectMetadata) (string, e
 		}
 		r = m.Public
 	case ProjectMetadataKeyPreventVul:
-		if m.PreventVul == sPtr {
+		if m.PreventVul == nil {
 			return "", &ErrProjectMetadataValuePreventVulUndefined{}
 		}
 		r = *m.PreventVul
 	case ProjectMetadataKeyRetentionID:
-		if m.RetentionID == sPtr {
+		if m.RetentionID == nil {
 			return "", &ErrProjectMetadataValueRetentionIDUndefined{}
 		}
 		r = *m.RetentionID

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -2,6 +2,8 @@ package project
 
 import (
 	projectapi "github.com/mittwald/goharbor-client/v3/apiv2/internal/api/client/project"
+	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
+
 	"net/http"
 
 	"github.com/go-openapi/runtime"
@@ -62,6 +64,9 @@ const (
 
 	// ErrProjectMetadataUndefinedMsg is the error message for ErrProjectMetadataUndefined error.
 	ErrProjectMetadataUndefinedMsg = "project metadata undefined"
+
+	// ErrProjectMetadataValueUndefinedMsg is the error message used for MetadataKey's being undefined or nil.
+	ErrProjectMetadataValueUndefinedMsg = "project metadata value is nil: "
 )
 
 // ErrProjectNameNotProvided describes a missing project name.
@@ -199,6 +204,62 @@ func (e *ErrProjectMetadataUndefined) Error() string {
 	return ErrProjectMetadataUndefinedMsg
 }
 
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValueEnableContentTrustUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValueEnableContentTrustUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyEnableContentTrust)
+}
+
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValueAutoScanUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValueAutoScanUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyAutoScan)
+}
+
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValueSeverityUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValueSeverityUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeySeverity)
+}
+
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValueReuseSysCveAllowlistUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValueReuseSysCveAllowlistUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyReuseSysCveAllowlist)
+}
+
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValuePublicUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValuePublicUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyPublic)
+}
+
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValuePreventVulUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValuePreventVulUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyPreventVul)
+}
+
+// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+type ErrProjectMetadataValueRetentionIDUndefined struct{}
+
+// Error returns the error message.
+func (e *ErrProjectMetadataValueRetentionIDUndefined) Error() string {
+	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyRetentionID)
+}
+
 // ErrProjectMetadataAlreadyExists describes an error, which happens
 // when a metadata key of a project is tried to be created a second time.
 type ErrProjectMetadataAlreadyExists struct{}
@@ -215,6 +276,55 @@ type ErrProjectUnknownResource struct{}
 // Error returns the error message.
 func (e *ErrProjectUnknownResource) Error() string {
 	return ErrProjectUnknownResourceMsg
+}
+
+// retrieveMetadataValue returns the value of the metadata k that is contained in the project metadata m.
+// Returns an empty string plus an error when encountering a nil pointer, or if the requested key k is invalid.
+func retrieveMetadataValue(k MetadataKey, m *modelv2.ProjectMetadata) (string, error) {
+	var r string
+	var sPtr *string
+
+	switch k {
+	case ProjectMetadataKeyEnableContentTrust:
+		if m.EnableContentTrust == sPtr {
+			return "", &ErrProjectMetadataValueEnableContentTrustUndefined{}
+		}
+		r = *m.EnableContentTrust
+	case ProjectMetadataKeyAutoScan:
+		if m.AutoScan == sPtr {
+			return "", &ErrProjectMetadataValueAutoScanUndefined{}
+		}
+		r = *m.AutoScan
+	case ProjectMetadataKeySeverity:
+		if m.Severity == sPtr {
+			return "", &ErrProjectMetadataValueSeverityUndefined{}
+		}
+		r = *m.Severity
+	case ProjectMetadataKeyReuseSysCveAllowlist:
+		if m.ReuseSysCveAllowlist == sPtr {
+			return "", &ErrProjectMetadataValueReuseSysCveAllowlistUndefined{}
+		}
+		r = *m.ReuseSysCveAllowlist
+	case ProjectMetadataKeyPublic:
+		if m.Public == "" {
+			return "", &ErrProjectMetadataValuePublicUndefined{}
+		}
+		r = m.Public
+	case ProjectMetadataKeyPreventVul:
+		if m.PreventVul == sPtr {
+			return "", &ErrProjectMetadataValuePreventVulUndefined{}
+		}
+		r = *m.PreventVul
+	case ProjectMetadataKeyRetentionID:
+		if m.RetentionID == sPtr {
+			return "", &ErrProjectMetadataValueRetentionIDUndefined{}
+		}
+		r = *m.RetentionID
+	default:
+		return "", &ErrProjectInvalidRequest{}
+	}
+
+	return r, nil
 }
 
 // handleProjectErrors takes a swagger generated error as input,

--- a/apiv2/project/project_test.go
+++ b/apiv2/project/project_test.go
@@ -98,48 +98,6 @@ func TestRESTClient_NewProject(t *testing.T) {
 	p.AssertExpectations(t)
 }
 
-// A workaround to test the successful return of the "201" status on a NewProject() call
-func TestRESTClient_NewProject_201(t *testing.T) {
-	p := &mocks.MockProjectClientService{}
-
-	legacyClient := BuildLegacyClientWithMock(nil)
-	v2Client := BuildProjectClientWithMocks(p)
-
-	cl := NewClient(legacyClient, v2Client, authInfo)
-
-	ctx := context.Background()
-
-	postProjectParams := &projectapi.CreateProjectParams{
-		Project: pReq,
-		Context: ctx,
-	}
-
-	listProjectParams := &projectapi.ListProjectsParams{
-		Name:    &pReq.ProjectName,
-		Context: ctx,
-	}
-
-	getProjectParams := &projectapi.GetProjectParams{
-		ProjectID: exampleProjectID,
-		Context:   ctx,
-	}
-
-	p.On("CreateProject", postProjectParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-		Return(&projectapi.CreateProjectCreated{}, nil)
-
-	p.On("ListProjects", listProjectParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-		Return(&projectapi.ListProjectsOK{Payload: []*modelv2.Project{exampleProject}}, nil)
-
-	p.On("GetProject", getProjectParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-		Return(&projectapi.GetProjectOK{Payload: exampleProject}, nil)
-
-	_, err := cl.NewProject(ctx, exampleProject.Name, int(exampleStorageLimit))
-
-	assert.NoError(t, err)
-
-	p.AssertExpectations(t)
-}
-
 func TestRESTClient_NewProject_ErrProjectNotFound(t *testing.T) {
 	p := &mocks.MockProjectClientService{}
 
@@ -1583,7 +1541,8 @@ func TestRESTClient_GetProjectMetadataValue(t *testing.T) {
 	}
 
 	var sPtr = "test"
-	for i := range keys {
+
+	for _, k := range keys {
 		getProjectsParams := &projectapi.GetProjectParams{
 			ProjectID: exampleProjectID,
 			Context:   ctx,
@@ -1603,7 +1562,7 @@ func TestRESTClient_GetProjectMetadataValue(t *testing.T) {
 				ProjectID: int32(exampleProjectID),
 			}}, nil)
 
-		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, keys[i])
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
 
 		assert.Equal(t, val, sPtr)
 
@@ -1611,6 +1570,154 @@ func TestRESTClient_GetProjectMetadataValue(t *testing.T) {
 
 		p.AssertExpectations(t)
 	}
+}
+
+func TestRESTClient_GetProjectMetadataValue_ValuesUndefined(t *testing.T) {
+	t.Parallel()
+
+	p := &mocks.MockProjectClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(nil)
+	v2Client := BuildProjectClientWithMocks(p)
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	getProjectsParams := &projectapi.GetProjectParams{
+		ProjectID: exampleProjectID,
+		Context:   ctx,
+	}
+
+	var k MetadataKey
+	t.Run("ProjectMetadataValueEnableContentTrustUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeyEnableContentTrust
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValueEnableContentTrustUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+	t.Run("ProjectMetadataValueAutoScanUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeyAutoScan
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValueAutoScanUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+	t.Run("ProjectMetadataValueSeverityUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeySeverity
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValueSeverityUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+	t.Run("ProjectMetadataValueReuseSysCveAllowlistUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeyReuseSysCveAllowlist
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValueReuseSysCveAllowlistUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+	t.Run("ProjectMetadataValueRetentionIDUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeyRetentionID
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValueRetentionIDUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+	t.Run("ProjectMetadataValuePublicUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeyPublic
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValuePublicUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+	t.Run("ProjectMetadataValuePreventVulUndefined", func(t *testing.T) {
+		k = ProjectMetadataKeyPreventVul
+		p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+				Metadata:  &modelv2.ProjectMetadata{},
+				ProjectID: int32(exampleProjectID),
+			}}, nil)
+		val, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, k)
+		if assert.Error(t, err) {
+			assert.Equal(t, val, "")
+			assert.IsType(t, &ErrProjectMetadataValuePreventVulUndefined{}, err)
+		}
+		p.AssertExpectations(t)
+	})
+}
+
+func TestRESTClient_GetProjectMetadataValue_MetadataNil(t *testing.T) {
+	p := &mocks.MockProjectClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(nil)
+	v2Client := BuildProjectClientWithMocks(p)
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	getProjectsParams := &projectapi.GetProjectParams{
+		ProjectID: exampleProjectID,
+		Context:   ctx,
+	}
+
+	p.On("GetProject", getProjectsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&projectapi.GetProjectOK{Payload: &modelv2.Project{
+			Metadata:  nil,
+			ProjectID: int32(exampleProjectID),
+		}}, nil)
+
+	_, err := cl.GetProjectMetadataValue(ctx, exampleProjectID, ProjectMetadataKeyRetentionID)
+
+	if assert.Error(t, err) {
+		assert.IsType(t, &ErrProjectMetadataUndefined{}, err)
+	}
+
+	p.AssertExpectations(t)
 }
 
 func TestRESTClient_GetProjectMetadataValue_ErrProjectUnknownResource(t *testing.T) {

--- a/apiv2/retention/retention.go
+++ b/apiv2/retention/retention.go
@@ -12,8 +12,7 @@ import (
 	"github.com/mittwald/goharbor-client/v3/apiv2/internal/legacyapi/client"
 	"github.com/mittwald/goharbor-client/v3/apiv2/internal/legacyapi/client/products"
 	model "github.com/mittwald/goharbor-client/v3/apiv2/model/legacy"
-	p "github.com/mittwald/goharbor-client/v3/apiv2/project"
-	pc "github.com/mittwald/goharbor-client/v3/apiv2/project"
+	projectapi "github.com/mittwald/goharbor-client/v3/apiv2/project"
 )
 
 const (
@@ -120,9 +119,9 @@ func (c *RESTClient) NewRetentionPolicy(ctx context.Context, ret *model.Retentio
 // GetRetentionPolicyByProject returns a retention policy identified by the corresponding project resource.
 // The retention ID is stored in a project's metadata.
 func (c *RESTClient) GetRetentionPolicyByProject(ctx context.Context, project *modelv2.Project) (*model.RetentionPolicy, error) {
-	pc := pc.NewClient(c.LegacyClient, c.V2Client, c.AuthInfo)
+	pc := projectapi.NewClient(c.LegacyClient, c.V2Client, c.AuthInfo)
 
-	val, err := pc.GetProjectMetadataValue(ctx, int64(project.ProjectID), p.ProjectMetadataKeyRetentionID)
+	val, err := pc.GetProjectMetadataValue(ctx, int64(project.ProjectID), projectapi.ProjectMetadataKeyRetentionID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR includes improvement on the project client's behaviour when accessing metadata values as well as senseful unit tests for the retention client.

**Project client**
- when encountering nil pointer dereferences in project metadata values, an individual error message for every project metadata key is returned 
- unit tests have been expanded to test the above

**Retention client**
- added unit tests for the client's **Get***-methods in different scenarios