### PR TITLE
implicit storageLimit values

### DIFF
--- a/apiv2/quota/quota.go
+++ b/apiv2/quota/quota.go
@@ -49,7 +49,12 @@ func (c *RESTClient) GetQuotaByProjectID(ctx context.Context, projectID int64) (
 }
 
 // UpdateStorageQuotaByProjectID updates the storageLimit quota of a project.
+// A storageLimit value smaller than '0' will implicitly be set to '-1', equalling the 'unlimited' setting.
 func (c *RESTClient) UpdateStorageQuotaByProjectID(ctx context.Context, projectID int64, storageLimit int64) error {
+	if storageLimit <= 0 {
+		storageLimit = -1
+	}
+
 	params := &products.PutQuotasIDParams{
 		Hard: &legacymodel.QuotaUpdateReq{
 			Hard: map[string]int64{
@@ -61,6 +66,7 @@ func (c *RESTClient) UpdateStorageQuotaByProjectID(ctx context.Context, projectI
 	}
 
 	_, err := c.LegacyClient.Products.PutQuotasID(params, c.AuthInfo)
+
 	if err != nil {
 		return handleSwaggerQuotaErrors(err)
 	}

--- a/apiv2/quota/quota_integration_test.go
+++ b/apiv2/quota/quota_integration_test.go
@@ -17,15 +17,19 @@ import (
 )
 
 var (
-	u, _                       = url.Parse(integrationtest.Host)
-	legacySwaggerClient        = client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
-	v2SwaggerClient            = v2client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
-	authInfo                   = runtimeclient.BasicAuth(integrationtest.User, integrationtest.Password)
-	storageLimitPositive int64 = 1
-	storageLimitNegative int64 = -1
-	testProjectName            = "test-project"
+	u, _                        = url.Parse(integrationtest.Host)
+	legacySwaggerClient         = client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
+	v2SwaggerClient             = v2client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
+	authInfo                    = runtimeclient.BasicAuth(integrationtest.User, integrationtest.Password)
+	storageLimitPositive  int64 = 1
+	storageLimitNegative  int64 = -1
+	storageLimitNegative2 int64 = -1000
+	storageLimitNull      int64 = 0
+	testProjectName             = "test-project"
 )
 
+// TestAPIGetQuotaByProjectID_PositiveQuota creates a project with a positive storage limit set,
+// gets the storage quota and compares the fetched value.
 func TestAPIGetQuotaByProjectID_PositiveQuota(t *testing.T) {
 	ctx := context.Background()
 	c := NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
@@ -41,9 +45,11 @@ func TestAPIGetQuotaByProjectID_PositiveQuota(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, q)
 
-	require.Equal(t, q.Hard["storage"], storageLimitPositive)
+	require.Equal(t, storageLimitPositive, q.Hard["storage"])
 }
 
+// TestAPIGetQuotaByProjectID_NegativeQuota creates a project with a negative storage limit set,
+// gets the storage quota and compares the fetched value.
 func TestAPIGetQuotaByProjectID_NegativeQuota(t *testing.T) {
 	ctx := context.Background()
 	c := NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
@@ -58,5 +64,88 @@ func TestAPIGetQuotaByProjectID_NegativeQuota(t *testing.T) {
 	q, err := c.GetQuotaByProjectID(ctx, int64(project.ProjectID))
 	require.NoError(t, err)
 	require.NotNil(t, q)
-	require.Equal(t, q.Hard["storage"], storageLimitNegative)
+	require.Equal(t, storageLimitNegative, q.Hard["storage"])
+}
+
+func TestAPIUpdateQuotaByProjectID(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+
+	// TestAPIUpdateQuotaByProjectID_PositiveQuota creates a project with a negative storage limit.
+	// Updates the projects storage quota to a positive value and compares the observed values.
+	t.Run("PositiveQuota", func(t *testing.T) {
+		pc := project.NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+		p, err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+		defer pc.DeleteProject(ctx, p)
+
+		project, err := pc.GetProjectByName(ctx, testProjectName)
+		require.NoError(t, err)
+
+		err = c.UpdateStorageQuotaByProjectID(ctx, int64(project.ProjectID), storageLimitPositive)
+		require.NoError(t, err)
+
+		q, err := c.GetQuotaByProjectID(ctx, int64(project.ProjectID))
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		require.Equal(t, storageLimitPositive, q.Hard["storage"])
+	})
+
+	// TestAPIUpdateQuotaByProjectID_PositiveQuota creates a project with a positive storage limit.
+	// Updates the projects storage quota to a negative value and compares the observed values.
+	t.Run("NegativeQuota", func(t *testing.T) {
+		pc := project.NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+		p, err := pc.NewProject(ctx, testProjectName, &storageLimitPositive)
+		defer pc.DeleteProject(ctx, p)
+
+		project, err := pc.GetProjectByName(ctx, testProjectName)
+		require.NoError(t, err)
+
+		err = c.UpdateStorageQuotaByProjectID(ctx, int64(project.ProjectID), storageLimitNegative)
+		require.NoError(t, err)
+
+		q, err := c.GetQuotaByProjectID(ctx, int64(project.ProjectID))
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		require.Equal(t, storageLimitNegative, q.Hard["storage"])
+	})
+
+	// TestAPIUpdateQuotaByProjectID_NegativeQuota_2 creates a project with a storage limit set.
+	// Tries updating the storage quota to a value of "-1000",
+	// which is expected to result in the quota being implicitly set to '-1'.
+	t.Run("NegativeQuota_2", func(t *testing.T) {
+		pc := project.NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+		p, err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+		defer pc.DeleteProject(ctx, p)
+
+		project, err := pc.GetProjectByName(ctx, testProjectName)
+		require.NoError(t, err)
+
+		err = c.UpdateStorageQuotaByProjectID(ctx, int64(project.ProjectID), storageLimitNegative2)
+		require.NoError(t, err)
+
+		q, err := c.GetQuotaByProjectID(ctx, int64(project.ProjectID))
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		require.Equal(t, storageLimitNegative, q.Hard["storage"])
+	})
+
+	// TestAPIUpdateQuotaByProjectID_NullQuota creates a project with a storage limit set.
+	// Tries updating the storage quota to a value of "0",
+	// which is expected to result in the quota being implicitly set to '-1'.
+	t.Run("NullQuota", func(t *testing.T) {
+		pc := project.NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+		p, err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+		defer pc.DeleteProject(ctx, p)
+
+		project, err := pc.GetProjectByName(ctx, testProjectName)
+		require.NoError(t, err)
+
+		err = c.UpdateStorageQuotaByProjectID(ctx, int64(project.ProjectID), storageLimitNull)
+		require.NoError(t, err)
+
+		q, err := c.GetQuotaByProjectID(ctx, int64(project.ProjectID))
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		require.Equal(t, storageLimitNegative, q.Hard["storage"])
+	})
 }

--- a/apiv2/quota/quota_test.go
+++ b/apiv2/quota/quota_test.go
@@ -21,6 +21,7 @@ var (
 	testProjectID            int64 = 1
 	testStorageLimitPositive int64 = 1
 	testStorageLimitNegative int64 = -1
+	testStorageLimitNull     int64 = 0
 )
 
 func BuildLegacyClientWithMock(service *mocks.MockProductsClientService) *client.Harbor {
@@ -102,6 +103,26 @@ func TestRESTClient_UpdateStorageQuotaByProjectID(t *testing.T) {
 			Return(&products.PutQuotasIDOK{}, nil)
 
 		err := cl.UpdateStorageQuotaByProjectID(ctx, testProjectID, testStorageLimitNegative)
+		assert.NoError(t, err)
+
+		p.AssertExpectations(t)
+	})
+
+	t.Run("NullLimit", func(t *testing.T) {
+		putQuotasIDParams := &products.PutQuotasIDParams{
+			ID: testProjectID,
+			Hard: &legacymodel.QuotaUpdateReq{
+				Hard: map[string]int64{
+					"storage": testStorageLimitNegative,
+				},
+			},
+			Context: ctx,
+		}
+
+		p.On("PutQuotasID", putQuotasIDParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&products.PutQuotasIDOK{}, nil)
+
+		err := cl.UpdateStorageQuotaByProjectID(ctx, testProjectID, testStorageLimitNull)
 		assert.NoError(t, err)
 
 		p.AssertExpectations(t)


### PR DESCRIPTION
This PR extends the `quota` clients functionality in a way that invalid provided values are implicitly set to an infinite storage limit (`-1`). 

A value is considered invalid, if it is **smaller or equal to 0**. 
The harbor API does not return errors when updating quotas to an invalid value - it returns a `status 200` response without changing the quota value.