### PR TITLE
implement fetching retention policies by id

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -303,6 +303,11 @@ func (c *RESTClient) GetRetentionPolicyByProject(ctx context.Context, project *m
 	return c.retention.GetRetentionPolicyByProject(ctx, project)
 }
 
+// GetRetentionPolicyByID wraps the GetRetentionPolicyByID method of the retention sub-package.
+func (c *RESTClient) GetRetentionPolicyByID(ctx context.Context, id int64) (*model.RetentionPolicy, error) {
+	return c.retention.GetRetentionPolicyByID(ctx, id)
+}
+
 // UpdateRetentionPolicy wraps the UpdateRetentionPolicy method of the retention sub-package.
 func (c *RESTClient) UpdateRetentionPolicy(ctx context.Context, ret *model.RetentionPolicy) error {
 	return c.retention.UpdateRetentionPolicy(ctx, ret)


### PR DESCRIPTION
This PR adds a functionality to the retention client that enables the user to fetch retention policies by their ID.

Previously, this was only possible via `GetRetentionPolicyByProject()`, which required passing a `project` struct as argument.
In some cases this seems a little too bloated, while the now added function only requires the retention's ID.