### PR TITLE
re-generate code using latest go-swagger image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ mock-cleanup integration-test-v1 integration-test-v2
 V1_VERSION = v1.10.6
 V2_VERSION = v2.1.3
 MOCKERY_VERSION = v2.5.1
-GOSWAGGER_VERSION = v0.26.0
+GOSWAGGER_VERSION = v0.26.1
 
 # Run all code generation targets
 generate: swagger-generate mock-generate

--- a/apiv1/internal/api/client/products/products_client.go
+++ b/apiv1/internal/api/client/products/products_client.go
@@ -25,83 +25,86 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteProjectsProjectID(params *DeleteProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDOK, error)
+	DeleteProjectsProjectID(params *DeleteProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDOK, error)
 
-	DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMembersMidOK, error)
+	DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMembersMidOK, error)
 
-	DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error)
+	DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error)
 
-	DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteRegistriesIDOK, error)
+	DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRegistriesIDOK, error)
 
-	DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteReplicationPoliciesIDOK, error)
+	DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteReplicationPoliciesIDOK, error)
 
-	DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteUsersUserIDOK, error)
+	DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteUsersUserIDOK, error)
 
-	GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter) (*GetHealthOK, error)
+	GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetHealthOK, error)
 
-	GetProjects(params *GetProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsOK, error)
+	GetProjects(params *GetProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsOK, error)
 
-	GetProjectsProjectID(params *GetProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDOK, error)
+	GetProjectsProjectID(params *GetProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDOK, error)
 
-	GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMembersOK, error)
+	GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMembersOK, error)
 
-	GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasOK, error)
+	GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasOK, error)
 
-	GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasMetaNameOK, error)
+	GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasMetaNameOK, error)
 
-	GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesOK, error)
+	GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesOK, error)
 
-	GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsOK, error)
+	GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsOK, error)
 
-	GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDOK, error)
+	GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDOK, error)
 
-	GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesOK, error)
+	GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesOK, error)
 
-	GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesIDOK, error)
+	GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesIDOK, error)
 
-	GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDOK, error)
+	GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDOK, error)
 
-	GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsMetadatasOK, error)
+	GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsMetadatasOK, error)
 
-	GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcScheduleOK, error)
+	GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcScheduleOK, error)
 
-	GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersOK, error)
+	GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersOK, error)
 
-	PostProjects(params *PostProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsCreated, error)
+	PostProjects(params *PostProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsCreated, error)
 
-	PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMembersCreated, error)
+	PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMembersCreated, error)
 
-	PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMetadatasOK, error)
+	PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMetadatasOK, error)
 
-	PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*PostRegistriesCreated, error)
+	PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRegistriesCreated, error)
 
-	PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationExecutionsCreated, error)
+	PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationExecutionsCreated, error)
 
-	PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationPoliciesCreated, error)
+	PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationPoliciesCreated, error)
 
-	PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostRetentionsCreated, error)
+	PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRetentionsCreated, error)
 
-	PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemGcScheduleOK, error)
+	PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemGcScheduleOK, error)
 
-	PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter) (*PostUsersCreated, error)
+	PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostUsersCreated, error)
 
-	PutProjectsProjectID(params *PutProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDOK, error)
+	PutProjectsProjectID(params *PutProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDOK, error)
 
-	PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMembersMidOK, error)
+	PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMembersMidOK, error)
 
-	PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMetadatasMetaNameOK, error)
+	PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMetadatasMetaNameOK, error)
 
-	PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutRegistriesIDOK, error)
+	PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutRegistriesIDOK, error)
 
-	PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutReplicationPoliciesIDOK, error)
+	PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutReplicationPoliciesIDOK, error)
 
-	PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemGcScheduleOK, error)
+	PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemGcScheduleOK, error)
 
-	PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDOK, error)
+	PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDOK, error)
 
-	PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDPasswordOK, error)
+	PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDPasswordOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -112,13 +115,12 @@ type ClientService interface {
   This endpoint is aimed to delete project by project ID.
 
 */
-func (a *Client) DeleteProjectsProjectID(params *DeleteProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDOK, error) {
+func (a *Client) DeleteProjectsProjectID(params *DeleteProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectID",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}",
@@ -130,7 +132,12 @@ func (a *Client) DeleteProjectsProjectID(params *DeleteProjectsProjectIDParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -147,13 +154,12 @@ func (a *Client) DeleteProjectsProjectID(params *DeleteProjectsProjectIDParams, 
 /*
   DeleteProjectsProjectIDMembersMid deletes project member
 */
-func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMembersMidOK, error) {
+func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMembersMidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDMembersMidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDMembersMid",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/members/{mid}",
@@ -165,7 +171,12 @@ func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProject
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -185,13 +196,12 @@ func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProject
   This endpoint is aimed to delete metadata of a project.
 
 */
-func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
+func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDMetadatasMetaNameParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDMetadatasMetaName",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/metadatas/{meta_name}",
@@ -203,7 +213,12 @@ func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjects
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -223,13 +238,12 @@ func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjects
   This endpoint is for to delete specific registry.
 
 */
-func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteRegistriesIDOK, error) {
+func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRegistriesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteRegistriesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteRegistriesID",
 		Method:             "DELETE",
 		PathPattern:        "/registries/{id}",
@@ -241,7 +255,12 @@ func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -261,13 +280,12 @@ func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo r
   Delete the replication policy specified by ID.
 
 */
-func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteReplicationPoliciesIDOK, error) {
+func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteReplicationPoliciesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteReplicationPoliciesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteReplicationPoliciesID",
 		Method:             "DELETE",
 		PathPattern:        "/replication/policies/{id}",
@@ -279,7 +297,12 @@ func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesID
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -300,13 +323,12 @@ func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesID
 be removed.It actually won't be deleted from DB.
 
 */
-func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteUsersUserIDOK, error) {
+func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteUsersUserIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteUsersUserIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteUsersUserID",
 		Method:             "DELETE",
 		PathPattern:        "/users/{user_id}",
@@ -318,7 +340,12 @@ func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -338,13 +365,12 @@ func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo run
   The endpoint returns the health stauts of the system.
 
 */
-func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter) (*GetHealthOK, error) {
+func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetHealthOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetHealthParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetHealth",
 		Method:             "GET",
 		PathPattern:        "/health",
@@ -356,7 +382,12 @@ func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -376,13 +407,12 @@ func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthI
   This endpoint returns all projects created by Harbor, and can be filtered by project name.
 
 */
-func (a *Client) GetProjects(params *GetProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsOK, error) {
+func (a *Client) GetProjects(params *GetProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjects",
 		Method:             "GET",
 		PathPattern:        "/projects",
@@ -394,7 +424,12 @@ func (a *Client) GetProjects(params *GetProjectsParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -414,13 +449,12 @@ func (a *Client) GetProjects(params *GetProjectsParams, authInfo runtime.ClientA
   This endpoint returns specific project information by project ID.
 
 */
-func (a *Client) GetProjectsProjectID(params *GetProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDOK, error) {
+func (a *Client) GetProjectsProjectID(params *GetProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectID",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}",
@@ -432,7 +466,12 @@ func (a *Client) GetProjectsProjectID(params *GetProjectsProjectIDParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -451,13 +490,12 @@ func (a *Client) GetProjectsProjectID(params *GetProjectsProjectIDParams, authIn
 
   Get all project member information
 */
-func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMembersOK, error) {
+func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMembersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMembersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMembers",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/members",
@@ -469,7 +507,12 @@ func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembers
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -489,13 +532,12 @@ func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembers
   This endpoint returns metadata of the project specified by project ID.
 
 */
-func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasOK, error) {
+func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMetadatasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMetadatas",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/metadatas",
@@ -507,7 +549,12 @@ func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetad
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -527,13 +574,12 @@ func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetad
   This endpoint returns specified metadata of a project.
 
 */
-func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasMetaNameOK, error) {
+func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasMetaNameOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMetadatasMetaNameParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMetadatasMetaName",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/metadatas/{meta_name}",
@@ -545,7 +591,12 @@ func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -565,13 +616,12 @@ func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjec
   This endpoint let user list filtered registries by name, if name is nil, list returns all registries.
 
 */
-func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesOK, error) {
+func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRegistriesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRegistries",
 		Method:             "GET",
 		PathPattern:        "/registries",
@@ -583,7 +633,12 @@ func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -603,13 +658,12 @@ func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.Cli
   This endpoint let user list replication executions.
 
 */
-func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsOK, error) {
+func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationExecutions",
 		Method:             "GET",
 		PathPattern:        "/replication/executions",
@@ -621,7 +675,12 @@ func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -641,13 +700,12 @@ func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams
   This endpoint is for user to get one execution of the replication.
 
 */
-func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDOK, error) {
+func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationExecutionsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationExecutionsID",
 		Method:             "GET",
 		PathPattern:        "/replication/executions/{id}",
@@ -659,7 +717,12 @@ func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -679,13 +742,12 @@ func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDPa
   This endpoint let user list replication policies
 
 */
-func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesOK, error) {
+func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationPolicies",
 		Method:             "GET",
 		PathPattern:        "/replication/policies",
@@ -697,7 +759,12 @@ func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -717,13 +784,12 @@ func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, au
   This endpoint let user get replication policy by specific ID.
 
 */
-func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesIDOK, error) {
+func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationPoliciesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationPoliciesID",
 		Method:             "GET",
 		PathPattern:        "/replication/policies/{id}",
@@ -735,7 +801,12 @@ func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -754,13 +825,12 @@ func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams
 
   Get Retention Policy.
 */
-func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDOK, error) {
+func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsID",
 		Method:             "GET",
 		PathPattern:        "/retentions/{id}",
@@ -772,7 +842,12 @@ func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -791,13 +866,12 @@ func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime
 
   Get Retention Metadatas.
 */
-func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsMetadatasOK, error) {
+func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsMetadatasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsMetadatasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsMetadatas",
 		Method:             "GET",
 		PathPattern:        "/retentions/metadatas",
@@ -809,7 +883,12 @@ func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -828,13 +907,12 @@ func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, au
 
   This endpoint is for get schedule of gc job.
 */
-func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcScheduleOK, error) {
+func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemGcScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemGcSchedule",
 		Method:             "GET",
 		PathPattern:        "/system/gc/schedule",
@@ -846,7 +924,12 @@ func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -866,13 +949,12 @@ func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo
   This endpoint is for user to search registered users, support for filtering results with username.Notice, by now this operation is only for administrator.
 
 */
-func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersOK, error) {
+func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsers",
 		Method:             "GET",
 		PathPattern:        "/users",
@@ -884,7 +966,12 @@ func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInf
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -904,13 +991,12 @@ func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInf
   This endpoint is for user to create a new project.
 
 */
-func (a *Client) PostProjects(params *PostProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsCreated, error) {
+func (a *Client) PostProjects(params *PostProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjects",
 		Method:             "POST",
 		PathPattern:        "/projects",
@@ -922,7 +1008,12 @@ func (a *Client) PostProjects(params *PostProjectsParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -941,13 +1032,12 @@ func (a *Client) PostProjects(params *PostProjectsParams, authInfo runtime.Clien
 
   Create project member relationship, the member can be one of the user_member and group_member,  The user_member need to specify user_id or username. If the user already exist in harbor DB, specify the user_id,  If does not exist in harbor DB, it will SearchAndOnBoard the user. The group_member need to specify id or ldap_group_dn. If the group already exist in harbor DB. specify the user group's id,  If does not exist, it will SearchAndOnBoard the group.
 */
-func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMembersCreated, error) {
+func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMembersCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDMembersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDMembers",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/members",
@@ -959,7 +1049,12 @@ func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembe
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -979,13 +1074,12 @@ func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembe
   This endpoint is aimed to add metadata of a project.
 
 */
-func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMetadatasOK, error) {
+func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMetadatasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDMetadatasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDMetadatas",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/metadatas",
@@ -997,7 +1091,12 @@ func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMet
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1017,13 +1116,12 @@ func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMet
   This endpoint is for user to create a new registry.
 
 */
-func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*PostRegistriesCreated, error) {
+func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRegistriesCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostRegistriesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostRegistries",
 		Method:             "POST",
 		PathPattern:        "/registries",
@@ -1035,7 +1133,12 @@ func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1055,13 +1158,12 @@ func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.C
   This endpoint is for user to start one execution of the replication.
 
 */
-func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationExecutionsCreated, error) {
+func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationExecutionsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostReplicationExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostReplicationExecutions",
 		Method:             "POST",
 		PathPattern:        "/replication/executions",
@@ -1073,7 +1175,12 @@ func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1093,13 +1200,12 @@ func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsPara
   This endpoint let user create a replication policy
 
 */
-func (a *Client) PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationPoliciesCreated, error) {
+func (a *Client) PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationPoliciesCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostReplicationPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostReplicationPolicies",
 		Method:             "POST",
 		PathPattern:        "/replication/policies",
@@ -1111,7 +1217,12 @@ func (a *Client) PostReplicationPolicies(params *PostReplicationPoliciesParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1133,13 +1244,12 @@ You can check project metadatas to find whether a retention policy is already bi
 This method should only be called when no retention policy binded to project yet.
 
 */
-func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostRetentionsCreated, error) {
+func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRetentionsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostRetentionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostRetentions",
 		Method:             "POST",
 		PathPattern:        "/retentions",
@@ -1151,7 +1261,12 @@ func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1171,13 +1286,12 @@ func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.C
   This endpoint is for update gc schedule.
 
 */
-func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemGcScheduleOK, error) {
+func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemGcScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostSystemGcScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostSystemGcSchedule",
 		Method:             "POST",
 		PathPattern:        "/system/gc/schedule",
@@ -1189,7 +1303,12 @@ func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1209,13 +1328,12 @@ func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authIn
   This endpoint is to create a user if the user does not already exist.
 
 */
-func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter) (*PostUsersCreated, error) {
+func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostUsersCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostUsersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostUsers",
 		Method:             "POST",
 		PathPattern:        "/users",
@@ -1227,7 +1345,12 @@ func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1247,13 +1370,12 @@ func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthI
   This endpoint is aimed to update the properties of a project.
 
 */
-func (a *Client) PutProjectsProjectID(params *PutProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDOK, error) {
+func (a *Client) PutProjectsProjectID(params *PutProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectID",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}",
@@ -1265,7 +1387,12 @@ func (a *Client) PutProjectsProjectID(params *PutProjectsProjectIDParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1284,13 +1411,12 @@ func (a *Client) PutProjectsProjectID(params *PutProjectsProjectIDParams, authIn
 
   Update project member relationship
 */
-func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMembersMidOK, error) {
+func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMembersMidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDMembersMidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDMembersMid",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/members/{mid}",
@@ -1302,7 +1428,12 @@ func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMemb
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1322,13 +1453,12 @@ func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMemb
   This endpoint is aimed to update the metadata of a project.
 
 */
-func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMetadatasMetaNameOK, error) {
+func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMetadatasMetaNameOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDMetadatasMetaNameParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDMetadatasMetaName",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/metadatas/{meta_name}",
@@ -1340,7 +1470,12 @@ func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1360,13 +1495,12 @@ func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjec
   This endpoint is for update a given registry.
 
 */
-func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutRegistriesIDOK, error) {
+func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutRegistriesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutRegistriesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutRegistriesID",
 		Method:             "PUT",
 		PathPattern:        "/registries/{id}",
@@ -1378,7 +1512,12 @@ func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1398,13 +1537,12 @@ func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime
   This endpoint let user update policy.
 
 */
-func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutReplicationPoliciesIDOK, error) {
+func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutReplicationPoliciesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutReplicationPoliciesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutReplicationPoliciesID",
 		Method:             "PUT",
 		PathPattern:        "/replication/policies/{id}",
@@ -1416,7 +1554,12 @@ func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1436,13 +1579,12 @@ func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams
   This endpoint is for update gc schedule.
 
 */
-func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemGcScheduleOK, error) {
+func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemGcScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutSystemGcScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutSystemGcSchedule",
 		Method:             "PUT",
 		PathPattern:        "/system/gc/schedule",
@@ -1454,7 +1596,12 @@ func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1474,13 +1621,12 @@ func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo
   This endpoint let a registered user change his profile.
 
 */
-func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDOK, error) {
+func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsersUserIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsersUserID",
 		Method:             "PUT",
 		PathPattern:        "/users/{user_id}",
@@ -1492,7 +1638,12 @@ func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1512,13 +1663,12 @@ func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.C
   This endpoint is for user to update password. Users with the admin role can change any user's password. Guest users can change only their own password.
 
 */
-func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDPasswordOK, error) {
+func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDPasswordOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsersUserIDPasswordParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsersUserIDPassword",
 		Method:             "PUT",
 		PathPattern:        "/users/{user_id}/password",
@@ -1530,7 +1680,12 @@ func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv1/mocks/client_service.go
+++ b/apiv1/mocks/client_service.go
@@ -13,13 +13,20 @@ type MockClientService struct {
 	mock.Mock
 }
 
-// DeleteProjectsProjectID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) DeleteProjectsProjectID(params *products.DeleteProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeleteProjectsProjectID(params *products.DeleteProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDOK)
@@ -27,8 +34,8 @@ func (_m *MockClientService) DeleteProjectsProjectID(params *products.DeleteProj
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -36,13 +43,20 @@ func (_m *MockClientService) DeleteProjectsProjectID(params *products.DeleteProj
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) DeleteProjectsProjectIDMembersMid(params *products.DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDMembersMidOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeleteProjectsProjectIDMembersMid(params *products.DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDMembersMidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDMembersMidOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDMembersMidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDMembersMidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDMembersMidOK)
@@ -50,8 +64,8 @@ func (_m *MockClientService) DeleteProjectsProjectIDMembersMid(params *products.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +73,20 @@ func (_m *MockClientService) DeleteProjectsProjectIDMembersMid(params *products.
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) DeleteProjectsProjectIDMetadatasMetaName(params *products.DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeleteProjectsProjectIDMetadatasMetaName(params *products.DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDMetadatasMetaNameOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDMetadatasMetaNameOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDMetadatasMetaNameOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDMetadatasMetaNameOK)
@@ -73,8 +94,8 @@ func (_m *MockClientService) DeleteProjectsProjectIDMetadatasMetaName(params *pr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -82,13 +103,20 @@ func (_m *MockClientService) DeleteProjectsProjectIDMetadatasMetaName(params *pr
 	return r0, r1
 }
 
-// DeleteRegistriesID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) DeleteRegistriesID(params *products.DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteRegistriesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteRegistriesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeleteRegistriesID(params *products.DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteRegistriesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteRegistriesIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter) *products.DeleteRegistriesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteRegistriesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteRegistriesIDOK)
@@ -96,8 +124,8 @@ func (_m *MockClientService) DeleteRegistriesID(params *products.DeleteRegistrie
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -105,13 +133,20 @@ func (_m *MockClientService) DeleteRegistriesID(params *products.DeleteRegistrie
 	return r0, r1
 }
 
-// DeleteReplicationPoliciesID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) DeleteReplicationPoliciesID(params *products.DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteReplicationPoliciesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteReplicationPoliciesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeleteReplicationPoliciesID(params *products.DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteReplicationPoliciesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteReplicationPoliciesIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) *products.DeleteReplicationPoliciesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteReplicationPoliciesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteReplicationPoliciesIDOK)
@@ -119,8 +154,8 @@ func (_m *MockClientService) DeleteReplicationPoliciesID(params *products.Delete
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -128,13 +163,20 @@ func (_m *MockClientService) DeleteReplicationPoliciesID(params *products.Delete
 	return r0, r1
 }
 
-// DeleteUsersUserID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) DeleteUsersUserID(params *products.DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteUsersUserIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteUsersUserID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeleteUsersUserID(params *products.DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteUsersUserIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteUsersUserIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter) *products.DeleteUsersUserIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteUsersUserIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteUsersUserIDOK)
@@ -142,8 +184,8 @@ func (_m *MockClientService) DeleteUsersUserID(params *products.DeleteUsersUserI
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -151,13 +193,20 @@ func (_m *MockClientService) DeleteUsersUserID(params *products.DeleteUsersUserI
 	return r0, r1
 }
 
-// GetHealth provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetHealth(params *products.GetHealthParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetHealthOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetHealth provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetHealth(params *products.GetHealthParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetHealthOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetHealthOK
-	if rf, ok := ret.Get(0).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter) *products.GetHealthOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetHealthOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetHealthOK)
@@ -165,8 +214,8 @@ func (_m *MockClientService) GetHealth(params *products.GetHealthParams, authInf
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -174,13 +223,20 @@ func (_m *MockClientService) GetHealth(params *products.GetHealthParams, authInf
 	return r0, r1
 }
 
-// GetProjects provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetProjects(params *products.GetProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjects provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetProjects(params *products.GetProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsParams, runtime.ClientAuthInfoWriter) *products.GetProjectsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsOK)
@@ -188,8 +244,8 @@ func (_m *MockClientService) GetProjects(params *products.GetProjectsParams, aut
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -197,13 +253,20 @@ func (_m *MockClientService) GetProjects(params *products.GetProjectsParams, aut
 	return r0, r1
 }
 
-// GetProjectsProjectID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetProjectsProjectID(params *products.GetProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetProjectsProjectID(params *products.GetProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDOK)
@@ -211,8 +274,8 @@ func (_m *MockClientService) GetProjectsProjectID(params *products.GetProjectsPr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -220,13 +283,20 @@ func (_m *MockClientService) GetProjectsProjectID(params *products.GetProjectsPr
 	return r0, r1
 }
 
-// GetProjectsProjectIDMembers provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetProjectsProjectIDMembers(params *products.GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMembersOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMembers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetProjectsProjectIDMembers(params *products.GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMembersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMembersOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMembersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMembersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMembersOK)
@@ -234,8 +304,8 @@ func (_m *MockClientService) GetProjectsProjectIDMembers(params *products.GetPro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -243,13 +313,20 @@ func (_m *MockClientService) GetProjectsProjectIDMembers(params *products.GetPro
 	return r0, r1
 }
 
-// GetProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetProjectsProjectIDMetadatas(params *products.GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMetadatasOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetProjectsProjectIDMetadatas(params *products.GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMetadatasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMetadatasOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMetadatasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMetadatasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMetadatasOK)
@@ -257,8 +334,8 @@ func (_m *MockClientService) GetProjectsProjectIDMetadatas(params *products.GetP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -266,13 +343,20 @@ func (_m *MockClientService) GetProjectsProjectIDMetadatas(params *products.GetP
 	return r0, r1
 }
 
-// GetProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetProjectsProjectIDMetadatasMetaName(params *products.GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMetadatasMetaNameOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetProjectsProjectIDMetadatasMetaName(params *products.GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMetadatasMetaNameOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMetadatasMetaNameOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMetadatasMetaNameOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMetadatasMetaNameOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMetadatasMetaNameOK)
@@ -280,8 +364,8 @@ func (_m *MockClientService) GetProjectsProjectIDMetadatasMetaName(params *produ
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -289,13 +373,20 @@ func (_m *MockClientService) GetProjectsProjectIDMetadatasMetaName(params *produ
 	return r0, r1
 }
 
-// GetRegistries provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetRegistries(params *products.GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRegistriesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRegistries provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetRegistries(params *products.GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRegistriesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRegistriesOK
-	if rf, ok := ret.Get(0).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter) *products.GetRegistriesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRegistriesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRegistriesOK)
@@ -303,8 +394,8 @@ func (_m *MockClientService) GetRegistries(params *products.GetRegistriesParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -312,13 +403,20 @@ func (_m *MockClientService) GetRegistries(params *products.GetRegistriesParams,
 	return r0, r1
 }
 
-// GetReplicationExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetReplicationExecutions(params *products.GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationExecutionsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetReplicationExecutions(params *products.GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationExecutionsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationExecutionsOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter) *products.GetReplicationExecutionsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationExecutionsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationExecutionsOK)
@@ -326,8 +424,8 @@ func (_m *MockClientService) GetReplicationExecutions(params *products.GetReplic
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -335,13 +433,20 @@ func (_m *MockClientService) GetReplicationExecutions(params *products.GetReplic
 	return r0, r1
 }
 
-// GetReplicationExecutionsID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetReplicationExecutionsID(params *products.GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationExecutionsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationExecutionsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetReplicationExecutionsID(params *products.GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationExecutionsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationExecutionsIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter) *products.GetReplicationExecutionsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationExecutionsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationExecutionsIDOK)
@@ -349,8 +454,8 @@ func (_m *MockClientService) GetReplicationExecutionsID(params *products.GetRepl
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -358,13 +463,20 @@ func (_m *MockClientService) GetReplicationExecutionsID(params *products.GetRepl
 	return r0, r1
 }
 
-// GetReplicationPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetReplicationPolicies(params *products.GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationPoliciesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetReplicationPolicies(params *products.GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationPoliciesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationPoliciesOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter) *products.GetReplicationPoliciesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationPoliciesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationPoliciesOK)
@@ -372,8 +484,8 @@ func (_m *MockClientService) GetReplicationPolicies(params *products.GetReplicat
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -381,13 +493,20 @@ func (_m *MockClientService) GetReplicationPolicies(params *products.GetReplicat
 	return r0, r1
 }
 
-// GetReplicationPoliciesID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetReplicationPoliciesID(params *products.GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationPoliciesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationPoliciesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetReplicationPoliciesID(params *products.GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationPoliciesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationPoliciesIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) *products.GetReplicationPoliciesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationPoliciesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationPoliciesIDOK)
@@ -395,8 +514,8 @@ func (_m *MockClientService) GetReplicationPoliciesID(params *products.GetReplic
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -404,13 +523,20 @@ func (_m *MockClientService) GetReplicationPoliciesID(params *products.GetReplic
 	return r0, r1
 }
 
-// GetRetentionsID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetRetentionsID(params *products.GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetRetentionsID(params *products.GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsIDOK)
@@ -418,8 +544,8 @@ func (_m *MockClientService) GetRetentionsID(params *products.GetRetentionsIDPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -427,13 +553,20 @@ func (_m *MockClientService) GetRetentionsID(params *products.GetRetentionsIDPar
 	return r0, r1
 }
 
-// GetRetentionsMetadatas provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetRetentionsMetadatas(params *products.GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsMetadatasOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsMetadatas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetRetentionsMetadatas(params *products.GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsMetadatasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsMetadatasOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsMetadatasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsMetadatasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsMetadatasOK)
@@ -441,8 +574,8 @@ func (_m *MockClientService) GetRetentionsMetadatas(params *products.GetRetentio
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -450,13 +583,20 @@ func (_m *MockClientService) GetRetentionsMetadatas(params *products.GetRetentio
 	return r0, r1
 }
 
-// GetSystemGcSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetSystemGcSchedule(params *products.GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemGcScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemGcSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetSystemGcSchedule(params *products.GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemGcScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemGcScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter) *products.GetSystemGcScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemGcScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemGcScheduleOK)
@@ -464,8 +604,8 @@ func (_m *MockClientService) GetSystemGcSchedule(params *products.GetSystemGcSch
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -473,13 +613,20 @@ func (_m *MockClientService) GetSystemGcSchedule(params *products.GetSystemGcSch
 	return r0, r1
 }
 
-// GetUsers provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) GetUsers(params *products.GetUsersParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsersOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetUsers(params *products.GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsersOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter) *products.GetUsersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsersOK)
@@ -487,8 +634,8 @@ func (_m *MockClientService) GetUsers(params *products.GetUsersParams, authInfo 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -496,13 +643,20 @@ func (_m *MockClientService) GetUsers(params *products.GetUsersParams, authInfo 
 	return r0, r1
 }
 
-// PostProjects provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostProjects(params *products.PostProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjects provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostProjects(params *products.PostProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsParams, runtime.ClientAuthInfoWriter) *products.PostProjectsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsCreated)
@@ -510,8 +664,8 @@ func (_m *MockClientService) PostProjects(params *products.PostProjectsParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -519,13 +673,20 @@ func (_m *MockClientService) PostProjects(params *products.PostProjectsParams, a
 	return r0, r1
 }
 
-// PostProjectsProjectIDMembers provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostProjectsProjectIDMembers(params *products.PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDMembersCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDMembers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostProjectsProjectIDMembers(params *products.PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDMembersCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDMembersCreated
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDMembersCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDMembersCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDMembersCreated)
@@ -533,8 +694,8 @@ func (_m *MockClientService) PostProjectsProjectIDMembers(params *products.PostP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -542,13 +703,20 @@ func (_m *MockClientService) PostProjectsProjectIDMembers(params *products.PostP
 	return r0, r1
 }
 
-// PostProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostProjectsProjectIDMetadatas(params *products.PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDMetadatasOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostProjectsProjectIDMetadatas(params *products.PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDMetadatasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDMetadatasOK
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDMetadatasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDMetadatasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDMetadatasOK)
@@ -556,8 +724,8 @@ func (_m *MockClientService) PostProjectsProjectIDMetadatas(params *products.Pos
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -565,13 +733,20 @@ func (_m *MockClientService) PostProjectsProjectIDMetadatas(params *products.Pos
 	return r0, r1
 }
 
-// PostRegistries provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostRegistries(params *products.PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostRegistriesCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostRegistries provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostRegistries(params *products.PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostRegistriesCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostRegistriesCreated
-	if rf, ok := ret.Get(0).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter) *products.PostRegistriesCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostRegistriesCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostRegistriesCreated)
@@ -579,8 +754,8 @@ func (_m *MockClientService) PostRegistries(params *products.PostRegistriesParam
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -588,13 +763,20 @@ func (_m *MockClientService) PostRegistries(params *products.PostRegistriesParam
 	return r0, r1
 }
 
-// PostReplicationExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostReplicationExecutions(params *products.PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostReplicationExecutionsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostReplicationExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostReplicationExecutions(params *products.PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostReplicationExecutionsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostReplicationExecutionsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter) *products.PostReplicationExecutionsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostReplicationExecutionsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostReplicationExecutionsCreated)
@@ -602,8 +784,8 @@ func (_m *MockClientService) PostReplicationExecutions(params *products.PostRepl
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -611,13 +793,20 @@ func (_m *MockClientService) PostReplicationExecutions(params *products.PostRepl
 	return r0, r1
 }
 
-// PostReplicationPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostReplicationPolicies(params *products.PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostReplicationPoliciesCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostReplicationPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostReplicationPolicies(params *products.PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostReplicationPoliciesCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostReplicationPoliciesCreated
-	if rf, ok := ret.Get(0).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter) *products.PostReplicationPoliciesCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostReplicationPoliciesCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostReplicationPoliciesCreated)
@@ -625,8 +814,8 @@ func (_m *MockClientService) PostReplicationPolicies(params *products.PostReplic
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -634,13 +823,20 @@ func (_m *MockClientService) PostReplicationPolicies(params *products.PostReplic
 	return r0, r1
 }
 
-// PostRetentions provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostRetentions(params *products.PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostRetentionsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostRetentions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostRetentions(params *products.PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostRetentionsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostRetentionsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter) *products.PostRetentionsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostRetentionsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostRetentionsCreated)
@@ -648,8 +844,8 @@ func (_m *MockClientService) PostRetentions(params *products.PostRetentionsParam
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -657,13 +853,20 @@ func (_m *MockClientService) PostRetentions(params *products.PostRetentionsParam
 	return r0, r1
 }
 
-// PostSystemGcSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostSystemGcSchedule(params *products.PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostSystemGcScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostSystemGcSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostSystemGcSchedule(params *products.PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostSystemGcScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostSystemGcScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter) *products.PostSystemGcScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostSystemGcScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostSystemGcScheduleOK)
@@ -671,8 +874,8 @@ func (_m *MockClientService) PostSystemGcSchedule(params *products.PostSystemGcS
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -680,13 +883,20 @@ func (_m *MockClientService) PostSystemGcSchedule(params *products.PostSystemGcS
 	return r0, r1
 }
 
-// PostUsers provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PostUsers(params *products.PostUsersParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostUsersCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostUsers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PostUsers(params *products.PostUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostUsersCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostUsersCreated
-	if rf, ok := ret.Get(0).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter) *products.PostUsersCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostUsersCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostUsersCreated)
@@ -694,8 +904,8 @@ func (_m *MockClientService) PostUsers(params *products.PostUsersParams, authInf
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -703,13 +913,20 @@ func (_m *MockClientService) PostUsers(params *products.PostUsersParams, authInf
 	return r0, r1
 }
 
-// PutProjectsProjectID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutProjectsProjectID(params *products.PutProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutProjectsProjectID(params *products.PutProjectsProjectIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDOK)
@@ -717,8 +934,8 @@ func (_m *MockClientService) PutProjectsProjectID(params *products.PutProjectsPr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -726,13 +943,20 @@ func (_m *MockClientService) PutProjectsProjectID(params *products.PutProjectsPr
 	return r0, r1
 }
 
-// PutProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutProjectsProjectIDMembersMid(params *products.PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDMembersMidOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutProjectsProjectIDMembersMid(params *products.PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDMembersMidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDMembersMidOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDMembersMidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDMembersMidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDMembersMidOK)
@@ -740,8 +964,8 @@ func (_m *MockClientService) PutProjectsProjectIDMembersMid(params *products.Put
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -749,13 +973,20 @@ func (_m *MockClientService) PutProjectsProjectIDMembersMid(params *products.Put
 	return r0, r1
 }
 
-// PutProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutProjectsProjectIDMetadatasMetaName(params *products.PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDMetadatasMetaNameOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutProjectsProjectIDMetadatasMetaName(params *products.PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDMetadatasMetaNameOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDMetadatasMetaNameOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDMetadatasMetaNameOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDMetadatasMetaNameOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDMetadatasMetaNameOK)
@@ -763,8 +994,8 @@ func (_m *MockClientService) PutProjectsProjectIDMetadatasMetaName(params *produ
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -772,13 +1003,20 @@ func (_m *MockClientService) PutProjectsProjectIDMetadatasMetaName(params *produ
 	return r0, r1
 }
 
-// PutRegistriesID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutRegistriesID(params *products.PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutRegistriesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutRegistriesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutRegistriesID(params *products.PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutRegistriesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutRegistriesIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter) *products.PutRegistriesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutRegistriesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutRegistriesIDOK)
@@ -786,8 +1024,8 @@ func (_m *MockClientService) PutRegistriesID(params *products.PutRegistriesIDPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -795,13 +1033,20 @@ func (_m *MockClientService) PutRegistriesID(params *products.PutRegistriesIDPar
 	return r0, r1
 }
 
-// PutReplicationPoliciesID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutReplicationPoliciesID(params *products.PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutReplicationPoliciesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutReplicationPoliciesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutReplicationPoliciesID(params *products.PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutReplicationPoliciesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutReplicationPoliciesIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) *products.PutReplicationPoliciesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutReplicationPoliciesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutReplicationPoliciesIDOK)
@@ -809,8 +1054,8 @@ func (_m *MockClientService) PutReplicationPoliciesID(params *products.PutReplic
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -818,13 +1063,20 @@ func (_m *MockClientService) PutReplicationPoliciesID(params *products.PutReplic
 	return r0, r1
 }
 
-// PutSystemGcSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutSystemGcSchedule(params *products.PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutSystemGcScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutSystemGcSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutSystemGcSchedule(params *products.PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutSystemGcScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutSystemGcScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter) *products.PutSystemGcScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutSystemGcScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutSystemGcScheduleOK)
@@ -832,8 +1084,8 @@ func (_m *MockClientService) PutSystemGcSchedule(params *products.PutSystemGcSch
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -841,13 +1093,20 @@ func (_m *MockClientService) PutSystemGcSchedule(params *products.PutSystemGcSch
 	return r0, r1
 }
 
-// PutUsersUserID provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutUsersUserID(params *products.PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsersUserIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsersUserID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutUsersUserID(params *products.PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsersUserIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsersUserIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter) *products.PutUsersUserIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsersUserIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsersUserIDOK)
@@ -855,8 +1114,8 @@ func (_m *MockClientService) PutUsersUserID(params *products.PutUsersUserIDParam
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -864,13 +1123,20 @@ func (_m *MockClientService) PutUsersUserID(params *products.PutUsersUserIDParam
 	return r0, r1
 }
 
-// PutUsersUserIDPassword provides a mock function with given fields: params, authInfo
-func (_m *MockClientService) PutUsersUserIDPassword(params *products.PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsersUserIDPasswordOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsersUserIDPassword provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) PutUsersUserIDPassword(params *products.PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsersUserIDPasswordOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsersUserIDPasswordOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter) *products.PutUsersUserIDPasswordOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsersUserIDPasswordOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsersUserIDPasswordOK)
@@ -878,8 +1144,8 @@ func (_m *MockClientService) PutUsersUserIDPassword(params *products.PutUsersUse
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/internal/api/client/artifact/artifact_client.go
+++ b/apiv2/internal/api/client/artifact/artifact_client.go
@@ -25,27 +25,30 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CopyArtifact(params *CopyArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*CopyArtifactCreated, error)
+	CopyArtifact(params *CopyArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CopyArtifactCreated, error)
 
-	AddLabel(params *AddLabelParams, authInfo runtime.ClientAuthInfoWriter) (*AddLabelOK, error)
+	AddLabel(params *AddLabelParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AddLabelOK, error)
 
-	CreateTag(params *CreateTagParams, authInfo runtime.ClientAuthInfoWriter) (*CreateTagCreated, error)
+	CreateTag(params *CreateTagParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateTagCreated, error)
 
-	DeleteArtifact(params *DeleteArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteArtifactOK, error)
+	DeleteArtifact(params *DeleteArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteArtifactOK, error)
 
-	DeleteTag(params *DeleteTagParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteTagOK, error)
+	DeleteTag(params *DeleteTagParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteTagOK, error)
 
-	GetAddition(params *GetAdditionParams, authInfo runtime.ClientAuthInfoWriter) (*GetAdditionOK, error)
+	GetAddition(params *GetAdditionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetAdditionOK, error)
 
-	GetArtifact(params *GetArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*GetArtifactOK, error)
+	GetArtifact(params *GetArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetArtifactOK, error)
 
-	ListArtifacts(params *ListArtifactsParams, authInfo runtime.ClientAuthInfoWriter) (*ListArtifactsOK, error)
+	ListArtifacts(params *ListArtifactsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListArtifactsOK, error)
 
-	ListTags(params *ListTagsParams, authInfo runtime.ClientAuthInfoWriter) (*ListTagsOK, error)
+	ListTags(params *ListTagsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListTagsOK, error)
 
-	RemoveLabel(params *RemoveLabelParams, authInfo runtime.ClientAuthInfoWriter) (*RemoveLabelOK, error)
+	RemoveLabel(params *RemoveLabelParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RemoveLabelOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -55,13 +58,12 @@ type ClientService interface {
 
   Copy the artifact specified in the "from" parameter to the repository.
 */
-func (a *Client) CopyArtifact(params *CopyArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*CopyArtifactCreated, error) {
+func (a *Client) CopyArtifact(params *CopyArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CopyArtifactCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCopyArtifactParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "CopyArtifact",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts",
@@ -73,7 +75,12 @@ func (a *Client) CopyArtifact(params *CopyArtifactParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -92,13 +99,12 @@ func (a *Client) CopyArtifact(params *CopyArtifactParams, authInfo runtime.Clien
 
   Add label to the specified artiact.
 */
-func (a *Client) AddLabel(params *AddLabelParams, authInfo runtime.ClientAuthInfoWriter) (*AddLabelOK, error) {
+func (a *Client) AddLabel(params *AddLabelParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AddLabelOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAddLabelParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "addLabel",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/labels",
@@ -110,7 +116,12 @@ func (a *Client) AddLabel(params *AddLabelParams, authInfo runtime.ClientAuthInf
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -129,13 +140,12 @@ func (a *Client) AddLabel(params *AddLabelParams, authInfo runtime.ClientAuthInf
 
   Create a tag for the specified artifact
 */
-func (a *Client) CreateTag(params *CreateTagParams, authInfo runtime.ClientAuthInfoWriter) (*CreateTagCreated, error) {
+func (a *Client) CreateTag(params *CreateTagParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateTagCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateTagParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createTag",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/tags",
@@ -147,7 +157,12 @@ func (a *Client) CreateTag(params *CreateTagParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -166,13 +181,12 @@ func (a *Client) CreateTag(params *CreateTagParams, authInfo runtime.ClientAuthI
 
   Delete the artifact specified by the reference under the project and repository. The reference can be digest or tag
 */
-func (a *Client) DeleteArtifact(params *DeleteArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteArtifactOK, error) {
+func (a *Client) DeleteArtifact(params *DeleteArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteArtifactOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteArtifactParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteArtifact",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}",
@@ -184,7 +198,12 @@ func (a *Client) DeleteArtifact(params *DeleteArtifactParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -203,13 +222,12 @@ func (a *Client) DeleteArtifact(params *DeleteArtifactParams, authInfo runtime.C
 
   Delete the tag of the specified artifact
 */
-func (a *Client) DeleteTag(params *DeleteTagParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteTagOK, error) {
+func (a *Client) DeleteTag(params *DeleteTagParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteTagOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteTagParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteTag",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/tags/{tag_name}",
@@ -221,7 +239,12 @@ func (a *Client) DeleteTag(params *DeleteTagParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -240,13 +263,12 @@ func (a *Client) DeleteTag(params *DeleteTagParams, authInfo runtime.ClientAuthI
 
   Get the addition of the artifact specified by the reference under the project and repository.
 */
-func (a *Client) GetAddition(params *GetAdditionParams, authInfo runtime.ClientAuthInfoWriter) (*GetAdditionOK, error) {
+func (a *Client) GetAddition(params *GetAdditionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetAdditionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetAdditionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getAddition",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/additions/{addition}",
@@ -258,7 +280,12 @@ func (a *Client) GetAddition(params *GetAdditionParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -277,13 +304,12 @@ func (a *Client) GetAddition(params *GetAdditionParams, authInfo runtime.ClientA
 
   Get the artifact specified by the reference under the project and repository. The reference can be digest or tag.
 */
-func (a *Client) GetArtifact(params *GetArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*GetArtifactOK, error) {
+func (a *Client) GetArtifact(params *GetArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetArtifactOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetArtifactParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getArtifact",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}",
@@ -295,7 +321,12 @@ func (a *Client) GetArtifact(params *GetArtifactParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -314,13 +345,12 @@ func (a *Client) GetArtifact(params *GetArtifactParams, authInfo runtime.ClientA
 
   List artifacts under the specific project and repository. Except the basic properties, the other supported queries in "q" includes "tags=*" to list only tagged artifacts, "tags=nil" to list only untagged artifacts, "tags=~v" to list artifacts whose tag fuzzy matches "v", "tags=v" to list artifact whose tag exactly matches "v", "labels=(id1, id2)" to list artifacts that both labels with id1 and id2 are added to
 */
-func (a *Client) ListArtifacts(params *ListArtifactsParams, authInfo runtime.ClientAuthInfoWriter) (*ListArtifactsOK, error) {
+func (a *Client) ListArtifacts(params *ListArtifactsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListArtifactsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListArtifactsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listArtifacts",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts",
@@ -332,7 +362,12 @@ func (a *Client) ListArtifacts(params *ListArtifactsParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -351,13 +386,12 @@ func (a *Client) ListArtifacts(params *ListArtifactsParams, authInfo runtime.Cli
 
   List tags of the specific artifact
 */
-func (a *Client) ListTags(params *ListTagsParams, authInfo runtime.ClientAuthInfoWriter) (*ListTagsOK, error) {
+func (a *Client) ListTags(params *ListTagsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListTagsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListTagsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listTags",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/tags",
@@ -369,7 +403,12 @@ func (a *Client) ListTags(params *ListTagsParams, authInfo runtime.ClientAuthInf
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -388,13 +427,12 @@ func (a *Client) ListTags(params *ListTagsParams, authInfo runtime.ClientAuthInf
 
   Remove the label from the specified artiact.
 */
-func (a *Client) RemoveLabel(params *RemoveLabelParams, authInfo runtime.ClientAuthInfoWriter) (*RemoveLabelOK, error) {
+func (a *Client) RemoveLabel(params *RemoveLabelParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RemoveLabelOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRemoveLabelParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "removeLabel",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/labels/{label_id}",
@@ -406,7 +444,12 @@ func (a *Client) RemoveLabel(params *RemoveLabelParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/api/client/auditlog/auditlog_client.go
+++ b/apiv2/internal/api/client/auditlog/auditlog_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	ListAuditLogs(params *ListAuditLogsParams, authInfo runtime.ClientAuthInfoWriter) (*ListAuditLogsOK, error)
+	ListAuditLogs(params *ListAuditLogsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListAuditLogsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -38,13 +41,12 @@ type ClientService interface {
   This endpoint let user see the recent operation logs of the projects which he is member of
 
 */
-func (a *Client) ListAuditLogs(params *ListAuditLogsParams, authInfo runtime.ClientAuthInfoWriter) (*ListAuditLogsOK, error) {
+func (a *Client) ListAuditLogs(params *ListAuditLogsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListAuditLogsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListAuditLogsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listAuditLogs",
 		Method:             "GET",
 		PathPattern:        "/audit-logs",
@@ -56,7 +58,12 @@ func (a *Client) ListAuditLogs(params *ListAuditLogsParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/api/client/icon/icon_client.go
+++ b/apiv2/internal/api/client/icon/icon_client.go
@@ -25,9 +25,12 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetIcon(params *GetIconParams, authInfo runtime.ClientAuthInfoWriter) (*GetIconOK, error)
+	GetIcon(params *GetIconParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetIconOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -37,13 +40,12 @@ type ClientService interface {
 
   Get the artifact icon with the specified digest. As the original icon image is resized and encoded before returning, the parameter "digest" in the path doesn't match the hash of the returned content
 */
-func (a *Client) GetIcon(params *GetIconParams, authInfo runtime.ClientAuthInfoWriter) (*GetIconOK, error) {
+func (a *Client) GetIcon(params *GetIconParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetIconOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetIconParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getIcon",
 		Method:             "GET",
 		PathPattern:        "/icons/{digest}",
@@ -55,7 +57,12 @@ func (a *Client) GetIcon(params *GetIconParams, authInfo runtime.ClientAuthInfoW
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/api/client/preheat/preheat_client.go
+++ b/apiv2/internal/api/client/preheat/preheat_client.go
@@ -25,45 +25,48 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateInstance(params *CreateInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*CreateInstanceCreated, error)
+	CreateInstance(params *CreateInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateInstanceCreated, error)
 
-	CreatePolicy(params *CreatePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*CreatePolicyCreated, error)
+	CreatePolicy(params *CreatePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreatePolicyCreated, error)
 
-	DeleteInstance(params *DeleteInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteInstanceOK, error)
+	DeleteInstance(params *DeleteInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteInstanceOK, error)
 
-	DeletePolicy(params *DeletePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*DeletePolicyOK, error)
+	DeletePolicy(params *DeletePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeletePolicyOK, error)
 
-	GetExecution(params *GetExecutionParams, authInfo runtime.ClientAuthInfoWriter) (*GetExecutionOK, error)
+	GetExecution(params *GetExecutionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetExecutionOK, error)
 
-	GetInstance(params *GetInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*GetInstanceOK, error)
+	GetInstance(params *GetInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetInstanceOK, error)
 
-	GetPolicy(params *GetPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*GetPolicyOK, error)
+	GetPolicy(params *GetPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetPolicyOK, error)
 
-	GetPreheatLog(params *GetPreheatLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetPreheatLogOK, error)
+	GetPreheatLog(params *GetPreheatLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetPreheatLogOK, error)
 
-	ListExecutions(params *ListExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*ListExecutionsOK, error)
+	ListExecutions(params *ListExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListExecutionsOK, error)
 
-	ListInstances(params *ListInstancesParams, authInfo runtime.ClientAuthInfoWriter) (*ListInstancesOK, error)
+	ListInstances(params *ListInstancesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListInstancesOK, error)
 
-	ListPolicies(params *ListPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*ListPoliciesOK, error)
+	ListPolicies(params *ListPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListPoliciesOK, error)
 
-	ListProviders(params *ListProvidersParams, authInfo runtime.ClientAuthInfoWriter) (*ListProvidersOK, error)
+	ListProviders(params *ListProvidersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListProvidersOK, error)
 
-	ListProvidersUnderProject(params *ListProvidersUnderProjectParams, authInfo runtime.ClientAuthInfoWriter) (*ListProvidersUnderProjectOK, error)
+	ListProvidersUnderProject(params *ListProvidersUnderProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListProvidersUnderProjectOK, error)
 
-	ListTasks(params *ListTasksParams, authInfo runtime.ClientAuthInfoWriter) (*ListTasksOK, error)
+	ListTasks(params *ListTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListTasksOK, error)
 
-	ManualPreheat(params *ManualPreheatParams, authInfo runtime.ClientAuthInfoWriter) (*ManualPreheatCreated, error)
+	ManualPreheat(params *ManualPreheatParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ManualPreheatCreated, error)
 
-	PingInstances(params *PingInstancesParams, authInfo runtime.ClientAuthInfoWriter) (*PingInstancesOK, error)
+	PingInstances(params *PingInstancesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PingInstancesOK, error)
 
-	StopExecution(params *StopExecutionParams, authInfo runtime.ClientAuthInfoWriter) (*StopExecutionOK, error)
+	StopExecution(params *StopExecutionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*StopExecutionOK, error)
 
-	UpdateInstance(params *UpdateInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateInstanceOK, error)
+	UpdateInstance(params *UpdateInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateInstanceOK, error)
 
-	UpdatePolicy(params *UpdatePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*UpdatePolicyOK, error)
+	UpdatePolicy(params *UpdatePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdatePolicyOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -73,13 +76,12 @@ type ClientService interface {
 
   Create p2p provider instances
 */
-func (a *Client) CreateInstance(params *CreateInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*CreateInstanceCreated, error) {
+func (a *Client) CreateInstance(params *CreateInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateInstanceCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateInstanceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "CreateInstance",
 		Method:             "POST",
 		PathPattern:        "/p2p/preheat/instances",
@@ -91,7 +93,12 @@ func (a *Client) CreateInstance(params *CreateInstanceParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -110,13 +117,12 @@ func (a *Client) CreateInstance(params *CreateInstanceParams, authInfo runtime.C
 
   Create a preheat policy under a project
 */
-func (a *Client) CreatePolicy(params *CreatePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*CreatePolicyCreated, error) {
+func (a *Client) CreatePolicy(params *CreatePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreatePolicyCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreatePolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "CreatePolicy",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_name}/preheat/policies",
@@ -128,7 +134,12 @@ func (a *Client) CreatePolicy(params *CreatePolicyParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -147,13 +158,12 @@ func (a *Client) CreatePolicy(params *CreatePolicyParams, authInfo runtime.Clien
 
   Delete the specified P2P provider instance
 */
-func (a *Client) DeleteInstance(params *DeleteInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteInstanceOK, error) {
+func (a *Client) DeleteInstance(params *DeleteInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteInstanceOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteInstanceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteInstance",
 		Method:             "DELETE",
 		PathPattern:        "/p2p/preheat/instances/{preheat_instance_name}",
@@ -165,7 +175,12 @@ func (a *Client) DeleteInstance(params *DeleteInstanceParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -184,13 +199,12 @@ func (a *Client) DeleteInstance(params *DeleteInstanceParams, authInfo runtime.C
 
   Delete a preheat policy
 */
-func (a *Client) DeletePolicy(params *DeletePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*DeletePolicyOK, error) {
+func (a *Client) DeletePolicy(params *DeletePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeletePolicyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeletePolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeletePolicy",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}",
@@ -202,7 +216,12 @@ func (a *Client) DeletePolicy(params *DeletePolicyParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -221,13 +240,12 @@ func (a *Client) DeletePolicy(params *DeletePolicyParams, authInfo runtime.Clien
 
   Get a execution detail by id
 */
-func (a *Client) GetExecution(params *GetExecutionParams, authInfo runtime.ClientAuthInfoWriter) (*GetExecutionOK, error) {
+func (a *Client) GetExecution(params *GetExecutionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetExecutionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetExecutionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetExecution",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}/executions/{execution_id}",
@@ -239,7 +257,12 @@ func (a *Client) GetExecution(params *GetExecutionParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -258,13 +281,12 @@ func (a *Client) GetExecution(params *GetExecutionParams, authInfo runtime.Clien
 
   Get a P2P provider instance
 */
-func (a *Client) GetInstance(params *GetInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*GetInstanceOK, error) {
+func (a *Client) GetInstance(params *GetInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetInstanceOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetInstanceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetInstance",
 		Method:             "GET",
 		PathPattern:        "/p2p/preheat/instances/{preheat_instance_name}",
@@ -276,7 +298,12 @@ func (a *Client) GetInstance(params *GetInstanceParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -295,13 +322,12 @@ func (a *Client) GetInstance(params *GetInstanceParams, authInfo runtime.ClientA
 
   Get a preheat policy
 */
-func (a *Client) GetPolicy(params *GetPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*GetPolicyOK, error) {
+func (a *Client) GetPolicy(params *GetPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetPolicyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetPolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetPolicy",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}",
@@ -313,7 +339,12 @@ func (a *Client) GetPolicy(params *GetPolicyParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -332,13 +363,12 @@ func (a *Client) GetPolicy(params *GetPolicyParams, authInfo runtime.ClientAuthI
 
   Get the log text stream of the specified task for the given execution
 */
-func (a *Client) GetPreheatLog(params *GetPreheatLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetPreheatLogOK, error) {
+func (a *Client) GetPreheatLog(params *GetPreheatLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetPreheatLogOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetPreheatLogParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetPreheatLog",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}/executions/{execution_id}/tasks/{task_id}/logs",
@@ -350,7 +380,12 @@ func (a *Client) GetPreheatLog(params *GetPreheatLogParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -369,13 +404,12 @@ func (a *Client) GetPreheatLog(params *GetPreheatLogParams, authInfo runtime.Cli
 
   List executions for the given policy
 */
-func (a *Client) ListExecutions(params *ListExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*ListExecutionsOK, error) {
+func (a *Client) ListExecutions(params *ListExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListExecutionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ListExecutions",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}/executions",
@@ -387,7 +421,12 @@ func (a *Client) ListExecutions(params *ListExecutionsParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -406,13 +445,12 @@ func (a *Client) ListExecutions(params *ListExecutionsParams, authInfo runtime.C
 
   List P2P provider instances
 */
-func (a *Client) ListInstances(params *ListInstancesParams, authInfo runtime.ClientAuthInfoWriter) (*ListInstancesOK, error) {
+func (a *Client) ListInstances(params *ListInstancesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListInstancesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListInstancesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ListInstances",
 		Method:             "GET",
 		PathPattern:        "/p2p/preheat/instances",
@@ -424,7 +462,12 @@ func (a *Client) ListInstances(params *ListInstancesParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -443,13 +486,12 @@ func (a *Client) ListInstances(params *ListInstancesParams, authInfo runtime.Cli
 
   List preheat policies
 */
-func (a *Client) ListPolicies(params *ListPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*ListPoliciesOK, error) {
+func (a *Client) ListPolicies(params *ListPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListPoliciesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ListPolicies",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/policies",
@@ -461,7 +503,12 @@ func (a *Client) ListPolicies(params *ListPoliciesParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -480,13 +527,12 @@ func (a *Client) ListPolicies(params *ListPoliciesParams, authInfo runtime.Clien
 
   List P2P providers
 */
-func (a *Client) ListProviders(params *ListProvidersParams, authInfo runtime.ClientAuthInfoWriter) (*ListProvidersOK, error) {
+func (a *Client) ListProviders(params *ListProvidersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListProvidersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListProvidersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ListProviders",
 		Method:             "GET",
 		PathPattern:        "/p2p/preheat/providers",
@@ -498,7 +544,12 @@ func (a *Client) ListProviders(params *ListProvidersParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -517,13 +568,12 @@ func (a *Client) ListProviders(params *ListProvidersParams, authInfo runtime.Cli
 
   Get all providers at project level
 */
-func (a *Client) ListProvidersUnderProject(params *ListProvidersUnderProjectParams, authInfo runtime.ClientAuthInfoWriter) (*ListProvidersUnderProjectOK, error) {
+func (a *Client) ListProvidersUnderProject(params *ListProvidersUnderProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListProvidersUnderProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListProvidersUnderProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ListProvidersUnderProject",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/providers",
@@ -535,7 +585,12 @@ func (a *Client) ListProvidersUnderProject(params *ListProvidersUnderProjectPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -554,13 +609,12 @@ func (a *Client) ListProvidersUnderProject(params *ListProvidersUnderProjectPara
 
   List all the related tasks for the given execution
 */
-func (a *Client) ListTasks(params *ListTasksParams, authInfo runtime.ClientAuthInfoWriter) (*ListTasksOK, error) {
+func (a *Client) ListTasks(params *ListTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListTasksOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListTasksParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ListTasks",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}/executions/{execution_id}/tasks",
@@ -572,7 +626,12 @@ func (a *Client) ListTasks(params *ListTasksParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -591,13 +650,12 @@ func (a *Client) ListTasks(params *ListTasksParams, authInfo runtime.ClientAuthI
 
   Manual preheat
 */
-func (a *Client) ManualPreheat(params *ManualPreheatParams, authInfo runtime.ClientAuthInfoWriter) (*ManualPreheatCreated, error) {
+func (a *Client) ManualPreheat(params *ManualPreheatParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ManualPreheatCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewManualPreheatParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "ManualPreheat",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}",
@@ -609,7 +667,12 @@ func (a *Client) ManualPreheat(params *ManualPreheatParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -629,13 +692,12 @@ func (a *Client) ManualPreheat(params *ManualPreheatParams, authInfo runtime.Cli
   This endpoint checks status of a instance, the instance can be given by ID or Endpoint URL (together with credential)
 
 */
-func (a *Client) PingInstances(params *PingInstancesParams, authInfo runtime.ClientAuthInfoWriter) (*PingInstancesOK, error) {
+func (a *Client) PingInstances(params *PingInstancesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PingInstancesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPingInstancesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PingInstances",
 		Method:             "POST",
 		PathPattern:        "/p2p/preheat/instances/ping",
@@ -647,7 +709,12 @@ func (a *Client) PingInstances(params *PingInstancesParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -666,13 +733,12 @@ func (a *Client) PingInstances(params *PingInstancesParams, authInfo runtime.Cli
 
   Stop a execution
 */
-func (a *Client) StopExecution(params *StopExecutionParams, authInfo runtime.ClientAuthInfoWriter) (*StopExecutionOK, error) {
+func (a *Client) StopExecution(params *StopExecutionParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*StopExecutionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewStopExecutionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "StopExecution",
 		Method:             "PATCH",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}/executions/{execution_id}",
@@ -684,7 +750,12 @@ func (a *Client) StopExecution(params *StopExecutionParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -703,13 +774,12 @@ func (a *Client) StopExecution(params *StopExecutionParams, authInfo runtime.Cli
 
   Update the specified P2P provider instance
 */
-func (a *Client) UpdateInstance(params *UpdateInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateInstanceOK, error) {
+func (a *Client) UpdateInstance(params *UpdateInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateInstanceOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateInstanceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "UpdateInstance",
 		Method:             "PUT",
 		PathPattern:        "/p2p/preheat/instances/{preheat_instance_name}",
@@ -721,7 +791,12 @@ func (a *Client) UpdateInstance(params *UpdateInstanceParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -740,13 +815,12 @@ func (a *Client) UpdateInstance(params *UpdateInstanceParams, authInfo runtime.C
 
   Update preheat policy
 */
-func (a *Client) UpdatePolicy(params *UpdatePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*UpdatePolicyOK, error) {
+func (a *Client) UpdatePolicy(params *UpdatePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdatePolicyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdatePolicyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "UpdatePolicy",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_name}/preheat/policies/{preheat_policy_name}",
@@ -758,7 +832,12 @@ func (a *Client) UpdatePolicy(params *UpdatePolicyParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/api/client/project/project_client.go
+++ b/apiv2/internal/api/client/project/project_client.go
@@ -25,25 +25,28 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectCreated, error)
+	CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectCreated, error)
 
-	DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectOK, error)
+	DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectOK, error)
 
-	GetLogs(params *GetLogsParams, authInfo runtime.ClientAuthInfoWriter) (*GetLogsOK, error)
+	GetLogs(params *GetLogsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLogsOK, error)
 
-	GetProject(params *GetProjectParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectOK, error)
+	GetProject(params *GetProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectOK, error)
 
-	GetProjectDeletable(params *GetProjectDeletableParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectDeletableOK, error)
+	GetProjectDeletable(params *GetProjectDeletableParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectDeletableOK, error)
 
-	GetProjectSummary(params *GetProjectSummaryParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectSummaryOK, error)
+	GetProjectSummary(params *GetProjectSummaryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectSummaryOK, error)
 
-	HeadProject(params *HeadProjectParams, authInfo runtime.ClientAuthInfoWriter) (*HeadProjectOK, error)
+	HeadProject(params *HeadProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*HeadProjectOK, error)
 
-	ListProjects(params *ListProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*ListProjectsOK, error)
+	ListProjects(params *ListProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListProjectsOK, error)
 
-	UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateProjectOK, error)
+	UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateProjectOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -53,13 +56,12 @@ type ClientService interface {
 
   This endpoint is for user to create a new project.
 */
-func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*CreateProjectCreated, error) {
+func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateProjectCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createProject",
 		Method:             "POST",
 		PathPattern:        "/projects",
@@ -71,7 +73,12 @@ func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -90,13 +97,12 @@ func (a *Client) CreateProject(params *CreateProjectParams, authInfo runtime.Cli
 
   This endpoint is aimed to delete project by project ID.
 */
-func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectOK, error) {
+func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteProject",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}",
@@ -108,7 +114,12 @@ func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +138,12 @@ func (a *Client) DeleteProject(params *DeleteProjectParams, authInfo runtime.Cli
 
   Get recent logs of the projects
 */
-func (a *Client) GetLogs(params *GetLogsParams, authInfo runtime.ClientAuthInfoWriter) (*GetLogsOK, error) {
+func (a *Client) GetLogs(params *GetLogsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLogsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogs",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/logs",
@@ -145,7 +155,12 @@ func (a *Client) GetLogs(params *GetLogsParams, authInfo runtime.ClientAuthInfoW
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -164,13 +179,12 @@ func (a *Client) GetLogs(params *GetLogsParams, authInfo runtime.ClientAuthInfoW
 
   This endpoint returns specific project information by project ID.
 */
-func (a *Client) GetProject(params *GetProjectParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectOK, error) {
+func (a *Client) GetProject(params *GetProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getProject",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}",
@@ -182,7 +196,12 @@ func (a *Client) GetProject(params *GetProjectParams, authInfo runtime.ClientAut
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -201,13 +220,12 @@ func (a *Client) GetProject(params *GetProjectParams, authInfo runtime.ClientAut
 
   Get the deletable status of the project
 */
-func (a *Client) GetProjectDeletable(params *GetProjectDeletableParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectDeletableOK, error) {
+func (a *Client) GetProjectDeletable(params *GetProjectDeletableParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectDeletableOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectDeletableParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getProjectDeletable",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/_deletable",
@@ -219,7 +237,12 @@ func (a *Client) GetProjectDeletable(params *GetProjectDeletableParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +261,12 @@ func (a *Client) GetProjectDeletable(params *GetProjectDeletableParams, authInfo
 
   Get summary of the project.
 */
-func (a *Client) GetProjectSummary(params *GetProjectSummaryParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectSummaryOK, error) {
+func (a *Client) GetProjectSummary(params *GetProjectSummaryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectSummaryOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectSummaryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getProjectSummary",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/summary",
@@ -256,7 +278,12 @@ func (a *Client) GetProjectSummary(params *GetProjectSummaryParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -275,13 +302,12 @@ func (a *Client) GetProjectSummary(params *GetProjectSummaryParams, authInfo run
 
   This endpoint is used to check if the project name provided already exist.
 */
-func (a *Client) HeadProject(params *HeadProjectParams, authInfo runtime.ClientAuthInfoWriter) (*HeadProjectOK, error) {
+func (a *Client) HeadProject(params *HeadProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*HeadProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewHeadProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "headProject",
 		Method:             "HEAD",
 		PathPattern:        "/projects",
@@ -293,7 +319,12 @@ func (a *Client) HeadProject(params *HeadProjectParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -312,13 +343,12 @@ func (a *Client) HeadProject(params *HeadProjectParams, authInfo runtime.ClientA
 
   This endpoint returns projects created by Harbor.
 */
-func (a *Client) ListProjects(params *ListProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*ListProjectsOK, error) {
+func (a *Client) ListProjects(params *ListProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListProjectsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListProjectsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listProjects",
 		Method:             "GET",
 		PathPattern:        "/projects",
@@ -330,7 +360,12 @@ func (a *Client) ListProjects(params *ListProjectsParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -349,13 +384,12 @@ func (a *Client) ListProjects(params *ListProjectsParams, authInfo runtime.Clien
 
   This endpoint is aimed to update the properties of a project.
 */
-func (a *Client) UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateProjectOK, error) {
+func (a *Client) UpdateProject(params *UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateProjectOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateProjectParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateProject",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}",
@@ -367,7 +401,12 @@ func (a *Client) UpdateProject(params *UpdateProjectParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/api/client/repository/repository_client.go
+++ b/apiv2/internal/api/client/repository/repository_client.go
@@ -25,15 +25,18 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteRepository(params *DeleteRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteRepositoryOK, error)
+	DeleteRepository(params *DeleteRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRepositoryOK, error)
 
-	GetRepository(params *GetRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*GetRepositoryOK, error)
+	GetRepository(params *GetRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRepositoryOK, error)
 
-	ListRepositories(params *ListRepositoriesParams, authInfo runtime.ClientAuthInfoWriter) (*ListRepositoriesOK, error)
+	ListRepositories(params *ListRepositoriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListRepositoriesOK, error)
 
-	UpdateRepository(params *UpdateRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateRepositoryOK, error)
+	UpdateRepository(params *UpdateRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateRepositoryOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,13 +46,12 @@ type ClientService interface {
 
   Delete the repository specified by name
 */
-func (a *Client) DeleteRepository(params *DeleteRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteRepositoryOK, error) {
+func (a *Client) DeleteRepository(params *DeleteRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRepositoryOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteRepositoryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteRepository",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}",
@@ -61,7 +63,12 @@ func (a *Client) DeleteRepository(params *DeleteRepositoryParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +87,12 @@ func (a *Client) DeleteRepository(params *DeleteRepositoryParams, authInfo runti
 
   Get the repository specified by name
 */
-func (a *Client) GetRepository(params *GetRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*GetRepositoryOK, error) {
+func (a *Client) GetRepository(params *GetRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRepositoryOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRepositoryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getRepository",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}",
@@ -98,7 +104,12 @@ func (a *Client) GetRepository(params *GetRepositoryParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +128,12 @@ func (a *Client) GetRepository(params *GetRepositoryParams, authInfo runtime.Cli
 
   List repositories of the specified project
 */
-func (a *Client) ListRepositories(params *ListRepositoriesParams, authInfo runtime.ClientAuthInfoWriter) (*ListRepositoriesOK, error) {
+func (a *Client) ListRepositories(params *ListRepositoriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ListRepositoriesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListRepositoriesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listRepositories",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories",
@@ -135,7 +145,12 @@ func (a *Client) ListRepositories(params *ListRepositoriesParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -154,13 +169,12 @@ func (a *Client) ListRepositories(params *ListRepositoriesParams, authInfo runti
 
   Update the repository specified by name
 */
-func (a *Client) UpdateRepository(params *UpdateRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateRepositoryOK, error) {
+func (a *Client) UpdateRepository(params *UpdateRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateRepositoryOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateRepositoryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateRepository",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}",
@@ -172,7 +186,12 @@ func (a *Client) UpdateRepository(params *UpdateRepositoryParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/api/client/scan/scan_client.go
+++ b/apiv2/internal/api/client/scan/scan_client.go
@@ -25,11 +25,14 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetReportLog(params *GetReportLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetReportLogOK, error)
+	GetReportLog(params *GetReportLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReportLogOK, error)
 
-	ScanArtifact(params *ScanArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*ScanArtifactAccepted, error)
+	ScanArtifact(params *ScanArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ScanArtifactAccepted, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -39,13 +42,12 @@ type ClientService interface {
 
   Get the log of the scan report
 */
-func (a *Client) GetReportLog(params *GetReportLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetReportLogOK, error) {
+func (a *Client) GetReportLog(params *GetReportLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReportLogOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReportLogParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getReportLog",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/scan/{report_id}/log",
@@ -57,7 +59,12 @@ func (a *Client) GetReportLog(params *GetReportLogParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +83,12 @@ func (a *Client) GetReportLog(params *GetReportLogParams, authInfo runtime.Clien
 
   Scan the specified artifact
 */
-func (a *Client) ScanArtifact(params *ScanArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*ScanArtifactAccepted, error) {
+func (a *Client) ScanArtifact(params *ScanArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ScanArtifactAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewScanArtifactParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "scanArtifact",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/scan",
@@ -94,7 +100,12 @@ func (a *Client) ScanArtifact(params *ScanArtifactParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/legacyapi/client/products/products_client.go
+++ b/apiv2/internal/legacyapi/client/products/products_client.go
@@ -25,241 +25,244 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteChartrepoRepoChartsNameVersionLabelsID(params *DeleteChartrepoRepoChartsNameVersionLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteChartrepoRepoChartsNameVersionLabelsIDOK, error)
+	DeleteChartrepoRepoChartsNameVersionLabelsID(params *DeleteChartrepoRepoChartsNameVersionLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteChartrepoRepoChartsNameVersionLabelsIDOK, error)
 
-	DeleteLabelsID(params *DeleteLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteLabelsIDOK, error)
+	DeleteLabelsID(params *DeleteLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteLabelsIDOK, error)
 
-	DeleteProjectsProjectIDImmutabletagrulesID(params *DeleteProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDImmutabletagrulesIDOK, error)
+	DeleteProjectsProjectIDImmutabletagrulesID(params *DeleteProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDImmutabletagrulesIDOK, error)
 
-	DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMembersMidOK, error)
+	DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMembersMidOK, error)
 
-	DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error)
+	DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error)
 
-	DeleteProjectsProjectIDRobotsRobotID(params *DeleteProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDRobotsRobotIDOK, error)
+	DeleteProjectsProjectIDRobotsRobotID(params *DeleteProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDRobotsRobotIDOK, error)
 
-	DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK, error)
+	DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK, error)
 
-	DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteRegistriesIDOK, error)
+	DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRegistriesIDOK, error)
 
-	DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteReplicationPoliciesIDOK, error)
+	DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteReplicationPoliciesIDOK, error)
 
-	DeleteUsergroupsGroupID(params *DeleteUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteUsergroupsGroupIDOK, error)
+	DeleteUsergroupsGroupID(params *DeleteUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteUsergroupsGroupIDOK, error)
 
-	DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteUsersUserIDOK, error)
+	DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteUsersUserIDOK, error)
 
-	GetChartrepoRepoChartsNameVersionLabels(params *GetChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*GetChartrepoRepoChartsNameVersionLabelsOK, error)
+	GetChartrepoRepoChartsNameVersionLabels(params *GetChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetChartrepoRepoChartsNameVersionLabelsOK, error)
 
-	GetConfigurations(params *GetConfigurationsParams, authInfo runtime.ClientAuthInfoWriter) (*GetConfigurationsOK, error)
+	GetConfigurations(params *GetConfigurationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetConfigurationsOK, error)
 
-	GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter) (*GetHealthOK, error)
+	GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetHealthOK, error)
 
-	GetLabels(params *GetLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*GetLabelsOK, error)
+	GetLabels(params *GetLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLabelsOK, error)
 
-	GetLabelsID(params *GetLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetLabelsIDOK, error)
+	GetLabelsID(params *GetLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLabelsIDOK, error)
 
-	GetLdapGroupsSearch(params *GetLdapGroupsSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetLdapGroupsSearchOK, error)
+	GetLdapGroupsSearch(params *GetLdapGroupsSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLdapGroupsSearchOK, error)
 
-	GetLdapUsersSearch(params *GetLdapUsersSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetLdapUsersSearchOK, error)
+	GetLdapUsersSearch(params *GetLdapUsersSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLdapUsersSearchOK, error)
 
-	GetProjectsProjectIDImmutabletagrules(params *GetProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDImmutabletagrulesOK, error)
+	GetProjectsProjectIDImmutabletagrules(params *GetProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDImmutabletagrulesOK, error)
 
-	GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMembersOK, error)
+	GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMembersOK, error)
 
-	GetProjectsProjectIDMembersMid(params *GetProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMembersMidOK, error)
+	GetProjectsProjectIDMembersMid(params *GetProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMembersMidOK, error)
 
-	GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasOK, error)
+	GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasOK, error)
 
-	GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasMetaNameOK, error)
+	GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasMetaNameOK, error)
 
-	GetProjectsProjectIDRobots(params *GetProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDRobotsOK, error)
+	GetProjectsProjectIDRobots(params *GetProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDRobotsOK, error)
 
-	GetProjectsProjectIDRobotsRobotID(params *GetProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDRobotsRobotIDOK, error)
+	GetProjectsProjectIDRobotsRobotID(params *GetProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDRobotsRobotIDOK, error)
 
-	GetProjectsProjectIDScanner(params *GetProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDScannerOK, error)
+	GetProjectsProjectIDScanner(params *GetProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDScannerOK, error)
 
-	GetProjectsProjectIDScannerCandidates(params *GetProjectsProjectIDScannerCandidatesParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDScannerCandidatesOK, error)
+	GetProjectsProjectIDScannerCandidates(params *GetProjectsProjectIDScannerCandidatesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDScannerCandidatesOK, error)
 
-	GetProjectsProjectIDWebhookEvents(params *GetProjectsProjectIDWebhookEventsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookEventsOK, error)
+	GetProjectsProjectIDWebhookEvents(params *GetProjectsProjectIDWebhookEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookEventsOK, error)
 
-	GetProjectsProjectIDWebhookJobs(params *GetProjectsProjectIDWebhookJobsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookJobsOK, error)
+	GetProjectsProjectIDWebhookJobs(params *GetProjectsProjectIDWebhookJobsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookJobsOK, error)
 
-	GetProjectsProjectIDWebhookLasttrigger(params *GetProjectsProjectIDWebhookLasttriggerParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookLasttriggerOK, error)
+	GetProjectsProjectIDWebhookLasttrigger(params *GetProjectsProjectIDWebhookLasttriggerParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookLasttriggerOK, error)
 
-	GetProjectsProjectIDWebhookPolicies(params *GetProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookPoliciesOK, error)
+	GetProjectsProjectIDWebhookPolicies(params *GetProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookPoliciesOK, error)
 
-	GetProjectsProjectIDWebhookPoliciesPolicyID(params *GetProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookPoliciesPolicyIDOK, error)
+	GetProjectsProjectIDWebhookPoliciesPolicyID(params *GetProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookPoliciesPolicyIDOK, error)
 
-	GetQuotas(params *GetQuotasParams, authInfo runtime.ClientAuthInfoWriter) (*GetQuotasOK, error)
+	GetQuotas(params *GetQuotasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetQuotasOK, error)
 
-	GetQuotasID(params *GetQuotasIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetQuotasIDOK, error)
+	GetQuotasID(params *GetQuotasIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetQuotasIDOK, error)
 
-	GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesOK, error)
+	GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesOK, error)
 
-	GetRegistriesID(params *GetRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesIDOK, error)
+	GetRegistriesID(params *GetRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesIDOK, error)
 
-	GetRegistriesIDInfo(params *GetRegistriesIDInfoParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesIDInfoOK, error)
+	GetRegistriesIDInfo(params *GetRegistriesIDInfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesIDInfoOK, error)
 
-	GetRegistriesIDNamespace(params *GetRegistriesIDNamespaceParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesIDNamespaceOK, error)
+	GetRegistriesIDNamespace(params *GetRegistriesIDNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesIDNamespaceOK, error)
 
-	GetReplicationAdapters(params *GetReplicationAdaptersParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationAdaptersOK, error)
+	GetReplicationAdapters(params *GetReplicationAdaptersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationAdaptersOK, error)
 
-	GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsOK, error)
+	GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsOK, error)
 
-	GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDOK, error)
+	GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDOK, error)
 
-	GetReplicationExecutionsIDTasks(params *GetReplicationExecutionsIDTasksParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDTasksOK, error)
+	GetReplicationExecutionsIDTasks(params *GetReplicationExecutionsIDTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDTasksOK, error)
 
-	GetReplicationExecutionsIDTasksTaskIDLog(params *GetReplicationExecutionsIDTasksTaskIDLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDTasksTaskIDLogOK, error)
+	GetReplicationExecutionsIDTasksTaskIDLog(params *GetReplicationExecutionsIDTasksTaskIDLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDTasksTaskIDLogOK, error)
 
-	GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesOK, error)
+	GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesOK, error)
 
-	GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesIDOK, error)
+	GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesIDOK, error)
 
-	GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDOK, error)
+	GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDOK, error)
 
-	GetRetentionsIDExecutions(params *GetRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDExecutionsOK, error)
+	GetRetentionsIDExecutions(params *GetRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDExecutionsOK, error)
 
-	GetRetentionsIDExecutionsEidTasks(params *GetRetentionsIDExecutionsEidTasksParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDExecutionsEidTasksOK, error)
+	GetRetentionsIDExecutionsEidTasks(params *GetRetentionsIDExecutionsEidTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDExecutionsEidTasksOK, error)
 
-	GetRetentionsIDExecutionsEidTasksTid(params *GetRetentionsIDExecutionsEidTasksTidParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDExecutionsEidTasksTidOK, error)
+	GetRetentionsIDExecutionsEidTasksTid(params *GetRetentionsIDExecutionsEidTasksTidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDExecutionsEidTasksTidOK, error)
 
-	GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsMetadatasOK, error)
+	GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsMetadatasOK, error)
 
-	GetScanners(params *GetScannersParams, authInfo runtime.ClientAuthInfoWriter) (*GetScannersOK, error)
+	GetScanners(params *GetScannersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScannersOK, error)
 
-	GetScannersRegistrationID(params *GetScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetScannersRegistrationIDOK, error)
+	GetScannersRegistrationID(params *GetScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScannersRegistrationIDOK, error)
 
-	GetScannersRegistrationIDMetadata(params *GetScannersRegistrationIDMetadataParams, authInfo runtime.ClientAuthInfoWriter) (*GetScannersRegistrationIDMetadataOK, error)
+	GetScannersRegistrationIDMetadata(params *GetScannersRegistrationIDMetadataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScannersRegistrationIDMetadataOK, error)
 
-	GetScansAllMetrics(params *GetScansAllMetricsParams, authInfo runtime.ClientAuthInfoWriter) (*GetScansAllMetricsOK, error)
+	GetScansAllMetrics(params *GetScansAllMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScansAllMetricsOK, error)
 
-	GetScansScheduleMetrics(params *GetScansScheduleMetricsParams, authInfo runtime.ClientAuthInfoWriter) (*GetScansScheduleMetricsOK, error)
+	GetScansScheduleMetrics(params *GetScansScheduleMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScansScheduleMetricsOK, error)
 
-	GetSearch(params *GetSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetSearchOK, error)
+	GetSearch(params *GetSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSearchOK, error)
 
-	GetStatistics(params *GetStatisticsParams, authInfo runtime.ClientAuthInfoWriter) (*GetStatisticsOK, error)
+	GetStatistics(params *GetStatisticsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetStatisticsOK, error)
 
-	GetSystemCVEAllowlist(params *GetSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemCVEAllowlistOK, error)
+	GetSystemCVEAllowlist(params *GetSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemCVEAllowlistOK, error)
 
-	GetSystemGc(params *GetSystemGcParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcOK, error)
+	GetSystemGc(params *GetSystemGcParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcOK, error)
 
-	GetSystemGcID(params *GetSystemGcIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcIDOK, error)
+	GetSystemGcID(params *GetSystemGcIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcIDOK, error)
 
-	GetSystemGcIDLog(params *GetSystemGcIDLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcIDLogOK, error)
+	GetSystemGcIDLog(params *GetSystemGcIDLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcIDLogOK, error)
 
-	GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcScheduleOK, error)
+	GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcScheduleOK, error)
 
-	GetSystemScanAllSchedule(params *GetSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemScanAllScheduleOK, error)
+	GetSystemScanAllSchedule(params *GetSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemScanAllScheduleOK, error)
 
-	GetSysteminfo(params *GetSysteminfoParams, authInfo runtime.ClientAuthInfoWriter) (*GetSysteminfoOK, error)
+	GetSysteminfo(params *GetSysteminfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSysteminfoOK, error)
 
-	GetSysteminfoGetcert(params *GetSysteminfoGetcertParams, authInfo runtime.ClientAuthInfoWriter) (*GetSysteminfoGetcertOK, error)
+	GetSysteminfoGetcert(params *GetSysteminfoGetcertParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSysteminfoGetcertOK, error)
 
-	GetSysteminfoVolumes(params *GetSysteminfoVolumesParams, authInfo runtime.ClientAuthInfoWriter) (*GetSysteminfoVolumesOK, error)
+	GetSysteminfoVolumes(params *GetSysteminfoVolumesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSysteminfoVolumesOK, error)
 
-	GetUsergroups(params *GetUsergroupsParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsergroupsOK, error)
+	GetUsergroups(params *GetUsergroupsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsergroupsOK, error)
 
-	GetUsergroupsGroupID(params *GetUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsergroupsGroupIDOK, error)
+	GetUsergroupsGroupID(params *GetUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsergroupsGroupIDOK, error)
 
-	GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersOK, error)
+	GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersOK, error)
 
-	GetUsersCurrent(params *GetUsersCurrentParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersCurrentOK, error)
+	GetUsersCurrent(params *GetUsersCurrentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersCurrentOK, error)
 
-	GetUsersCurrentPermissions(params *GetUsersCurrentPermissionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersCurrentPermissionsOK, error)
+	GetUsersCurrentPermissions(params *GetUsersCurrentPermissionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersCurrentPermissionsOK, error)
 
-	GetUsersSearch(params *GetUsersSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersSearchOK, error)
+	GetUsersSearch(params *GetUsersSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersSearchOK, error)
 
-	GetUsersUserID(params *GetUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersUserIDOK, error)
+	GetUsersUserID(params *GetUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersUserIDOK, error)
 
-	PatchRetentionsIDExecutionsEid(params *PatchRetentionsIDExecutionsEidParams, authInfo runtime.ClientAuthInfoWriter) (*PatchRetentionsIDExecutionsEidOK, error)
+	PatchRetentionsIDExecutionsEid(params *PatchRetentionsIDExecutionsEidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PatchRetentionsIDExecutionsEidOK, error)
 
-	PostChartrepoRepoChartsNameVersionLabels(params *PostChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*PostChartrepoRepoChartsNameVersionLabelsOK, error)
+	PostChartrepoRepoChartsNameVersionLabels(params *PostChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostChartrepoRepoChartsNameVersionLabelsOK, error)
 
-	PostEmailPing(params *PostEmailPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostEmailPingOK, error)
+	PostEmailPing(params *PostEmailPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostEmailPingOK, error)
 
-	PostLabels(params *PostLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*PostLabelsCreated, error)
+	PostLabels(params *PostLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostLabelsCreated, error)
 
-	PostLdapPing(params *PostLdapPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostLdapPingOK, error)
+	PostLdapPing(params *PostLdapPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostLdapPingOK, error)
 
-	PostLdapUsersImport(params *PostLdapUsersImportParams, authInfo runtime.ClientAuthInfoWriter) (*PostLdapUsersImportOK, error)
+	PostLdapUsersImport(params *PostLdapUsersImportParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostLdapUsersImportOK, error)
 
-	PostProjectsProjectIDImmutabletagrules(params *PostProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDImmutabletagrulesOK, error)
+	PostProjectsProjectIDImmutabletagrules(params *PostProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDImmutabletagrulesOK, error)
 
-	PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMembersCreated, error)
+	PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMembersCreated, error)
 
-	PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMetadatasOK, error)
+	PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMetadatasOK, error)
 
-	PostProjectsProjectIDRobots(params *PostProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDRobotsCreated, error)
+	PostProjectsProjectIDRobots(params *PostProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDRobotsCreated, error)
 
-	PostProjectsProjectIDWebhookPolicies(params *PostProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDWebhookPoliciesCreated, error)
+	PostProjectsProjectIDWebhookPolicies(params *PostProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDWebhookPoliciesCreated, error)
 
-	PostProjectsProjectIDWebhookPoliciesTest(params *PostProjectsProjectIDWebhookPoliciesTestParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDWebhookPoliciesTestOK, error)
+	PostProjectsProjectIDWebhookPoliciesTest(params *PostProjectsProjectIDWebhookPoliciesTestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDWebhookPoliciesTestOK, error)
 
-	PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*PostRegistriesCreated, error)
+	PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRegistriesCreated, error)
 
-	PostRegistriesPing(params *PostRegistriesPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostRegistriesPingOK, error)
+	PostRegistriesPing(params *PostRegistriesPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRegistriesPingOK, error)
 
-	PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationExecutionsCreated, error)
+	PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationExecutionsCreated, error)
 
-	PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationPoliciesCreated, error)
+	PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationPoliciesCreated, error)
 
-	PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostRetentionsCreated, error)
+	PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRetentionsCreated, error)
 
-	PostRetentionsIDExecutions(params *PostRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostRetentionsIDExecutionsOK, error)
+	PostRetentionsIDExecutions(params *PostRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRetentionsIDExecutionsOK, error)
 
-	PostScannersPing(params *PostScannersPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostScannersPingOK, error)
+	PostScannersPing(params *PostScannersPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostScannersPingOK, error)
 
-	PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemGcScheduleOK, error)
+	PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemGcScheduleOK, error)
 
-	PostSystemOidcPing(params *PostSystemOidcPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemOidcPingOK, error)
+	PostSystemOidcPing(params *PostSystemOidcPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemOidcPingOK, error)
 
-	PostSystemScanAllSchedule(params *PostSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemScanAllScheduleOK, error)
+	PostSystemScanAllSchedule(params *PostSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemScanAllScheduleOK, error)
 
-	PostUsergroups(params *PostUsergroupsParams, authInfo runtime.ClientAuthInfoWriter) (*PostUsergroupsCreated, error)
+	PostUsergroups(params *PostUsergroupsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostUsergroupsCreated, error)
 
-	PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter) (*PostUsersCreated, error)
+	PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostUsersCreated, error)
 
-	PutConfigurations(params *PutConfigurationsParams, authInfo runtime.ClientAuthInfoWriter) (*PutConfigurationsOK, error)
+	PutConfigurations(params *PutConfigurationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutConfigurationsOK, error)
 
-	PutLabelsID(params *PutLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutLabelsIDOK, error)
+	PutLabelsID(params *PutLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutLabelsIDOK, error)
 
-	PutProjectsProjectIDImmutabletagrulesID(params *PutProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDImmutabletagrulesIDOK, error)
+	PutProjectsProjectIDImmutabletagrulesID(params *PutProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDImmutabletagrulesIDOK, error)
 
-	PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMembersMidOK, error)
+	PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMembersMidOK, error)
 
-	PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMetadatasMetaNameOK, error)
+	PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMetadatasMetaNameOK, error)
 
-	PutProjectsProjectIDRobotsRobotID(params *PutProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDRobotsRobotIDOK, error)
+	PutProjectsProjectIDRobotsRobotID(params *PutProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDRobotsRobotIDOK, error)
 
-	PutProjectsProjectIDWebhookPoliciesPolicyID(params *PutProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDWebhookPoliciesPolicyIDOK, error)
+	PutProjectsProjectIDWebhookPoliciesPolicyID(params *PutProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDWebhookPoliciesPolicyIDOK, error)
 
-	PutQuotasID(params *PutQuotasIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutQuotasIDOK, error)
+	PutQuotasID(params *PutQuotasIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutQuotasIDOK, error)
 
-	PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutRegistriesIDOK, error)
+	PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutRegistriesIDOK, error)
 
-	PutReplicationExecutionsID(params *PutReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutReplicationExecutionsIDOK, error)
+	PutReplicationExecutionsID(params *PutReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutReplicationExecutionsIDOK, error)
 
-	PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutReplicationPoliciesIDOK, error)
+	PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutReplicationPoliciesIDOK, error)
 
-	PutRetentionsID(params *PutRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutRetentionsIDOK, error)
+	PutRetentionsID(params *PutRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutRetentionsIDOK, error)
 
-	PutSystemCVEAllowlist(params *PutSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemCVEAllowlistOK, error)
+	PutSystemCVEAllowlist(params *PutSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemCVEAllowlistOK, error)
 
-	PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemGcScheduleOK, error)
+	PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemGcScheduleOK, error)
 
-	PutSystemScanAllSchedule(params *PutSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemScanAllScheduleOK, error)
+	PutSystemScanAllSchedule(params *PutSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemScanAllScheduleOK, error)
 
-	PutUsergroupsGroupID(params *PutUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsergroupsGroupIDOK, error)
+	PutUsergroupsGroupID(params *PutUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsergroupsGroupIDOK, error)
 
-	PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDOK, error)
+	PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDOK, error)
 
-	PutUsersUserIDCliSecret(params *PutUsersUserIDCliSecretParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDCliSecretOK, error)
+	PutUsersUserIDCliSecret(params *PutUsersUserIDCliSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDCliSecretOK, error)
 
-	PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDPasswordOK, error)
+	PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDPasswordOK, error)
 
-	PutUsersUserIDSysadmin(params *PutUsersUserIDSysadminParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDSysadminOK, error)
+	PutUsersUserIDSysadmin(params *PutUsersUserIDSysadminParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDSysadminOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -269,13 +272,12 @@ type ClientService interface {
 
   Remove label from the specified chart version.
 */
-func (a *Client) DeleteChartrepoRepoChartsNameVersionLabelsID(params *DeleteChartrepoRepoChartsNameVersionLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteChartrepoRepoChartsNameVersionLabelsIDOK, error) {
+func (a *Client) DeleteChartrepoRepoChartsNameVersionLabelsID(params *DeleteChartrepoRepoChartsNameVersionLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteChartrepoRepoChartsNameVersionLabelsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteChartrepoRepoChartsNameVersionLabelsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteChartrepoRepoChartsNameVersionLabelsID",
 		Method:             "DELETE",
 		PathPattern:        "/chartrepo/{repo}/charts/{name}/{version}/labels/{id}",
@@ -287,7 +289,12 @@ func (a *Client) DeleteChartrepoRepoChartsNameVersionLabelsID(params *DeleteChar
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -307,13 +314,12 @@ func (a *Client) DeleteChartrepoRepoChartsNameVersionLabelsID(params *DeleteChar
   Delete the label specified by ID.
 
 */
-func (a *Client) DeleteLabelsID(params *DeleteLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteLabelsIDOK, error) {
+func (a *Client) DeleteLabelsID(params *DeleteLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteLabelsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteLabelsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteLabelsID",
 		Method:             "DELETE",
 		PathPattern:        "/labels/{id}",
@@ -325,7 +331,12 @@ func (a *Client) DeleteLabelsID(params *DeleteLabelsIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -342,13 +353,12 @@ func (a *Client) DeleteLabelsID(params *DeleteLabelsIDParams, authInfo runtime.C
 /*
   DeleteProjectsProjectIDImmutabletagrulesID deletes the immutable tag rule
 */
-func (a *Client) DeleteProjectsProjectIDImmutabletagrulesID(params *DeleteProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDImmutabletagrulesIDOK, error) {
+func (a *Client) DeleteProjectsProjectIDImmutabletagrulesID(params *DeleteProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDImmutabletagrulesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDImmutabletagrulesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDImmutabletagrulesID",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/immutabletagrules/{id}",
@@ -360,7 +370,12 @@ func (a *Client) DeleteProjectsProjectIDImmutabletagrulesID(params *DeleteProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -377,13 +392,12 @@ func (a *Client) DeleteProjectsProjectIDImmutabletagrulesID(params *DeleteProjec
 /*
   DeleteProjectsProjectIDMembersMid deletes project member
 */
-func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMembersMidOK, error) {
+func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMembersMidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDMembersMidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDMembersMid",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/members/{mid}",
@@ -395,7 +409,12 @@ func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProject
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -415,13 +434,12 @@ func (a *Client) DeleteProjectsProjectIDMembersMid(params *DeleteProjectsProject
   This endpoint is aimed to delete metadata of a project.
 
 */
-func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
+func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDMetadatasMetaNameParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDMetadatasMetaName",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/metadatas/{meta_name}",
@@ -433,7 +451,12 @@ func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjects
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -452,13 +475,12 @@ func (a *Client) DeleteProjectsProjectIDMetadatasMetaName(params *DeleteProjects
 
   Delete the specified robot account
 */
-func (a *Client) DeleteProjectsProjectIDRobotsRobotID(params *DeleteProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDRobotsRobotIDOK, error) {
+func (a *Client) DeleteProjectsProjectIDRobotsRobotID(params *DeleteProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDRobotsRobotIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDRobotsRobotIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDRobotsRobotID",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/robots/{robot_id}",
@@ -470,7 +492,12 @@ func (a *Client) DeleteProjectsProjectIDRobotsRobotID(params *DeleteProjectsProj
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -490,13 +517,12 @@ func (a *Client) DeleteProjectsProjectIDRobotsRobotID(params *DeleteProjectsProj
   This endpoint is aimed to delete webhookpolicy of a project.
 
 */
-func (a *Client) DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
+func (a *Client) DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteProjectsProjectIDWebhookPoliciesPolicyIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteProjectsProjectIDWebhookPoliciesPolicyID",
 		Method:             "DELETE",
 		PathPattern:        "/projects/{project_id}/webhook/policies/{policy_id}",
@@ -508,7 +534,12 @@ func (a *Client) DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *DeletePr
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -528,13 +559,12 @@ func (a *Client) DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *DeletePr
   This endpoint is for to delete specific registry.
 
 */
-func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteRegistriesIDOK, error) {
+func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRegistriesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteRegistriesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteRegistriesID",
 		Method:             "DELETE",
 		PathPattern:        "/registries/{id}",
@@ -546,7 +576,12 @@ func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -566,13 +601,12 @@ func (a *Client) DeleteRegistriesID(params *DeleteRegistriesIDParams, authInfo r
   Delete the replication policy specified by ID.
 
 */
-func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteReplicationPoliciesIDOK, error) {
+func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteReplicationPoliciesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteReplicationPoliciesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteReplicationPoliciesID",
 		Method:             "DELETE",
 		PathPattern:        "/replication/policies/{id}",
@@ -584,7 +618,12 @@ func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesID
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -603,13 +642,12 @@ func (a *Client) DeleteReplicationPoliciesID(params *DeleteReplicationPoliciesID
 
   Delete user group
 */
-func (a *Client) DeleteUsergroupsGroupID(params *DeleteUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteUsergroupsGroupIDOK, error) {
+func (a *Client) DeleteUsergroupsGroupID(params *DeleteUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteUsergroupsGroupIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteUsergroupsGroupIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteUsergroupsGroupID",
 		Method:             "DELETE",
 		PathPattern:        "/usergroups/{group_id}",
@@ -621,7 +659,12 @@ func (a *Client) DeleteUsergroupsGroupID(params *DeleteUsergroupsGroupIDParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -642,13 +685,12 @@ func (a *Client) DeleteUsergroupsGroupID(params *DeleteUsergroupsGroupIDParams, 
 be removed.It actually won't be deleted from DB.
 
 */
-func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteUsersUserIDOK, error) {
+func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteUsersUserIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteUsersUserIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteUsersUserID",
 		Method:             "DELETE",
 		PathPattern:        "/users/{user_id}",
@@ -660,7 +702,12 @@ func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -679,13 +726,12 @@ func (a *Client) DeleteUsersUserID(params *DeleteUsersUserIDParams, authInfo run
 
   Return the attahced labels of the specified chart version.
 */
-func (a *Client) GetChartrepoRepoChartsNameVersionLabels(params *GetChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*GetChartrepoRepoChartsNameVersionLabelsOK, error) {
+func (a *Client) GetChartrepoRepoChartsNameVersionLabels(params *GetChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetChartrepoRepoChartsNameVersionLabelsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetChartrepoRepoChartsNameVersionLabelsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetChartrepoRepoChartsNameVersionLabels",
 		Method:             "GET",
 		PathPattern:        "/chartrepo/{repo}/charts/{name}/{version}/labels",
@@ -697,7 +743,12 @@ func (a *Client) GetChartrepoRepoChartsNameVersionLabels(params *GetChartrepoRep
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -717,13 +768,12 @@ func (a *Client) GetChartrepoRepoChartsNameVersionLabels(params *GetChartrepoRep
   This endpoint is for retrieving system configurations that only provides for admin user.
 
 */
-func (a *Client) GetConfigurations(params *GetConfigurationsParams, authInfo runtime.ClientAuthInfoWriter) (*GetConfigurationsOK, error) {
+func (a *Client) GetConfigurations(params *GetConfigurationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetConfigurationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetConfigurationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetConfigurations",
 		Method:             "GET",
 		PathPattern:        "/configurations",
@@ -735,7 +785,12 @@ func (a *Client) GetConfigurations(params *GetConfigurationsParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -755,13 +810,12 @@ func (a *Client) GetConfigurations(params *GetConfigurationsParams, authInfo run
   The endpoint returns the health stauts of the system.
 
 */
-func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter) (*GetHealthOK, error) {
+func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetHealthOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetHealthParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetHealth",
 		Method:             "GET",
 		PathPattern:        "/health",
@@ -773,7 +827,12 @@ func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -793,13 +852,12 @@ func (a *Client) GetHealth(params *GetHealthParams, authInfo runtime.ClientAuthI
   This endpoint let user list labels by name, scope and project_id
 
 */
-func (a *Client) GetLabels(params *GetLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*GetLabelsOK, error) {
+func (a *Client) GetLabels(params *GetLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLabelsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLabelsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetLabels",
 		Method:             "GET",
 		PathPattern:        "/labels",
@@ -811,7 +869,12 @@ func (a *Client) GetLabels(params *GetLabelsParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -831,13 +894,12 @@ func (a *Client) GetLabels(params *GetLabelsParams, authInfo runtime.ClientAuthI
   This endpoint let user get the label by specific ID.
 
 */
-func (a *Client) GetLabelsID(params *GetLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetLabelsIDOK, error) {
+func (a *Client) GetLabelsID(params *GetLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLabelsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLabelsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetLabelsID",
 		Method:             "GET",
 		PathPattern:        "/labels/{id}",
@@ -849,7 +911,12 @@ func (a *Client) GetLabelsID(params *GetLabelsIDParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -869,13 +936,12 @@ func (a *Client) GetLabelsID(params *GetLabelsIDParams, authInfo runtime.ClientA
   This endpoint searches the available ldap groups based on related configuration parameters. support to search by groupname or groupdn.
 
 */
-func (a *Client) GetLdapGroupsSearch(params *GetLdapGroupsSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetLdapGroupsSearchOK, error) {
+func (a *Client) GetLdapGroupsSearch(params *GetLdapGroupsSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLdapGroupsSearchOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLdapGroupsSearchParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetLdapGroupsSearch",
 		Method:             "GET",
 		PathPattern:        "/ldap/groups/search",
@@ -887,7 +953,12 @@ func (a *Client) GetLdapGroupsSearch(params *GetLdapGroupsSearchParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -907,13 +978,12 @@ func (a *Client) GetLdapGroupsSearch(params *GetLdapGroupsSearchParams, authInfo
   This endpoint searches the available ldap users based on related configuration parameters. Support searched by input ladp configuration, load configuration from the system and specific filter.
 
 */
-func (a *Client) GetLdapUsersSearch(params *GetLdapUsersSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetLdapUsersSearchOK, error) {
+func (a *Client) GetLdapUsersSearch(params *GetLdapUsersSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetLdapUsersSearchOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLdapUsersSearchParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetLdapUsersSearch",
 		Method:             "GET",
 		PathPattern:        "/ldap/users/search",
@@ -925,7 +995,12 @@ func (a *Client) GetLdapUsersSearch(params *GetLdapUsersSearchParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -945,13 +1020,12 @@ func (a *Client) GetLdapUsersSearch(params *GetLdapUsersSearchParams, authInfo r
   This endpoint returns the immutable tag rules of a project
 
 */
-func (a *Client) GetProjectsProjectIDImmutabletagrules(params *GetProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDImmutabletagrulesOK, error) {
+func (a *Client) GetProjectsProjectIDImmutabletagrules(params *GetProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDImmutabletagrulesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDImmutabletagrulesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDImmutabletagrules",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/immutabletagrules",
@@ -963,7 +1037,12 @@ func (a *Client) GetProjectsProjectIDImmutabletagrules(params *GetProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -982,13 +1061,12 @@ func (a *Client) GetProjectsProjectIDImmutabletagrules(params *GetProjectsProjec
 
   Get all project member information
 */
-func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMembersOK, error) {
+func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMembersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMembersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMembers",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/members",
@@ -1000,7 +1078,12 @@ func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembers
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1019,13 +1102,12 @@ func (a *Client) GetProjectsProjectIDMembers(params *GetProjectsProjectIDMembers
 
   Get the project member information
 */
-func (a *Client) GetProjectsProjectIDMembersMid(params *GetProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMembersMidOK, error) {
+func (a *Client) GetProjectsProjectIDMembersMid(params *GetProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMembersMidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMembersMidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMembersMid",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/members/{mid}",
@@ -1037,7 +1119,12 @@ func (a *Client) GetProjectsProjectIDMembersMid(params *GetProjectsProjectIDMemb
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1057,13 +1144,12 @@ func (a *Client) GetProjectsProjectIDMembersMid(params *GetProjectsProjectIDMemb
   This endpoint returns metadata of the project specified by project ID.
 
 */
-func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasOK, error) {
+func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMetadatasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMetadatas",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/metadatas",
@@ -1075,7 +1161,12 @@ func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetad
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1095,13 +1186,12 @@ func (a *Client) GetProjectsProjectIDMetadatas(params *GetProjectsProjectIDMetad
   This endpoint returns specified metadata of a project.
 
 */
-func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDMetadatasMetaNameOK, error) {
+func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDMetadatasMetaNameOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDMetadatasMetaNameParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDMetadatasMetaName",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/metadatas/{meta_name}",
@@ -1113,7 +1203,12 @@ func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1132,13 +1227,12 @@ func (a *Client) GetProjectsProjectIDMetadatasMetaName(params *GetProjectsProjec
 
   Get all robot accounts of specified project
 */
-func (a *Client) GetProjectsProjectIDRobots(params *GetProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDRobotsOK, error) {
+func (a *Client) GetProjectsProjectIDRobots(params *GetProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDRobotsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDRobotsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDRobots",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/robots",
@@ -1150,7 +1244,12 @@ func (a *Client) GetProjectsProjectIDRobots(params *GetProjectsProjectIDRobotsPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1169,13 +1268,12 @@ func (a *Client) GetProjectsProjectIDRobots(params *GetProjectsProjectIDRobotsPa
 
   Return the infor of the specified robot account.
 */
-func (a *Client) GetProjectsProjectIDRobotsRobotID(params *GetProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDRobotsRobotIDOK, error) {
+func (a *Client) GetProjectsProjectIDRobotsRobotID(params *GetProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDRobotsRobotIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDRobotsRobotIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDRobotsRobotID",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/robots/{robot_id}",
@@ -1187,7 +1285,12 @@ func (a *Client) GetProjectsProjectIDRobotsRobotID(params *GetProjectsProjectIDR
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1206,13 +1309,12 @@ func (a *Client) GetProjectsProjectIDRobotsRobotID(params *GetProjectsProjectIDR
 
   Get the scanner registration of the specified project. If no scanner registration is configured for the specified project, the system default scanner registration will be returned.
 */
-func (a *Client) GetProjectsProjectIDScanner(params *GetProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDScannerOK, error) {
+func (a *Client) GetProjectsProjectIDScanner(params *GetProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDScannerOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDScannerParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDScanner",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/scanner",
@@ -1224,7 +1326,12 @@ func (a *Client) GetProjectsProjectIDScanner(params *GetProjectsProjectIDScanner
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1244,13 +1351,12 @@ func (a *Client) GetProjectsProjectIDScanner(params *GetProjectsProjectIDScanner
   Retrieve the system configured scanner registrations as candidates of setting project level scanner.
 
 */
-func (a *Client) GetProjectsProjectIDScannerCandidates(params *GetProjectsProjectIDScannerCandidatesParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDScannerCandidatesOK, error) {
+func (a *Client) GetProjectsProjectIDScannerCandidates(params *GetProjectsProjectIDScannerCandidatesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDScannerCandidatesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDScannerCandidatesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDScannerCandidates",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/scanner/candidates",
@@ -1262,7 +1368,12 @@ func (a *Client) GetProjectsProjectIDScannerCandidates(params *GetProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1281,13 +1392,12 @@ func (a *Client) GetProjectsProjectIDScannerCandidates(params *GetProjectsProjec
 
   Get supportted event types and notify types.
 */
-func (a *Client) GetProjectsProjectIDWebhookEvents(params *GetProjectsProjectIDWebhookEventsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookEventsOK, error) {
+func (a *Client) GetProjectsProjectIDWebhookEvents(params *GetProjectsProjectIDWebhookEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookEventsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDWebhookEventsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDWebhookEvents",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/webhook/events",
@@ -1299,7 +1409,12 @@ func (a *Client) GetProjectsProjectIDWebhookEvents(params *GetProjectsProjectIDW
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1319,13 +1434,12 @@ func (a *Client) GetProjectsProjectIDWebhookEvents(params *GetProjectsProjectIDW
   This endpoint returns webhook jobs of a project.
 
 */
-func (a *Client) GetProjectsProjectIDWebhookJobs(params *GetProjectsProjectIDWebhookJobsParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookJobsOK, error) {
+func (a *Client) GetProjectsProjectIDWebhookJobs(params *GetProjectsProjectIDWebhookJobsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookJobsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDWebhookJobsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDWebhookJobs",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/webhook/jobs",
@@ -1337,7 +1451,12 @@ func (a *Client) GetProjectsProjectIDWebhookJobs(params *GetProjectsProjectIDWeb
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,13 +1476,12 @@ func (a *Client) GetProjectsProjectIDWebhookJobs(params *GetProjectsProjectIDWeb
   This endpoint returns last trigger information of project webhook policy.
 
 */
-func (a *Client) GetProjectsProjectIDWebhookLasttrigger(params *GetProjectsProjectIDWebhookLasttriggerParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookLasttriggerOK, error) {
+func (a *Client) GetProjectsProjectIDWebhookLasttrigger(params *GetProjectsProjectIDWebhookLasttriggerParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookLasttriggerOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDWebhookLasttriggerParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDWebhookLasttrigger",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/webhook/lasttrigger",
@@ -1375,7 +1493,12 @@ func (a *Client) GetProjectsProjectIDWebhookLasttrigger(params *GetProjectsProje
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1395,13 +1518,12 @@ func (a *Client) GetProjectsProjectIDWebhookLasttrigger(params *GetProjectsProje
   This endpoint returns webhook policies of a project.
 
 */
-func (a *Client) GetProjectsProjectIDWebhookPolicies(params *GetProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookPoliciesOK, error) {
+func (a *Client) GetProjectsProjectIDWebhookPolicies(params *GetProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookPoliciesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDWebhookPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDWebhookPolicies",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/webhook/policies",
@@ -1413,7 +1535,12 @@ func (a *Client) GetProjectsProjectIDWebhookPolicies(params *GetProjectsProjectI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1433,13 +1560,12 @@ func (a *Client) GetProjectsProjectIDWebhookPolicies(params *GetProjectsProjectI
   This endpoint returns specified webhook policy of a project.
 
 */
-func (a *Client) GetProjectsProjectIDWebhookPoliciesPolicyID(params *GetProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
+func (a *Client) GetProjectsProjectIDWebhookPoliciesPolicyID(params *GetProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetProjectsProjectIDWebhookPoliciesPolicyIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetProjectsProjectIDWebhookPoliciesPolicyID",
 		Method:             "GET",
 		PathPattern:        "/projects/{project_id}/webhook/policies/{policy_id}",
@@ -1451,7 +1577,12 @@ func (a *Client) GetProjectsProjectIDWebhookPoliciesPolicyID(params *GetProjects
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1470,13 +1601,12 @@ func (a *Client) GetProjectsProjectIDWebhookPoliciesPolicyID(params *GetProjects
 
   List quotas
 */
-func (a *Client) GetQuotas(params *GetQuotasParams, authInfo runtime.ClientAuthInfoWriter) (*GetQuotasOK, error) {
+func (a *Client) GetQuotas(params *GetQuotasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetQuotasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetQuotasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetQuotas",
 		Method:             "GET",
 		PathPattern:        "/quotas",
@@ -1488,7 +1618,12 @@ func (a *Client) GetQuotas(params *GetQuotasParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1507,13 +1642,12 @@ func (a *Client) GetQuotas(params *GetQuotasParams, authInfo runtime.ClientAuthI
 
   Get the specified quota
 */
-func (a *Client) GetQuotasID(params *GetQuotasIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetQuotasIDOK, error) {
+func (a *Client) GetQuotasID(params *GetQuotasIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetQuotasIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetQuotasIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetQuotasID",
 		Method:             "GET",
 		PathPattern:        "/quotas/{id}",
@@ -1525,7 +1659,12 @@ func (a *Client) GetQuotasID(params *GetQuotasIDParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1545,13 +1684,12 @@ func (a *Client) GetQuotasID(params *GetQuotasIDParams, authInfo runtime.ClientA
   List registries according to the query.
 
 */
-func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesOK, error) {
+func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRegistriesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRegistries",
 		Method:             "GET",
 		PathPattern:        "/registries",
@@ -1563,7 +1701,12 @@ func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1582,13 +1725,12 @@ func (a *Client) GetRegistries(params *GetRegistriesParams, authInfo runtime.Cli
 
   This endpoint is for get specific registry.
 */
-func (a *Client) GetRegistriesID(params *GetRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesIDOK, error) {
+func (a *Client) GetRegistriesID(params *GetRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRegistriesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRegistriesID",
 		Method:             "GET",
 		PathPattern:        "/registries/{id}",
@@ -1600,7 +1742,12 @@ func (a *Client) GetRegistriesID(params *GetRegistriesIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1619,13 +1766,12 @@ func (a *Client) GetRegistriesID(params *GetRegistriesIDParams, authInfo runtime
 
   Get the info of one specific registry.
 */
-func (a *Client) GetRegistriesIDInfo(params *GetRegistriesIDInfoParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesIDInfoOK, error) {
+func (a *Client) GetRegistriesIDInfo(params *GetRegistriesIDInfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesIDInfoOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRegistriesIDInfoParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRegistriesIDInfo",
 		Method:             "GET",
 		PathPattern:        "/registries/{id}/info",
@@ -1637,7 +1783,12 @@ func (a *Client) GetRegistriesIDInfo(params *GetRegistriesIDInfoParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1657,13 +1808,12 @@ func (a *Client) GetRegistriesIDInfo(params *GetRegistriesIDInfoParams, authInfo
   This endpoint let user list namespaces of registry according to query.
 
 */
-func (a *Client) GetRegistriesIDNamespace(params *GetRegistriesIDNamespaceParams, authInfo runtime.ClientAuthInfoWriter) (*GetRegistriesIDNamespaceOK, error) {
+func (a *Client) GetRegistriesIDNamespace(params *GetRegistriesIDNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRegistriesIDNamespaceOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRegistriesIDNamespaceParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRegistriesIDNamespace",
 		Method:             "GET",
 		PathPattern:        "/registries/{id}/namespace",
@@ -1675,7 +1825,12 @@ func (a *Client) GetRegistriesIDNamespace(params *GetRegistriesIDNamespaceParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1695,13 +1850,12 @@ func (a *Client) GetRegistriesIDNamespace(params *GetRegistriesIDNamespaceParams
   This endpoint let user list supported adapters.
 
 */
-func (a *Client) GetReplicationAdapters(params *GetReplicationAdaptersParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationAdaptersOK, error) {
+func (a *Client) GetReplicationAdapters(params *GetReplicationAdaptersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationAdaptersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationAdaptersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationAdapters",
 		Method:             "GET",
 		PathPattern:        "/replication/adapters",
@@ -1713,7 +1867,12 @@ func (a *Client) GetReplicationAdapters(params *GetReplicationAdaptersParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1733,13 +1892,12 @@ func (a *Client) GetReplicationAdapters(params *GetReplicationAdaptersParams, au
   This endpoint let user list replication executions.
 
 */
-func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsOK, error) {
+func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationExecutions",
 		Method:             "GET",
 		PathPattern:        "/replication/executions",
@@ -1751,7 +1909,12 @@ func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1771,13 +1934,12 @@ func (a *Client) GetReplicationExecutions(params *GetReplicationExecutionsParams
   This endpoint is for user to get one execution of the replication.
 
 */
-func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDOK, error) {
+func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationExecutionsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationExecutionsID",
 		Method:             "GET",
 		PathPattern:        "/replication/executions/{id}",
@@ -1789,7 +1951,12 @@ func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1809,13 +1976,12 @@ func (a *Client) GetReplicationExecutionsID(params *GetReplicationExecutionsIDPa
   This endpoint is for user to get the task list of one execution.
 
 */
-func (a *Client) GetReplicationExecutionsIDTasks(params *GetReplicationExecutionsIDTasksParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDTasksOK, error) {
+func (a *Client) GetReplicationExecutionsIDTasks(params *GetReplicationExecutionsIDTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDTasksOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationExecutionsIDTasksParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationExecutionsIDTasks",
 		Method:             "GET",
 		PathPattern:        "/replication/executions/{id}/tasks",
@@ -1827,7 +1993,12 @@ func (a *Client) GetReplicationExecutionsIDTasks(params *GetReplicationExecution
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1847,13 +2018,12 @@ func (a *Client) GetReplicationExecutionsIDTasks(params *GetReplicationExecution
   This endpoint is for user to get the log of one task.
 
 */
-func (a *Client) GetReplicationExecutionsIDTasksTaskIDLog(params *GetReplicationExecutionsIDTasksTaskIDLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationExecutionsIDTasksTaskIDLogOK, error) {
+func (a *Client) GetReplicationExecutionsIDTasksTaskIDLog(params *GetReplicationExecutionsIDTasksTaskIDLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationExecutionsIDTasksTaskIDLogOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationExecutionsIDTasksTaskIDLogParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationExecutionsIDTasksTaskIDLog",
 		Method:             "GET",
 		PathPattern:        "/replication/executions/{id}/tasks/{task_id}/log",
@@ -1865,7 +2035,12 @@ func (a *Client) GetReplicationExecutionsIDTasksTaskIDLog(params *GetReplication
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1885,13 +2060,12 @@ func (a *Client) GetReplicationExecutionsIDTasksTaskIDLog(params *GetReplication
   This endpoint let user list replication policies
 
 */
-func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesOK, error) {
+func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationPolicies",
 		Method:             "GET",
 		PathPattern:        "/replication/policies",
@@ -1903,7 +2077,12 @@ func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1923,13 +2102,12 @@ func (a *Client) GetReplicationPolicies(params *GetReplicationPoliciesParams, au
   This endpoint let user get replication policy by specific ID.
 
 */
-func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetReplicationPoliciesIDOK, error) {
+func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetReplicationPoliciesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetReplicationPoliciesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetReplicationPoliciesID",
 		Method:             "GET",
 		PathPattern:        "/replication/policies/{id}",
@@ -1941,7 +2119,12 @@ func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1960,13 +2143,12 @@ func (a *Client) GetReplicationPoliciesID(params *GetReplicationPoliciesIDParams
 
   Get Retention Policy.
 */
-func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDOK, error) {
+func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsID",
 		Method:             "GET",
 		PathPattern:        "/retentions/{id}",
@@ -1978,7 +2160,12 @@ func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1997,13 +2184,12 @@ func (a *Client) GetRetentionsID(params *GetRetentionsIDParams, authInfo runtime
 
   Get a Retention job, job status may be delayed before job service schedule it up.
 */
-func (a *Client) GetRetentionsIDExecutions(params *GetRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDExecutionsOK, error) {
+func (a *Client) GetRetentionsIDExecutions(params *GetRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDExecutionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsIDExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsIDExecutions",
 		Method:             "GET",
 		PathPattern:        "/retentions/{id}/executions",
@@ -2015,7 +2201,12 @@ func (a *Client) GetRetentionsIDExecutions(params *GetRetentionsIDExecutionsPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2034,13 +2225,12 @@ func (a *Client) GetRetentionsIDExecutions(params *GetRetentionsIDExecutionsPara
 
   Get Retention job tasks, each repository as a task.
 */
-func (a *Client) GetRetentionsIDExecutionsEidTasks(params *GetRetentionsIDExecutionsEidTasksParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDExecutionsEidTasksOK, error) {
+func (a *Client) GetRetentionsIDExecutionsEidTasks(params *GetRetentionsIDExecutionsEidTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDExecutionsEidTasksOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsIDExecutionsEidTasksParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsIDExecutionsEidTasks",
 		Method:             "GET",
 		PathPattern:        "/retentions/{id}/executions/{eid}/tasks",
@@ -2052,7 +2242,12 @@ func (a *Client) GetRetentionsIDExecutionsEidTasks(params *GetRetentionsIDExecut
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2071,13 +2266,12 @@ func (a *Client) GetRetentionsIDExecutionsEidTasks(params *GetRetentionsIDExecut
 
   Get Retention job task log, tags ratain or deletion detail will be shown in a table.
 */
-func (a *Client) GetRetentionsIDExecutionsEidTasksTid(params *GetRetentionsIDExecutionsEidTasksTidParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsIDExecutionsEidTasksTidOK, error) {
+func (a *Client) GetRetentionsIDExecutionsEidTasksTid(params *GetRetentionsIDExecutionsEidTasksTidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsIDExecutionsEidTasksTidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsIDExecutionsEidTasksTidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsIDExecutionsEidTasksTid",
 		Method:             "GET",
 		PathPattern:        "/retentions/{id}/executions/{eid}/tasks/{tid}",
@@ -2089,7 +2283,12 @@ func (a *Client) GetRetentionsIDExecutionsEidTasksTid(params *GetRetentionsIDExe
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2108,13 +2307,12 @@ func (a *Client) GetRetentionsIDExecutionsEidTasksTid(params *GetRetentionsIDExe
 
   Get Retention Metadatas.
 */
-func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*GetRetentionsMetadatasOK, error) {
+func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRetentionsMetadatasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetRetentionsMetadatasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetRetentionsMetadatas",
 		Method:             "GET",
 		PathPattern:        "/retentions/metadatas",
@@ -2126,7 +2324,12 @@ func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2146,13 +2349,12 @@ func (a *Client) GetRetentionsMetadatas(params *GetRetentionsMetadatasParams, au
   Returns a list of currently configured scanner registrations.
 
 */
-func (a *Client) GetScanners(params *GetScannersParams, authInfo runtime.ClientAuthInfoWriter) (*GetScannersOK, error) {
+func (a *Client) GetScanners(params *GetScannersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScannersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetScannersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetScanners",
 		Method:             "GET",
 		PathPattern:        "/scanners",
@@ -2164,7 +2366,12 @@ func (a *Client) GetScanners(params *GetScannersParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2184,13 +2391,12 @@ func (a *Client) GetScanners(params *GetScannersParams, authInfo runtime.ClientA
   Retruns the details of the specified scanner registration.
 
 */
-func (a *Client) GetScannersRegistrationID(params *GetScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetScannersRegistrationIDOK, error) {
+func (a *Client) GetScannersRegistrationID(params *GetScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScannersRegistrationIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetScannersRegistrationIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetScannersRegistrationID",
 		Method:             "GET",
 		PathPattern:        "/scanners/{registration_id}",
@@ -2202,7 +2408,12 @@ func (a *Client) GetScannersRegistrationID(params *GetScannersRegistrationIDPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2222,13 +2433,12 @@ func (a *Client) GetScannersRegistrationID(params *GetScannersRegistrationIDPara
   Get the metadata of the specified scanner registration, including the capabilities and customzied properties.
 
 */
-func (a *Client) GetScannersRegistrationIDMetadata(params *GetScannersRegistrationIDMetadataParams, authInfo runtime.ClientAuthInfoWriter) (*GetScannersRegistrationIDMetadataOK, error) {
+func (a *Client) GetScannersRegistrationIDMetadata(params *GetScannersRegistrationIDMetadataParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScannersRegistrationIDMetadataOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetScannersRegistrationIDMetadataParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetScannersRegistrationIDMetadata",
 		Method:             "GET",
 		PathPattern:        "/scanners/{registration_id}/metadata",
@@ -2240,7 +2450,12 @@ func (a *Client) GetScannersRegistrationIDMetadata(params *GetScannersRegistrati
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2259,13 +2474,12 @@ func (a *Client) GetScannersRegistrationIDMetadata(params *GetScannersRegistrati
 
   Get the metrics of the latest scan all process
 */
-func (a *Client) GetScansAllMetrics(params *GetScansAllMetricsParams, authInfo runtime.ClientAuthInfoWriter) (*GetScansAllMetricsOK, error) {
+func (a *Client) GetScansAllMetrics(params *GetScansAllMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScansAllMetricsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetScansAllMetricsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetScansAllMetrics",
 		Method:             "GET",
 		PathPattern:        "/scans/all/metrics",
@@ -2277,7 +2491,12 @@ func (a *Client) GetScansAllMetrics(params *GetScansAllMetricsParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2296,13 +2515,12 @@ func (a *Client) GetScansAllMetrics(params *GetScansAllMetricsParams, authInfo r
 
   Get the metrics of the latest scheduled scan all process
 */
-func (a *Client) GetScansScheduleMetrics(params *GetScansScheduleMetricsParams, authInfo runtime.ClientAuthInfoWriter) (*GetScansScheduleMetricsOK, error) {
+func (a *Client) GetScansScheduleMetrics(params *GetScansScheduleMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetScansScheduleMetricsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetScansScheduleMetricsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetScansScheduleMetrics",
 		Method:             "GET",
 		PathPattern:        "/scans/schedule/metrics",
@@ -2314,7 +2532,12 @@ func (a *Client) GetScansScheduleMetrics(params *GetScansScheduleMetricsParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2334,13 +2557,12 @@ func (a *Client) GetScansScheduleMetrics(params *GetScansScheduleMetricsParams, 
   The Search endpoint returns information about the projects ,repositories  and helm charts offered at public status or related to the current logged in user. The response includes the project, repository list and charts in a proper display order.
 
 */
-func (a *Client) GetSearch(params *GetSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetSearchOK, error) {
+func (a *Client) GetSearch(params *GetSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSearchOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSearchParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSearch",
 		Method:             "GET",
 		PathPattern:        "/search",
@@ -2352,7 +2574,12 @@ func (a *Client) GetSearch(params *GetSearchParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2372,13 +2599,12 @@ func (a *Client) GetSearch(params *GetSearchParams, authInfo runtime.ClientAuthI
   This endpoint is aimed to statistic all of the projects number and repositories number relevant to the logined user, also the public projects number and repositories number. If the user is admin, he can also get total projects number and total repositories number.
 
 */
-func (a *Client) GetStatistics(params *GetStatisticsParams, authInfo runtime.ClientAuthInfoWriter) (*GetStatisticsOK, error) {
+func (a *Client) GetStatistics(params *GetStatisticsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetStatisticsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetStatisticsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetStatistics",
 		Method:             "GET",
 		PathPattern:        "/statistics",
@@ -2390,7 +2616,12 @@ func (a *Client) GetStatistics(params *GetStatisticsParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2409,13 +2640,12 @@ func (a *Client) GetStatistics(params *GetStatisticsParams, authInfo runtime.Cli
 
   Get the system level allowlist of CVE.  This API can be called by all authenticated users.
 */
-func (a *Client) GetSystemCVEAllowlist(params *GetSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemCVEAllowlistOK, error) {
+func (a *Client) GetSystemCVEAllowlist(params *GetSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemCVEAllowlistOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemCVEAllowlistParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemCVEAllowlist",
 		Method:             "GET",
 		PathPattern:        "/system/CVEAllowlist",
@@ -2427,7 +2657,12 @@ func (a *Client) GetSystemCVEAllowlist(params *GetSystemCVEAllowlistParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2446,13 +2681,12 @@ func (a *Client) GetSystemCVEAllowlist(params *GetSystemCVEAllowlistParams, auth
 
   This endpoint let user get latest ten gc results.
 */
-func (a *Client) GetSystemGc(params *GetSystemGcParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcOK, error) {
+func (a *Client) GetSystemGc(params *GetSystemGcParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemGcParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemGc",
 		Method:             "GET",
 		PathPattern:        "/system/gc",
@@ -2464,7 +2698,12 @@ func (a *Client) GetSystemGc(params *GetSystemGcParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2483,13 +2722,12 @@ func (a *Client) GetSystemGc(params *GetSystemGcParams, authInfo runtime.ClientA
 
   This endpoint let user get gc status filtered by specific ID.
 */
-func (a *Client) GetSystemGcID(params *GetSystemGcIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcIDOK, error) {
+func (a *Client) GetSystemGcID(params *GetSystemGcIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemGcIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemGcID",
 		Method:             "GET",
 		PathPattern:        "/system/gc/{id}",
@@ -2501,7 +2739,12 @@ func (a *Client) GetSystemGcID(params *GetSystemGcIDParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2520,13 +2763,12 @@ func (a *Client) GetSystemGcID(params *GetSystemGcIDParams, authInfo runtime.Cli
 
   This endpoint let user get gc job logs filtered by specific ID.
 */
-func (a *Client) GetSystemGcIDLog(params *GetSystemGcIDLogParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcIDLogOK, error) {
+func (a *Client) GetSystemGcIDLog(params *GetSystemGcIDLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcIDLogOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemGcIDLogParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemGcIDLog",
 		Method:             "GET",
 		PathPattern:        "/system/gc/{id}/log",
@@ -2538,7 +2780,12 @@ func (a *Client) GetSystemGcIDLog(params *GetSystemGcIDLogParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2557,13 +2804,12 @@ func (a *Client) GetSystemGcIDLog(params *GetSystemGcIDLogParams, authInfo runti
 
   This endpoint is for get schedule of gc job.
 */
-func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemGcScheduleOK, error) {
+func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemGcScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemGcScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemGcSchedule",
 		Method:             "GET",
 		PathPattern:        "/system/gc/schedule",
@@ -2575,7 +2821,12 @@ func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2594,13 +2845,12 @@ func (a *Client) GetSystemGcSchedule(params *GetSystemGcScheduleParams, authInfo
 
   This endpoint is for getting a schedule for the scan all job, which scans all of images in Harbor.
 */
-func (a *Client) GetSystemScanAllSchedule(params *GetSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*GetSystemScanAllScheduleOK, error) {
+func (a *Client) GetSystemScanAllSchedule(params *GetSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSystemScanAllScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSystemScanAllScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSystemScanAllSchedule",
 		Method:             "GET",
 		PathPattern:        "/system/scanAll/schedule",
@@ -2612,7 +2862,12 @@ func (a *Client) GetSystemScanAllSchedule(params *GetSystemScanAllScheduleParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2632,13 +2887,12 @@ func (a *Client) GetSystemScanAllSchedule(params *GetSystemScanAllScheduleParams
   This API is for retrieving general system info, this can be called by anonymous request.
 
 */
-func (a *Client) GetSysteminfo(params *GetSysteminfoParams, authInfo runtime.ClientAuthInfoWriter) (*GetSysteminfoOK, error) {
+func (a *Client) GetSysteminfo(params *GetSysteminfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSysteminfoOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSysteminfoParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSysteminfo",
 		Method:             "GET",
 		PathPattern:        "/systeminfo",
@@ -2650,7 +2904,12 @@ func (a *Client) GetSysteminfo(params *GetSysteminfoParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2670,13 +2929,12 @@ func (a *Client) GetSysteminfo(params *GetSysteminfoParams, authInfo runtime.Cli
   This endpoint is for downloading a default root certificate.
 
 */
-func (a *Client) GetSysteminfoGetcert(params *GetSysteminfoGetcertParams, authInfo runtime.ClientAuthInfoWriter) (*GetSysteminfoGetcertOK, error) {
+func (a *Client) GetSysteminfoGetcert(params *GetSysteminfoGetcertParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSysteminfoGetcertOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSysteminfoGetcertParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSysteminfoGetcert",
 		Method:             "GET",
 		PathPattern:        "/systeminfo/getcert",
@@ -2688,7 +2946,12 @@ func (a *Client) GetSysteminfoGetcert(params *GetSysteminfoGetcertParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2708,13 +2971,12 @@ func (a *Client) GetSysteminfoGetcert(params *GetSysteminfoGetcertParams, authIn
   This endpoint is for retrieving system volume info that only provides for admin user.
 
 */
-func (a *Client) GetSysteminfoVolumes(params *GetSysteminfoVolumesParams, authInfo runtime.ClientAuthInfoWriter) (*GetSysteminfoVolumesOK, error) {
+func (a *Client) GetSysteminfoVolumes(params *GetSysteminfoVolumesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetSysteminfoVolumesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetSysteminfoVolumesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetSysteminfoVolumes",
 		Method:             "GET",
 		PathPattern:        "/systeminfo/volumes",
@@ -2726,7 +2988,12 @@ func (a *Client) GetSysteminfoVolumes(params *GetSysteminfoVolumesParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2745,13 +3012,12 @@ func (a *Client) GetSysteminfoVolumes(params *GetSysteminfoVolumesParams, authIn
 
   Get all user groups information
 */
-func (a *Client) GetUsergroups(params *GetUsergroupsParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsergroupsOK, error) {
+func (a *Client) GetUsergroups(params *GetUsergroupsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsergroupsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsergroupsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsergroups",
 		Method:             "GET",
 		PathPattern:        "/usergroups",
@@ -2763,7 +3029,12 @@ func (a *Client) GetUsergroups(params *GetUsergroupsParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2782,13 +3053,12 @@ func (a *Client) GetUsergroups(params *GetUsergroupsParams, authInfo runtime.Cli
 
   Get user group information
 */
-func (a *Client) GetUsergroupsGroupID(params *GetUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsergroupsGroupIDOK, error) {
+func (a *Client) GetUsergroupsGroupID(params *GetUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsergroupsGroupIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsergroupsGroupIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsergroupsGroupID",
 		Method:             "GET",
 		PathPattern:        "/usergroups/{group_id}",
@@ -2800,7 +3070,12 @@ func (a *Client) GetUsergroupsGroupID(params *GetUsergroupsGroupIDParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2820,13 +3095,12 @@ func (a *Client) GetUsergroupsGroupID(params *GetUsergroupsGroupIDParams, authIn
   This endpoint is for user to search registered users, support for filtering results with username.Notice, by now this operation is only for administrator.
 
 */
-func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersOK, error) {
+func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsers",
 		Method:             "GET",
 		PathPattern:        "/users",
@@ -2838,7 +3112,12 @@ func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInf
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2858,13 +3137,12 @@ func (a *Client) GetUsers(params *GetUsersParams, authInfo runtime.ClientAuthInf
   This endpoint is to get the current user information.
 
 */
-func (a *Client) GetUsersCurrent(params *GetUsersCurrentParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersCurrentOK, error) {
+func (a *Client) GetUsersCurrent(params *GetUsersCurrentParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersCurrentOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsersCurrentParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsersCurrent",
 		Method:             "GET",
 		PathPattern:        "/users/current",
@@ -2876,7 +3154,12 @@ func (a *Client) GetUsersCurrent(params *GetUsersCurrentParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2896,13 +3179,12 @@ func (a *Client) GetUsersCurrent(params *GetUsersCurrentParams, authInfo runtime
   This endpoint is to get the current user permissions.
 
 */
-func (a *Client) GetUsersCurrentPermissions(params *GetUsersCurrentPermissionsParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersCurrentPermissionsOK, error) {
+func (a *Client) GetUsersCurrentPermissions(params *GetUsersCurrentPermissionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersCurrentPermissionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsersCurrentPermissionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsersCurrentPermissions",
 		Method:             "GET",
 		PathPattern:        "/users/current/permissions",
@@ -2914,7 +3196,12 @@ func (a *Client) GetUsersCurrentPermissions(params *GetUsersCurrentPermissionsPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2934,13 +3221,12 @@ func (a *Client) GetUsersCurrentPermissions(params *GetUsersCurrentPermissionsPa
   This endpoint is to search the users by username.
 
 */
-func (a *Client) GetUsersSearch(params *GetUsersSearchParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersSearchOK, error) {
+func (a *Client) GetUsersSearch(params *GetUsersSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersSearchOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsersSearchParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsersSearch",
 		Method:             "GET",
 		PathPattern:        "/users/search",
@@ -2952,7 +3238,12 @@ func (a *Client) GetUsersSearch(params *GetUsersSearchParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -2972,13 +3263,12 @@ func (a *Client) GetUsersSearch(params *GetUsersSearchParams, authInfo runtime.C
   Get user's profile with user id.
 
 */
-func (a *Client) GetUsersUserID(params *GetUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*GetUsersUserIDOK, error) {
+func (a *Client) GetUsersUserID(params *GetUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetUsersUserIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetUsersUserIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "GetUsersUserID",
 		Method:             "GET",
 		PathPattern:        "/users/{user_id}",
@@ -2990,7 +3280,12 @@ func (a *Client) GetUsersUserID(params *GetUsersUserIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3009,13 +3304,12 @@ func (a *Client) GetUsersUserID(params *GetUsersUserIDParams, authInfo runtime.C
 
   Stop a Retention job, only support "stop" action now.
 */
-func (a *Client) PatchRetentionsIDExecutionsEid(params *PatchRetentionsIDExecutionsEidParams, authInfo runtime.ClientAuthInfoWriter) (*PatchRetentionsIDExecutionsEidOK, error) {
+func (a *Client) PatchRetentionsIDExecutionsEid(params *PatchRetentionsIDExecutionsEidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PatchRetentionsIDExecutionsEidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPatchRetentionsIDExecutionsEidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PatchRetentionsIDExecutionsEid",
 		Method:             "PATCH",
 		PathPattern:        "/retentions/{id}/executions/{eid}",
@@ -3027,7 +3321,12 @@ func (a *Client) PatchRetentionsIDExecutionsEid(params *PatchRetentionsIDExecuti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3046,13 +3345,12 @@ func (a *Client) PatchRetentionsIDExecutionsEid(params *PatchRetentionsIDExecuti
 
   Mark label to the specified chart version.
 */
-func (a *Client) PostChartrepoRepoChartsNameVersionLabels(params *PostChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*PostChartrepoRepoChartsNameVersionLabelsOK, error) {
+func (a *Client) PostChartrepoRepoChartsNameVersionLabels(params *PostChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostChartrepoRepoChartsNameVersionLabelsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostChartrepoRepoChartsNameVersionLabelsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostChartrepoRepoChartsNameVersionLabels",
 		Method:             "POST",
 		PathPattern:        "/chartrepo/{repo}/charts/{name}/{version}/labels",
@@ -3064,7 +3362,12 @@ func (a *Client) PostChartrepoRepoChartsNameVersionLabels(params *PostChartrepoR
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3084,13 +3387,12 @@ func (a *Client) PostChartrepoRepoChartsNameVersionLabels(params *PostChartrepoR
   Test connection and authentication with email server.
 
 */
-func (a *Client) PostEmailPing(params *PostEmailPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostEmailPingOK, error) {
+func (a *Client) PostEmailPing(params *PostEmailPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostEmailPingOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostEmailPingParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostEmailPing",
 		Method:             "POST",
 		PathPattern:        "/email/ping",
@@ -3102,7 +3404,12 @@ func (a *Client) PostEmailPing(params *PostEmailPingParams, authInfo runtime.Cli
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3122,13 +3429,12 @@ func (a *Client) PostEmailPing(params *PostEmailPingParams, authInfo runtime.Cli
   This endpoint let user creates a label.
 
 */
-func (a *Client) PostLabels(params *PostLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*PostLabelsCreated, error) {
+func (a *Client) PostLabels(params *PostLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostLabelsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostLabelsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostLabels",
 		Method:             "POST",
 		PathPattern:        "/labels",
@@ -3140,7 +3446,12 @@ func (a *Client) PostLabels(params *PostLabelsParams, authInfo runtime.ClientAut
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3160,13 +3471,12 @@ func (a *Client) PostLabels(params *PostLabelsParams, authInfo runtime.ClientAut
   This endpoint ping the available ldap service for test related configuration parameters.
 
 */
-func (a *Client) PostLdapPing(params *PostLdapPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostLdapPingOK, error) {
+func (a *Client) PostLdapPing(params *PostLdapPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostLdapPingOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostLdapPingParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostLdapPing",
 		Method:             "POST",
 		PathPattern:        "/ldap/ping",
@@ -3178,7 +3488,12 @@ func (a *Client) PostLdapPing(params *PostLdapPingParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3199,13 +3514,12 @@ func (a *Client) PostLdapPing(params *PostLdapPingParams, authInfo runtime.Clien
 If have errors when import user, will return the list of importing failed uid and the failed reason.
 
 */
-func (a *Client) PostLdapUsersImport(params *PostLdapUsersImportParams, authInfo runtime.ClientAuthInfoWriter) (*PostLdapUsersImportOK, error) {
+func (a *Client) PostLdapUsersImport(params *PostLdapUsersImportParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostLdapUsersImportOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostLdapUsersImportParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostLdapUsersImport",
 		Method:             "POST",
 		PathPattern:        "/ldap/users/import",
@@ -3217,7 +3531,12 @@ func (a *Client) PostLdapUsersImport(params *PostLdapUsersImportParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3237,13 +3556,12 @@ func (a *Client) PostLdapUsersImport(params *PostLdapUsersImportParams, authInfo
   This endpoint add an immutable tag rule to the project
 
 */
-func (a *Client) PostProjectsProjectIDImmutabletagrules(params *PostProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDImmutabletagrulesOK, error) {
+func (a *Client) PostProjectsProjectIDImmutabletagrules(params *PostProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDImmutabletagrulesOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDImmutabletagrulesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDImmutabletagrules",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/immutabletagrules",
@@ -3255,7 +3573,12 @@ func (a *Client) PostProjectsProjectIDImmutabletagrules(params *PostProjectsProj
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3274,13 +3597,12 @@ func (a *Client) PostProjectsProjectIDImmutabletagrules(params *PostProjectsProj
 
   Create project member relationship, the member can be one of the user_member and group_member,  The user_member need to specify user_id or username. If the user already exist in harbor DB, specify the user_id,  If does not exist in harbor DB, it will SearchAndOnBoard the user. The group_member need to specify id or ldap_group_dn. If the group already exist in harbor DB. specify the user group's id,  If does not exist, it will SearchAndOnBoard the group.
 */
-func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMembersCreated, error) {
+func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMembersCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDMembersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDMembers",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/members",
@@ -3292,7 +3614,12 @@ func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembe
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3312,13 +3639,12 @@ func (a *Client) PostProjectsProjectIDMembers(params *PostProjectsProjectIDMembe
   This endpoint is aimed to add metadata of a project.
 
 */
-func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDMetadatasOK, error) {
+func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDMetadatasOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDMetadatasParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDMetadatas",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/metadatas",
@@ -3330,7 +3656,12 @@ func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMet
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3349,13 +3680,12 @@ func (a *Client) PostProjectsProjectIDMetadatas(params *PostProjectsProjectIDMet
 
   Create a robot account for project
 */
-func (a *Client) PostProjectsProjectIDRobots(params *PostProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDRobotsCreated, error) {
+func (a *Client) PostProjectsProjectIDRobots(params *PostProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDRobotsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDRobotsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDRobots",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/robots",
@@ -3367,7 +3697,12 @@ func (a *Client) PostProjectsProjectIDRobots(params *PostProjectsProjectIDRobots
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3387,13 +3722,12 @@ func (a *Client) PostProjectsProjectIDRobots(params *PostProjectsProjectIDRobots
   This endpoint create a webhook policy if the project does not have one.
 
 */
-func (a *Client) PostProjectsProjectIDWebhookPolicies(params *PostProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDWebhookPoliciesCreated, error) {
+func (a *Client) PostProjectsProjectIDWebhookPolicies(params *PostProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDWebhookPoliciesCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDWebhookPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDWebhookPolicies",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/webhook/policies",
@@ -3405,7 +3739,12 @@ func (a *Client) PostProjectsProjectIDWebhookPolicies(params *PostProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3425,13 +3764,12 @@ func (a *Client) PostProjectsProjectIDWebhookPolicies(params *PostProjectsProjec
   This endpoint tests webhook connection of a project.
 
 */
-func (a *Client) PostProjectsProjectIDWebhookPoliciesTest(params *PostProjectsProjectIDWebhookPoliciesTestParams, authInfo runtime.ClientAuthInfoWriter) (*PostProjectsProjectIDWebhookPoliciesTestOK, error) {
+func (a *Client) PostProjectsProjectIDWebhookPoliciesTest(params *PostProjectsProjectIDWebhookPoliciesTestParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostProjectsProjectIDWebhookPoliciesTestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostProjectsProjectIDWebhookPoliciesTestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostProjectsProjectIDWebhookPoliciesTest",
 		Method:             "POST",
 		PathPattern:        "/projects/{project_id}/webhook/policies/test",
@@ -3443,7 +3781,12 @@ func (a *Client) PostProjectsProjectIDWebhookPoliciesTest(params *PostProjectsPr
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3463,13 +3806,12 @@ func (a *Client) PostProjectsProjectIDWebhookPoliciesTest(params *PostProjectsPr
   This endpoint is for user to create a new registry.
 
 */
-func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*PostRegistriesCreated, error) {
+func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRegistriesCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostRegistriesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostRegistries",
 		Method:             "POST",
 		PathPattern:        "/registries",
@@ -3481,7 +3823,12 @@ func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3501,13 +3848,12 @@ func (a *Client) PostRegistries(params *PostRegistriesParams, authInfo runtime.C
   This endpoint checks status of a registry, the registry can be given by ID or URL (together with credential)
 
 */
-func (a *Client) PostRegistriesPing(params *PostRegistriesPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostRegistriesPingOK, error) {
+func (a *Client) PostRegistriesPing(params *PostRegistriesPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRegistriesPingOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostRegistriesPingParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostRegistriesPing",
 		Method:             "POST",
 		PathPattern:        "/registries/ping",
@@ -3519,7 +3865,12 @@ func (a *Client) PostRegistriesPing(params *PostRegistriesPingParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3539,13 +3890,12 @@ func (a *Client) PostRegistriesPing(params *PostRegistriesPingParams, authInfo r
   This endpoint is for user to start one execution of the replication.
 
 */
-func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationExecutionsCreated, error) {
+func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationExecutionsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostReplicationExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostReplicationExecutions",
 		Method:             "POST",
 		PathPattern:        "/replication/executions",
@@ -3557,7 +3907,12 @@ func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3577,13 +3932,12 @@ func (a *Client) PostReplicationExecutions(params *PostReplicationExecutionsPara
   This endpoint let user create a replication policy
 
 */
-func (a *Client) PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*PostReplicationPoliciesCreated, error) {
+func (a *Client) PostReplicationPolicies(params *PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostReplicationPoliciesCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostReplicationPoliciesParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostReplicationPolicies",
 		Method:             "POST",
 		PathPattern:        "/replication/policies",
@@ -3595,7 +3949,12 @@ func (a *Client) PostReplicationPolicies(params *PostReplicationPoliciesParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3617,13 +3976,12 @@ You can check project metadatas to find whether a retention policy is already bi
 This method should only be called when no retention policy binded to project yet.
 
 */
-func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostRetentionsCreated, error) {
+func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRetentionsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostRetentionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostRetentions",
 		Method:             "POST",
 		PathPattern:        "/retentions",
@@ -3635,7 +3993,12 @@ func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3654,13 +4017,12 @@ func (a *Client) PostRetentions(params *PostRetentionsParams, authInfo runtime.C
 
   Trigger a Retention job, if dry_run is True, nothing would be deleted actually.
 */
-func (a *Client) PostRetentionsIDExecutions(params *PostRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*PostRetentionsIDExecutionsOK, error) {
+func (a *Client) PostRetentionsIDExecutions(params *PostRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostRetentionsIDExecutionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostRetentionsIDExecutionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostRetentionsIDExecutions",
 		Method:             "POST",
 		PathPattern:        "/retentions/{id}/executions",
@@ -3672,7 +4034,12 @@ func (a *Client) PostRetentionsIDExecutions(params *PostRetentionsIDExecutionsPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3692,13 +4059,12 @@ func (a *Client) PostRetentionsIDExecutions(params *PostRetentionsIDExecutionsPa
   Pings scanner adapter to test endpoint URL and authorization settings.
 
 */
-func (a *Client) PostScannersPing(params *PostScannersPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostScannersPingOK, error) {
+func (a *Client) PostScannersPing(params *PostScannersPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostScannersPingOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostScannersPingParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostScannersPing",
 		Method:             "POST",
 		PathPattern:        "/scanners/ping",
@@ -3710,7 +4076,12 @@ func (a *Client) PostScannersPing(params *PostScannersPingParams, authInfo runti
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3730,13 +4101,12 @@ func (a *Client) PostScannersPing(params *PostScannersPingParams, authInfo runti
   This endpoint is for update gc schedule.
 
 */
-func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemGcScheduleOK, error) {
+func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemGcScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostSystemGcScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostSystemGcSchedule",
 		Method:             "POST",
 		PathPattern:        "/system/gc/schedule",
@@ -3748,7 +4118,12 @@ func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3767,13 +4142,12 @@ func (a *Client) PostSystemGcSchedule(params *PostSystemGcScheduleParams, authIn
 
   Test the OIDC endpoint, the setting of the endpoint is provided in the request.  This API can only be called by system admin.
 */
-func (a *Client) PostSystemOidcPing(params *PostSystemOidcPingParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemOidcPingOK, error) {
+func (a *Client) PostSystemOidcPing(params *PostSystemOidcPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemOidcPingOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostSystemOidcPingParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostSystemOidcPing",
 		Method:             "POST",
 		PathPattern:        "/system/oidc/ping",
@@ -3785,7 +4159,12 @@ func (a *Client) PostSystemOidcPing(params *PostSystemOidcPingParams, authInfo r
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3805,13 +4184,12 @@ func (a *Client) PostSystemOidcPing(params *PostSystemOidcPingParams, authInfo r
   This endpoint is for creating a schedule or a manual trigger for the scan all job, which scans all of images in Harbor.
 
 */
-func (a *Client) PostSystemScanAllSchedule(params *PostSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PostSystemScanAllScheduleOK, error) {
+func (a *Client) PostSystemScanAllSchedule(params *PostSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostSystemScanAllScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostSystemScanAllScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostSystemScanAllSchedule",
 		Method:             "POST",
 		PathPattern:        "/system/scanAll/schedule",
@@ -3823,7 +4201,12 @@ func (a *Client) PostSystemScanAllSchedule(params *PostSystemScanAllSchedulePara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3842,13 +4225,12 @@ func (a *Client) PostSystemScanAllSchedule(params *PostSystemScanAllSchedulePara
 
   Create user group information
 */
-func (a *Client) PostUsergroups(params *PostUsergroupsParams, authInfo runtime.ClientAuthInfoWriter) (*PostUsergroupsCreated, error) {
+func (a *Client) PostUsergroups(params *PostUsergroupsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostUsergroupsCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostUsergroupsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostUsergroups",
 		Method:             "POST",
 		PathPattern:        "/usergroups",
@@ -3860,7 +4242,12 @@ func (a *Client) PostUsergroups(params *PostUsergroupsParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3880,13 +4267,12 @@ func (a *Client) PostUsergroups(params *PostUsergroupsParams, authInfo runtime.C
   This endpoint is to create a user if the user does not already exist.
 
 */
-func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter) (*PostUsersCreated, error) {
+func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostUsersCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostUsersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostUsers",
 		Method:             "POST",
 		PathPattern:        "/users",
@@ -3898,7 +4284,12 @@ func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthI
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3918,13 +4309,12 @@ func (a *Client) PostUsers(params *PostUsersParams, authInfo runtime.ClientAuthI
   This endpoint is for modifying system configurations that only provides for admin user.
 
 */
-func (a *Client) PutConfigurations(params *PutConfigurationsParams, authInfo runtime.ClientAuthInfoWriter) (*PutConfigurationsOK, error) {
+func (a *Client) PutConfigurations(params *PutConfigurationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutConfigurationsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutConfigurationsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutConfigurations",
 		Method:             "PUT",
 		PathPattern:        "/configurations",
@@ -3936,7 +4326,12 @@ func (a *Client) PutConfigurations(params *PutConfigurationsParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3956,13 +4351,12 @@ func (a *Client) PutConfigurations(params *PutConfigurationsParams, authInfo run
   This endpoint let user update label properties.
 
 */
-func (a *Client) PutLabelsID(params *PutLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutLabelsIDOK, error) {
+func (a *Client) PutLabelsID(params *PutLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutLabelsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutLabelsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutLabelsID",
 		Method:             "PUT",
 		PathPattern:        "/labels/{id}",
@@ -3974,7 +4368,12 @@ func (a *Client) PutLabelsID(params *PutLabelsIDParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -3991,13 +4390,12 @@ func (a *Client) PutLabelsID(params *PutLabelsIDParams, authInfo runtime.ClientA
 /*
   PutProjectsProjectIDImmutabletagrulesID updates the immutable tag rule or enable or disable the rule
 */
-func (a *Client) PutProjectsProjectIDImmutabletagrulesID(params *PutProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDImmutabletagrulesIDOK, error) {
+func (a *Client) PutProjectsProjectIDImmutabletagrulesID(params *PutProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDImmutabletagrulesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDImmutabletagrulesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDImmutabletagrulesID",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/immutabletagrules/{id}",
@@ -4009,7 +4407,12 @@ func (a *Client) PutProjectsProjectIDImmutabletagrulesID(params *PutProjectsProj
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4028,13 +4431,12 @@ func (a *Client) PutProjectsProjectIDImmutabletagrulesID(params *PutProjectsProj
 
   Update project member relationship
 */
-func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMembersMidOK, error) {
+func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMembersMidOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDMembersMidParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDMembersMid",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/members/{mid}",
@@ -4046,7 +4448,12 @@ func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMemb
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4066,13 +4473,12 @@ func (a *Client) PutProjectsProjectIDMembersMid(params *PutProjectsProjectIDMemb
   This endpoint is aimed to update the metadata of a project.
 
 */
-func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDMetadatasMetaNameOK, error) {
+func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDMetadatasMetaNameOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDMetadatasMetaNameParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDMetadatasMetaName",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/metadatas/{meta_name}",
@@ -4084,7 +4490,12 @@ func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjec
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4103,13 +4514,12 @@ func (a *Client) PutProjectsProjectIDMetadatasMetaName(params *PutProjectsProjec
 
   Used to disable/enable a specified robot account.
 */
-func (a *Client) PutProjectsProjectIDRobotsRobotID(params *PutProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDRobotsRobotIDOK, error) {
+func (a *Client) PutProjectsProjectIDRobotsRobotID(params *PutProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDRobotsRobotIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDRobotsRobotIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDRobotsRobotID",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/robots/{robot_id}",
@@ -4121,7 +4531,12 @@ func (a *Client) PutProjectsProjectIDRobotsRobotID(params *PutProjectsProjectIDR
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4141,13 +4556,12 @@ func (a *Client) PutProjectsProjectIDRobotsRobotID(params *PutProjectsProjectIDR
   This endpoint is aimed to update the webhook policy of a project.
 
 */
-func (a *Client) PutProjectsProjectIDWebhookPoliciesPolicyID(params *PutProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
+func (a *Client) PutProjectsProjectIDWebhookPoliciesPolicyID(params *PutProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDWebhookPoliciesPolicyIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDWebhookPoliciesPolicyID",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/webhook/policies/{policy_id}",
@@ -4159,7 +4573,12 @@ func (a *Client) PutProjectsProjectIDWebhookPoliciesPolicyID(params *PutProjects
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4178,13 +4597,12 @@ func (a *Client) PutProjectsProjectIDWebhookPoliciesPolicyID(params *PutProjects
 
   Update hard limits of the specified quota
 */
-func (a *Client) PutQuotasID(params *PutQuotasIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutQuotasIDOK, error) {
+func (a *Client) PutQuotasID(params *PutQuotasIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutQuotasIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutQuotasIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutQuotasID",
 		Method:             "PUT",
 		PathPattern:        "/quotas/{id}",
@@ -4196,7 +4614,12 @@ func (a *Client) PutQuotasID(params *PutQuotasIDParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4216,13 +4639,12 @@ func (a *Client) PutQuotasID(params *PutQuotasIDParams, authInfo runtime.ClientA
   This endpoint is for update a given registry.
 
 */
-func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutRegistriesIDOK, error) {
+func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutRegistriesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutRegistriesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutRegistriesID",
 		Method:             "PUT",
 		PathPattern:        "/registries/{id}",
@@ -4234,7 +4656,12 @@ func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4254,13 +4681,12 @@ func (a *Client) PutRegistriesID(params *PutRegistriesIDParams, authInfo runtime
   This endpoint is for user to stop one execution of the replication.
 
 */
-func (a *Client) PutReplicationExecutionsID(params *PutReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutReplicationExecutionsIDOK, error) {
+func (a *Client) PutReplicationExecutionsID(params *PutReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutReplicationExecutionsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutReplicationExecutionsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutReplicationExecutionsID",
 		Method:             "PUT",
 		PathPattern:        "/replication/executions/{id}",
@@ -4272,7 +4698,12 @@ func (a *Client) PutReplicationExecutionsID(params *PutReplicationExecutionsIDPa
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4292,13 +4723,12 @@ func (a *Client) PutReplicationExecutionsID(params *PutReplicationExecutionsIDPa
   This endpoint let user update policy.
 
 */
-func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutReplicationPoliciesIDOK, error) {
+func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutReplicationPoliciesIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutReplicationPoliciesIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutReplicationPoliciesID",
 		Method:             "PUT",
 		PathPattern:        "/replication/policies/{id}",
@@ -4310,7 +4740,12 @@ func (a *Client) PutReplicationPoliciesID(params *PutReplicationPoliciesIDParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4332,13 +4767,12 @@ You can check project metadatas to find whether a retention policy is already bi
 This method should only be called when retention policy has already binded to project.
 
 */
-func (a *Client) PutRetentionsID(params *PutRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutRetentionsIDOK, error) {
+func (a *Client) PutRetentionsID(params *PutRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutRetentionsIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutRetentionsIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutRetentionsID",
 		Method:             "PUT",
 		PathPattern:        "/retentions/{id}",
@@ -4350,7 +4784,12 @@ func (a *Client) PutRetentionsID(params *PutRetentionsIDParams, authInfo runtime
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4369,13 +4808,12 @@ func (a *Client) PutRetentionsID(params *PutRetentionsIDParams, authInfo runtime
 
   This API overwrites the system level allowlist of CVE with the list in request body.  Only system Admin has permission to call this API.
 */
-func (a *Client) PutSystemCVEAllowlist(params *PutSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemCVEAllowlistOK, error) {
+func (a *Client) PutSystemCVEAllowlist(params *PutSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemCVEAllowlistOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutSystemCVEAllowlistParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutSystemCVEAllowlist",
 		Method:             "PUT",
 		PathPattern:        "/system/CVEAllowlist",
@@ -4387,7 +4825,12 @@ func (a *Client) PutSystemCVEAllowlist(params *PutSystemCVEAllowlistParams, auth
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4407,13 +4850,12 @@ func (a *Client) PutSystemCVEAllowlist(params *PutSystemCVEAllowlistParams, auth
   This endpoint is for update gc schedule.
 
 */
-func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemGcScheduleOK, error) {
+func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemGcScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutSystemGcScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutSystemGcSchedule",
 		Method:             "PUT",
 		PathPattern:        "/system/gc/schedule",
@@ -4425,7 +4867,12 @@ func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4445,13 +4892,12 @@ func (a *Client) PutSystemGcSchedule(params *PutSystemGcScheduleParams, authInfo
   This endpoint is for updating the schedule of scan all job, which scans all of images in Harbor.
 
 */
-func (a *Client) PutSystemScanAllSchedule(params *PutSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*PutSystemScanAllScheduleOK, error) {
+func (a *Client) PutSystemScanAllSchedule(params *PutSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutSystemScanAllScheduleOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutSystemScanAllScheduleParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutSystemScanAllSchedule",
 		Method:             "PUT",
 		PathPattern:        "/system/scanAll/schedule",
@@ -4463,7 +4909,12 @@ func (a *Client) PutSystemScanAllSchedule(params *PutSystemScanAllScheduleParams
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4482,13 +4933,12 @@ func (a *Client) PutSystemScanAllSchedule(params *PutSystemScanAllScheduleParams
 
   Update user group information
 */
-func (a *Client) PutUsergroupsGroupID(params *PutUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsergroupsGroupIDOK, error) {
+func (a *Client) PutUsergroupsGroupID(params *PutUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsergroupsGroupIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsergroupsGroupIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsergroupsGroupID",
 		Method:             "PUT",
 		PathPattern:        "/usergroups/{group_id}",
@@ -4500,7 +4950,12 @@ func (a *Client) PutUsergroupsGroupID(params *PutUsergroupsGroupIDParams, authIn
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4520,13 +4975,12 @@ func (a *Client) PutUsergroupsGroupID(params *PutUsergroupsGroupIDParams, authIn
   This endpoint let a registered user change his profile.
 
 */
-func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDOK, error) {
+func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsersUserIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsersUserID",
 		Method:             "PUT",
 		PathPattern:        "/users/{user_id}",
@@ -4538,7 +4992,12 @@ func (a *Client) PutUsersUserID(params *PutUsersUserIDParams, authInfo runtime.C
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4560,13 +5019,12 @@ Once this API returns with successful status, the old secret will be invalid, as
 for a user.
 
 */
-func (a *Client) PutUsersUserIDCliSecret(params *PutUsersUserIDCliSecretParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDCliSecretOK, error) {
+func (a *Client) PutUsersUserIDCliSecret(params *PutUsersUserIDCliSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDCliSecretOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsersUserIDCliSecretParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsersUserIDCliSecret",
 		Method:             "PUT",
 		PathPattern:        "/users/{user_id}/cli_secret",
@@ -4578,7 +5036,12 @@ func (a *Client) PutUsersUserIDCliSecret(params *PutUsersUserIDCliSecretParams, 
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4598,13 +5061,12 @@ func (a *Client) PutUsersUserIDCliSecret(params *PutUsersUserIDCliSecretParams, 
   This endpoint is for user to update password. Users with the admin role can change any user's password. Guest users can change only their own password.
 
 */
-func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDPasswordOK, error) {
+func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDPasswordOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsersUserIDPasswordParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsersUserIDPassword",
 		Method:             "PUT",
 		PathPattern:        "/users/{user_id}/password",
@@ -4616,7 +5078,12 @@ func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -4637,13 +5104,12 @@ func (a *Client) PutUsersUserIDPassword(params *PutUsersUserIDPasswordParams, au
 of Harbor.
 
 */
-func (a *Client) PutUsersUserIDSysadmin(params *PutUsersUserIDSysadminParams, authInfo runtime.ClientAuthInfoWriter) (*PutUsersUserIDSysadminOK, error) {
+func (a *Client) PutUsersUserIDSysadmin(params *PutUsersUserIDSysadminParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutUsersUserIDSysadminOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutUsersUserIDSysadminParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutUsersUserIDSysadmin",
 		Method:             "PUT",
 		PathPattern:        "/users/{user_id}/sysadmin",
@@ -4655,7 +5121,12 @@ func (a *Client) PutUsersUserIDSysadmin(params *PutUsersUserIDSysadminParams, au
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/internal/legacyapi/client/scanners/scanners_client.go
+++ b/apiv2/internal/legacyapi/client/scanners/scanners_client.go
@@ -25,17 +25,20 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteScannersRegistrationID(params *DeleteScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteScannersRegistrationIDOK, error)
+	DeleteScannersRegistrationID(params *DeleteScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteScannersRegistrationIDOK, error)
 
-	PatchScannersRegistrationID(params *PatchScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*PatchScannersRegistrationIDOK, error)
+	PatchScannersRegistrationID(params *PatchScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PatchScannersRegistrationIDOK, error)
 
-	PostScanners(params *PostScannersParams, authInfo runtime.ClientAuthInfoWriter) (*PostScannersCreated, error)
+	PostScanners(params *PostScannersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostScannersCreated, error)
 
-	PutProjectsProjectIDScanner(params *PutProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDScannerOK, error)
+	PutProjectsProjectIDScanner(params *PutProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDScannerOK, error)
 
-	PutScannersRegistrationID(params *PutScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutScannersRegistrationIDOK, error)
+	PutScannersRegistrationID(params *PutScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutScannersRegistrationIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -46,13 +49,12 @@ type ClientService interface {
   Deletes the specified scanner registration.
 
 */
-func (a *Client) DeleteScannersRegistrationID(params *DeleteScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteScannersRegistrationIDOK, error) {
+func (a *Client) DeleteScannersRegistrationID(params *DeleteScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteScannersRegistrationIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteScannersRegistrationIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "DeleteScannersRegistrationID",
 		Method:             "DELETE",
 		PathPattern:        "/scanners/{registration_id}",
@@ -64,7 +66,12 @@ func (a *Client) DeleteScannersRegistrationID(params *DeleteScannersRegistration
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -84,13 +91,12 @@ func (a *Client) DeleteScannersRegistrationID(params *DeleteScannersRegistration
   Set the specified scanner registration as the system default one.
 
 */
-func (a *Client) PatchScannersRegistrationID(params *PatchScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*PatchScannersRegistrationIDOK, error) {
+func (a *Client) PatchScannersRegistrationID(params *PatchScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PatchScannersRegistrationIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPatchScannersRegistrationIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PatchScannersRegistrationID",
 		Method:             "PATCH",
 		PathPattern:        "/scanners/{registration_id}",
@@ -102,7 +108,12 @@ func (a *Client) PatchScannersRegistrationID(params *PatchScannersRegistrationID
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -122,13 +133,12 @@ func (a *Client) PatchScannersRegistrationID(params *PatchScannersRegistrationID
   Creats a new scanner registration with the given data.
 
 */
-func (a *Client) PostScanners(params *PostScannersParams, authInfo runtime.ClientAuthInfoWriter) (*PostScannersCreated, error) {
+func (a *Client) PostScanners(params *PostScannersParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PostScannersCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPostScannersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PostScanners",
 		Method:             "POST",
 		PathPattern:        "/scanners",
@@ -140,7 +150,12 @@ func (a *Client) PostScanners(params *PostScannersParams, authInfo runtime.Clien
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -159,13 +174,12 @@ func (a *Client) PostScanners(params *PostScannersParams, authInfo runtime.Clien
 
   Set one of the system configured scanner registration as the indepndent scanner of the specified project.
 */
-func (a *Client) PutProjectsProjectIDScanner(params *PutProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter) (*PutProjectsProjectIDScannerOK, error) {
+func (a *Client) PutProjectsProjectIDScanner(params *PutProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutProjectsProjectIDScannerOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutProjectsProjectIDScannerParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutProjectsProjectIDScanner",
 		Method:             "PUT",
 		PathPattern:        "/projects/{project_id}/scanner",
@@ -177,7 +191,12 @@ func (a *Client) PutProjectsProjectIDScanner(params *PutProjectsProjectIDScanner
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -197,13 +216,12 @@ func (a *Client) PutProjectsProjectIDScanner(params *PutProjectsProjectIDScanner
   Updates the specified scanner registration.
 
 */
-func (a *Client) PutScannersRegistrationID(params *PutScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*PutScannersRegistrationIDOK, error) {
+func (a *Client) PutScannersRegistrationID(params *PutScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*PutScannersRegistrationIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutScannersRegistrationIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "PutScannersRegistrationID",
 		Method:             "PUT",
 		PathPattern:        "/scanners/{registration_id}",
@@ -215,7 +233,12 @@ func (a *Client) PutScannersRegistrationID(params *PutScannersRegistrationIDPara
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/apiv2/mocks/artifact_client_service.go
+++ b/apiv2/mocks/artifact_client_service.go
@@ -14,13 +14,20 @@ type MockArtifactClientService struct {
 	mock.Mock
 }
 
-// AddLabel provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) AddLabel(params *artifact.AddLabelParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.AddLabelOK, error) {
-	ret := _m.Called(params, authInfo)
+// AddLabel provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) AddLabel(params *artifact.AddLabelParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.AddLabelOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.AddLabelOK
-	if rf, ok := ret.Get(0).(func(*artifact.AddLabelParams, runtime.ClientAuthInfoWriter) *artifact.AddLabelOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.AddLabelParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.AddLabelOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.AddLabelOK)
@@ -28,8 +35,8 @@ func (_m *MockArtifactClientService) AddLabel(params *artifact.AddLabelParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.AddLabelParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.AddLabelParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -37,13 +44,20 @@ func (_m *MockArtifactClientService) AddLabel(params *artifact.AddLabelParams, a
 	return r0, r1
 }
 
-// CopyArtifact provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) CopyArtifact(params *artifact.CopyArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.CopyArtifactCreated, error) {
-	ret := _m.Called(params, authInfo)
+// CopyArtifact provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) CopyArtifact(params *artifact.CopyArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.CopyArtifactCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.CopyArtifactCreated
-	if rf, ok := ret.Get(0).(func(*artifact.CopyArtifactParams, runtime.ClientAuthInfoWriter) *artifact.CopyArtifactCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.CopyArtifactParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.CopyArtifactCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.CopyArtifactCreated)
@@ -51,8 +65,8 @@ func (_m *MockArtifactClientService) CopyArtifact(params *artifact.CopyArtifactP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.CopyArtifactParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.CopyArtifactParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -60,13 +74,20 @@ func (_m *MockArtifactClientService) CopyArtifact(params *artifact.CopyArtifactP
 	return r0, r1
 }
 
-// CreateTag provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) CreateTag(params *artifact.CreateTagParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.CreateTagCreated, error) {
-	ret := _m.Called(params, authInfo)
+// CreateTag provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) CreateTag(params *artifact.CreateTagParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.CreateTagCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.CreateTagCreated
-	if rf, ok := ret.Get(0).(func(*artifact.CreateTagParams, runtime.ClientAuthInfoWriter) *artifact.CreateTagCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.CreateTagParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.CreateTagCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.CreateTagCreated)
@@ -74,8 +95,8 @@ func (_m *MockArtifactClientService) CreateTag(params *artifact.CreateTagParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.CreateTagParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.CreateTagParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -83,13 +104,20 @@ func (_m *MockArtifactClientService) CreateTag(params *artifact.CreateTagParams,
 	return r0, r1
 }
 
-// DeleteArtifact provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) DeleteArtifact(params *artifact.DeleteArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.DeleteArtifactOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteArtifact provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) DeleteArtifact(params *artifact.DeleteArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.DeleteArtifactOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.DeleteArtifactOK
-	if rf, ok := ret.Get(0).(func(*artifact.DeleteArtifactParams, runtime.ClientAuthInfoWriter) *artifact.DeleteArtifactOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.DeleteArtifactParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.DeleteArtifactOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.DeleteArtifactOK)
@@ -97,8 +125,8 @@ func (_m *MockArtifactClientService) DeleteArtifact(params *artifact.DeleteArtif
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.DeleteArtifactParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.DeleteArtifactParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -106,13 +134,20 @@ func (_m *MockArtifactClientService) DeleteArtifact(params *artifact.DeleteArtif
 	return r0, r1
 }
 
-// DeleteTag provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) DeleteTag(params *artifact.DeleteTagParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.DeleteTagOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteTag provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) DeleteTag(params *artifact.DeleteTagParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.DeleteTagOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.DeleteTagOK
-	if rf, ok := ret.Get(0).(func(*artifact.DeleteTagParams, runtime.ClientAuthInfoWriter) *artifact.DeleteTagOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.DeleteTagParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.DeleteTagOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.DeleteTagOK)
@@ -120,8 +155,8 @@ func (_m *MockArtifactClientService) DeleteTag(params *artifact.DeleteTagParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.DeleteTagParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.DeleteTagParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -129,13 +164,20 @@ func (_m *MockArtifactClientService) DeleteTag(params *artifact.DeleteTagParams,
 	return r0, r1
 }
 
-// GetAddition provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) GetAddition(params *artifact.GetAdditionParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.GetAdditionOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetAddition provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) GetAddition(params *artifact.GetAdditionParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.GetAdditionOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.GetAdditionOK
-	if rf, ok := ret.Get(0).(func(*artifact.GetAdditionParams, runtime.ClientAuthInfoWriter) *artifact.GetAdditionOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.GetAdditionParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.GetAdditionOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.GetAdditionOK)
@@ -143,8 +185,8 @@ func (_m *MockArtifactClientService) GetAddition(params *artifact.GetAdditionPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.GetAdditionParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.GetAdditionParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -152,13 +194,20 @@ func (_m *MockArtifactClientService) GetAddition(params *artifact.GetAdditionPar
 	return r0, r1
 }
 
-// GetArtifact provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) GetArtifact(params *artifact.GetArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.GetArtifactOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetArtifact provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) GetArtifact(params *artifact.GetArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.GetArtifactOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.GetArtifactOK
-	if rf, ok := ret.Get(0).(func(*artifact.GetArtifactParams, runtime.ClientAuthInfoWriter) *artifact.GetArtifactOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.GetArtifactParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.GetArtifactOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.GetArtifactOK)
@@ -166,8 +215,8 @@ func (_m *MockArtifactClientService) GetArtifact(params *artifact.GetArtifactPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.GetArtifactParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.GetArtifactParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -175,13 +224,20 @@ func (_m *MockArtifactClientService) GetArtifact(params *artifact.GetArtifactPar
 	return r0, r1
 }
 
-// ListArtifacts provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) ListArtifacts(params *artifact.ListArtifactsParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.ListArtifactsOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListArtifacts provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) ListArtifacts(params *artifact.ListArtifactsParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.ListArtifactsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.ListArtifactsOK
-	if rf, ok := ret.Get(0).(func(*artifact.ListArtifactsParams, runtime.ClientAuthInfoWriter) *artifact.ListArtifactsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.ListArtifactsParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.ListArtifactsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.ListArtifactsOK)
@@ -189,8 +245,8 @@ func (_m *MockArtifactClientService) ListArtifacts(params *artifact.ListArtifact
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.ListArtifactsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.ListArtifactsParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -198,13 +254,20 @@ func (_m *MockArtifactClientService) ListArtifacts(params *artifact.ListArtifact
 	return r0, r1
 }
 
-// ListTags provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) ListTags(params *artifact.ListTagsParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.ListTagsOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListTags provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) ListTags(params *artifact.ListTagsParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.ListTagsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.ListTagsOK
-	if rf, ok := ret.Get(0).(func(*artifact.ListTagsParams, runtime.ClientAuthInfoWriter) *artifact.ListTagsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.ListTagsParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.ListTagsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.ListTagsOK)
@@ -212,8 +275,8 @@ func (_m *MockArtifactClientService) ListTags(params *artifact.ListTagsParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.ListTagsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.ListTagsParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -221,13 +284,20 @@ func (_m *MockArtifactClientService) ListTags(params *artifact.ListTagsParams, a
 	return r0, r1
 }
 
-// RemoveLabel provides a mock function with given fields: params, authInfo
-func (_m *MockArtifactClientService) RemoveLabel(params *artifact.RemoveLabelParams, authInfo runtime.ClientAuthInfoWriter) (*artifact.RemoveLabelOK, error) {
-	ret := _m.Called(params, authInfo)
+// RemoveLabel provides a mock function with given fields: params, authInfo, opts
+func (_m *MockArtifactClientService) RemoveLabel(params *artifact.RemoveLabelParams, authInfo runtime.ClientAuthInfoWriter, opts ...artifact.ClientOption) (*artifact.RemoveLabelOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *artifact.RemoveLabelOK
-	if rf, ok := ret.Get(0).(func(*artifact.RemoveLabelParams, runtime.ClientAuthInfoWriter) *artifact.RemoveLabelOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*artifact.RemoveLabelParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) *artifact.RemoveLabelOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*artifact.RemoveLabelOK)
@@ -235,8 +305,8 @@ func (_m *MockArtifactClientService) RemoveLabel(params *artifact.RemoveLabelPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*artifact.RemoveLabelParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*artifact.RemoveLabelParams, runtime.ClientAuthInfoWriter, ...artifact.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/auditlog_client_service.go
+++ b/apiv2/mocks/auditlog_client_service.go
@@ -14,13 +14,20 @@ type MockAuditlogClientService struct {
 	mock.Mock
 }
 
-// ListAuditLogs provides a mock function with given fields: params, authInfo
-func (_m *MockAuditlogClientService) ListAuditLogs(params *auditlog.ListAuditLogsParams, authInfo runtime.ClientAuthInfoWriter) (*auditlog.ListAuditLogsOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListAuditLogs provides a mock function with given fields: params, authInfo, opts
+func (_m *MockAuditlogClientService) ListAuditLogs(params *auditlog.ListAuditLogsParams, authInfo runtime.ClientAuthInfoWriter, opts ...auditlog.ClientOption) (*auditlog.ListAuditLogsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *auditlog.ListAuditLogsOK
-	if rf, ok := ret.Get(0).(func(*auditlog.ListAuditLogsParams, runtime.ClientAuthInfoWriter) *auditlog.ListAuditLogsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*auditlog.ListAuditLogsParams, runtime.ClientAuthInfoWriter, ...auditlog.ClientOption) *auditlog.ListAuditLogsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*auditlog.ListAuditLogsOK)
@@ -28,8 +35,8 @@ func (_m *MockAuditlogClientService) ListAuditLogs(params *auditlog.ListAuditLog
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*auditlog.ListAuditLogsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*auditlog.ListAuditLogsParams, runtime.ClientAuthInfoWriter, ...auditlog.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/icon_client_service.go
+++ b/apiv2/mocks/icon_client_service.go
@@ -14,13 +14,20 @@ type MockIconClientService struct {
 	mock.Mock
 }
 
-// GetIcon provides a mock function with given fields: params, authInfo
-func (_m *MockIconClientService) GetIcon(params *icon.GetIconParams, authInfo runtime.ClientAuthInfoWriter) (*icon.GetIconOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetIcon provides a mock function with given fields: params, authInfo, opts
+func (_m *MockIconClientService) GetIcon(params *icon.GetIconParams, authInfo runtime.ClientAuthInfoWriter, opts ...icon.ClientOption) (*icon.GetIconOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *icon.GetIconOK
-	if rf, ok := ret.Get(0).(func(*icon.GetIconParams, runtime.ClientAuthInfoWriter) *icon.GetIconOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*icon.GetIconParams, runtime.ClientAuthInfoWriter, ...icon.ClientOption) *icon.GetIconOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*icon.GetIconOK)
@@ -28,8 +35,8 @@ func (_m *MockIconClientService) GetIcon(params *icon.GetIconParams, authInfo ru
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*icon.GetIconParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*icon.GetIconParams, runtime.ClientAuthInfoWriter, ...icon.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/preheat_client_service.go
+++ b/apiv2/mocks/preheat_client_service.go
@@ -13,13 +13,20 @@ type MockPreheatClientService struct {
 	mock.Mock
 }
 
-// CreateInstance provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) CreateInstance(params *preheat.CreateInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.CreateInstanceCreated, error) {
-	ret := _m.Called(params, authInfo)
+// CreateInstance provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) CreateInstance(params *preheat.CreateInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.CreateInstanceCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.CreateInstanceCreated
-	if rf, ok := ret.Get(0).(func(*preheat.CreateInstanceParams, runtime.ClientAuthInfoWriter) *preheat.CreateInstanceCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.CreateInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.CreateInstanceCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.CreateInstanceCreated)
@@ -27,8 +34,8 @@ func (_m *MockPreheatClientService) CreateInstance(params *preheat.CreateInstanc
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.CreateInstanceParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.CreateInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -36,13 +43,20 @@ func (_m *MockPreheatClientService) CreateInstance(params *preheat.CreateInstanc
 	return r0, r1
 }
 
-// CreatePolicy provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) CreatePolicy(params *preheat.CreatePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.CreatePolicyCreated, error) {
-	ret := _m.Called(params, authInfo)
+// CreatePolicy provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) CreatePolicy(params *preheat.CreatePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.CreatePolicyCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.CreatePolicyCreated
-	if rf, ok := ret.Get(0).(func(*preheat.CreatePolicyParams, runtime.ClientAuthInfoWriter) *preheat.CreatePolicyCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.CreatePolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.CreatePolicyCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.CreatePolicyCreated)
@@ -50,8 +64,8 @@ func (_m *MockPreheatClientService) CreatePolicy(params *preheat.CreatePolicyPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.CreatePolicyParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.CreatePolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +73,20 @@ func (_m *MockPreheatClientService) CreatePolicy(params *preheat.CreatePolicyPar
 	return r0, r1
 }
 
-// DeleteInstance provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) DeleteInstance(params *preheat.DeleteInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.DeleteInstanceOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteInstance provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) DeleteInstance(params *preheat.DeleteInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.DeleteInstanceOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.DeleteInstanceOK
-	if rf, ok := ret.Get(0).(func(*preheat.DeleteInstanceParams, runtime.ClientAuthInfoWriter) *preheat.DeleteInstanceOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.DeleteInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.DeleteInstanceOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.DeleteInstanceOK)
@@ -73,8 +94,8 @@ func (_m *MockPreheatClientService) DeleteInstance(params *preheat.DeleteInstanc
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.DeleteInstanceParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.DeleteInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -82,13 +103,20 @@ func (_m *MockPreheatClientService) DeleteInstance(params *preheat.DeleteInstanc
 	return r0, r1
 }
 
-// DeletePolicy provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) DeletePolicy(params *preheat.DeletePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.DeletePolicyOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeletePolicy provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) DeletePolicy(params *preheat.DeletePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.DeletePolicyOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.DeletePolicyOK
-	if rf, ok := ret.Get(0).(func(*preheat.DeletePolicyParams, runtime.ClientAuthInfoWriter) *preheat.DeletePolicyOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.DeletePolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.DeletePolicyOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.DeletePolicyOK)
@@ -96,8 +124,8 @@ func (_m *MockPreheatClientService) DeletePolicy(params *preheat.DeletePolicyPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.DeletePolicyParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.DeletePolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -105,13 +133,20 @@ func (_m *MockPreheatClientService) DeletePolicy(params *preheat.DeletePolicyPar
 	return r0, r1
 }
 
-// GetExecution provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) GetExecution(params *preheat.GetExecutionParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.GetExecutionOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetExecution provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) GetExecution(params *preheat.GetExecutionParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.GetExecutionOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.GetExecutionOK
-	if rf, ok := ret.Get(0).(func(*preheat.GetExecutionParams, runtime.ClientAuthInfoWriter) *preheat.GetExecutionOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.GetExecutionParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.GetExecutionOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.GetExecutionOK)
@@ -119,8 +154,8 @@ func (_m *MockPreheatClientService) GetExecution(params *preheat.GetExecutionPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.GetExecutionParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.GetExecutionParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -128,13 +163,20 @@ func (_m *MockPreheatClientService) GetExecution(params *preheat.GetExecutionPar
 	return r0, r1
 }
 
-// GetInstance provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) GetInstance(params *preheat.GetInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.GetInstanceOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetInstance provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) GetInstance(params *preheat.GetInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.GetInstanceOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.GetInstanceOK
-	if rf, ok := ret.Get(0).(func(*preheat.GetInstanceParams, runtime.ClientAuthInfoWriter) *preheat.GetInstanceOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.GetInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.GetInstanceOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.GetInstanceOK)
@@ -142,8 +184,8 @@ func (_m *MockPreheatClientService) GetInstance(params *preheat.GetInstanceParam
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.GetInstanceParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.GetInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -151,13 +193,20 @@ func (_m *MockPreheatClientService) GetInstance(params *preheat.GetInstanceParam
 	return r0, r1
 }
 
-// GetPolicy provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) GetPolicy(params *preheat.GetPolicyParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.GetPolicyOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetPolicy provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) GetPolicy(params *preheat.GetPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.GetPolicyOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.GetPolicyOK
-	if rf, ok := ret.Get(0).(func(*preheat.GetPolicyParams, runtime.ClientAuthInfoWriter) *preheat.GetPolicyOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.GetPolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.GetPolicyOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.GetPolicyOK)
@@ -165,8 +214,8 @@ func (_m *MockPreheatClientService) GetPolicy(params *preheat.GetPolicyParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.GetPolicyParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.GetPolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -174,13 +223,20 @@ func (_m *MockPreheatClientService) GetPolicy(params *preheat.GetPolicyParams, a
 	return r0, r1
 }
 
-// GetPreheatLog provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) GetPreheatLog(params *preheat.GetPreheatLogParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.GetPreheatLogOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetPreheatLog provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) GetPreheatLog(params *preheat.GetPreheatLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.GetPreheatLogOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.GetPreheatLogOK
-	if rf, ok := ret.Get(0).(func(*preheat.GetPreheatLogParams, runtime.ClientAuthInfoWriter) *preheat.GetPreheatLogOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.GetPreheatLogParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.GetPreheatLogOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.GetPreheatLogOK)
@@ -188,8 +244,8 @@ func (_m *MockPreheatClientService) GetPreheatLog(params *preheat.GetPreheatLogP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.GetPreheatLogParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.GetPreheatLogParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -197,13 +253,20 @@ func (_m *MockPreheatClientService) GetPreheatLog(params *preheat.GetPreheatLogP
 	return r0, r1
 }
 
-// ListExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ListExecutions(params *preheat.ListExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ListExecutionsOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ListExecutions(params *preheat.ListExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ListExecutionsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ListExecutionsOK
-	if rf, ok := ret.Get(0).(func(*preheat.ListExecutionsParams, runtime.ClientAuthInfoWriter) *preheat.ListExecutionsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ListExecutionsParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ListExecutionsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ListExecutionsOK)
@@ -211,8 +274,8 @@ func (_m *MockPreheatClientService) ListExecutions(params *preheat.ListExecution
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ListExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ListExecutionsParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -220,13 +283,20 @@ func (_m *MockPreheatClientService) ListExecutions(params *preheat.ListExecution
 	return r0, r1
 }
 
-// ListInstances provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ListInstances(params *preheat.ListInstancesParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ListInstancesOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListInstances provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ListInstances(params *preheat.ListInstancesParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ListInstancesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ListInstancesOK
-	if rf, ok := ret.Get(0).(func(*preheat.ListInstancesParams, runtime.ClientAuthInfoWriter) *preheat.ListInstancesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ListInstancesParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ListInstancesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ListInstancesOK)
@@ -234,8 +304,8 @@ func (_m *MockPreheatClientService) ListInstances(params *preheat.ListInstancesP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ListInstancesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ListInstancesParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -243,13 +313,20 @@ func (_m *MockPreheatClientService) ListInstances(params *preheat.ListInstancesP
 	return r0, r1
 }
 
-// ListPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ListPolicies(params *preheat.ListPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ListPoliciesOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ListPolicies(params *preheat.ListPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ListPoliciesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ListPoliciesOK
-	if rf, ok := ret.Get(0).(func(*preheat.ListPoliciesParams, runtime.ClientAuthInfoWriter) *preheat.ListPoliciesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ListPoliciesParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ListPoliciesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ListPoliciesOK)
@@ -257,8 +334,8 @@ func (_m *MockPreheatClientService) ListPolicies(params *preheat.ListPoliciesPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ListPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ListPoliciesParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -266,13 +343,20 @@ func (_m *MockPreheatClientService) ListPolicies(params *preheat.ListPoliciesPar
 	return r0, r1
 }
 
-// ListProviders provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ListProviders(params *preheat.ListProvidersParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ListProvidersOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListProviders provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ListProviders(params *preheat.ListProvidersParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ListProvidersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ListProvidersOK
-	if rf, ok := ret.Get(0).(func(*preheat.ListProvidersParams, runtime.ClientAuthInfoWriter) *preheat.ListProvidersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ListProvidersParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ListProvidersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ListProvidersOK)
@@ -280,8 +364,8 @@ func (_m *MockPreheatClientService) ListProviders(params *preheat.ListProvidersP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ListProvidersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ListProvidersParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -289,13 +373,20 @@ func (_m *MockPreheatClientService) ListProviders(params *preheat.ListProvidersP
 	return r0, r1
 }
 
-// ListProvidersUnderProject provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ListProvidersUnderProject(params *preheat.ListProvidersUnderProjectParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ListProvidersUnderProjectOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListProvidersUnderProject provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ListProvidersUnderProject(params *preheat.ListProvidersUnderProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ListProvidersUnderProjectOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ListProvidersUnderProjectOK
-	if rf, ok := ret.Get(0).(func(*preheat.ListProvidersUnderProjectParams, runtime.ClientAuthInfoWriter) *preheat.ListProvidersUnderProjectOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ListProvidersUnderProjectParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ListProvidersUnderProjectOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ListProvidersUnderProjectOK)
@@ -303,8 +394,8 @@ func (_m *MockPreheatClientService) ListProvidersUnderProject(params *preheat.Li
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ListProvidersUnderProjectParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ListProvidersUnderProjectParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -312,13 +403,20 @@ func (_m *MockPreheatClientService) ListProvidersUnderProject(params *preheat.Li
 	return r0, r1
 }
 
-// ListTasks provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ListTasks(params *preheat.ListTasksParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ListTasksOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListTasks provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ListTasks(params *preheat.ListTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ListTasksOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ListTasksOK
-	if rf, ok := ret.Get(0).(func(*preheat.ListTasksParams, runtime.ClientAuthInfoWriter) *preheat.ListTasksOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ListTasksParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ListTasksOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ListTasksOK)
@@ -326,8 +424,8 @@ func (_m *MockPreheatClientService) ListTasks(params *preheat.ListTasksParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ListTasksParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ListTasksParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -335,13 +433,20 @@ func (_m *MockPreheatClientService) ListTasks(params *preheat.ListTasksParams, a
 	return r0, r1
 }
 
-// ManualPreheat provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) ManualPreheat(params *preheat.ManualPreheatParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.ManualPreheatCreated, error) {
-	ret := _m.Called(params, authInfo)
+// ManualPreheat provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) ManualPreheat(params *preheat.ManualPreheatParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.ManualPreheatCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.ManualPreheatCreated
-	if rf, ok := ret.Get(0).(func(*preheat.ManualPreheatParams, runtime.ClientAuthInfoWriter) *preheat.ManualPreheatCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.ManualPreheatParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.ManualPreheatCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.ManualPreheatCreated)
@@ -349,8 +454,8 @@ func (_m *MockPreheatClientService) ManualPreheat(params *preheat.ManualPreheatP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.ManualPreheatParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.ManualPreheatParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -358,13 +463,20 @@ func (_m *MockPreheatClientService) ManualPreheat(params *preheat.ManualPreheatP
 	return r0, r1
 }
 
-// PingInstances provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) PingInstances(params *preheat.PingInstancesParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.PingInstancesOK, error) {
-	ret := _m.Called(params, authInfo)
+// PingInstances provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) PingInstances(params *preheat.PingInstancesParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.PingInstancesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.PingInstancesOK
-	if rf, ok := ret.Get(0).(func(*preheat.PingInstancesParams, runtime.ClientAuthInfoWriter) *preheat.PingInstancesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.PingInstancesParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.PingInstancesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.PingInstancesOK)
@@ -372,8 +484,8 @@ func (_m *MockPreheatClientService) PingInstances(params *preheat.PingInstancesP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.PingInstancesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.PingInstancesParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -386,13 +498,20 @@ func (_m *MockPreheatClientService) SetTransport(transport runtime.ClientTranspo
 	_m.Called(transport)
 }
 
-// StopExecution provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) StopExecution(params *preheat.StopExecutionParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.StopExecutionOK, error) {
-	ret := _m.Called(params, authInfo)
+// StopExecution provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) StopExecution(params *preheat.StopExecutionParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.StopExecutionOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.StopExecutionOK
-	if rf, ok := ret.Get(0).(func(*preheat.StopExecutionParams, runtime.ClientAuthInfoWriter) *preheat.StopExecutionOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.StopExecutionParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.StopExecutionOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.StopExecutionOK)
@@ -400,8 +519,8 @@ func (_m *MockPreheatClientService) StopExecution(params *preheat.StopExecutionP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.StopExecutionParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.StopExecutionParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -409,13 +528,20 @@ func (_m *MockPreheatClientService) StopExecution(params *preheat.StopExecutionP
 	return r0, r1
 }
 
-// UpdateInstance provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) UpdateInstance(params *preheat.UpdateInstanceParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.UpdateInstanceOK, error) {
-	ret := _m.Called(params, authInfo)
+// UpdateInstance provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) UpdateInstance(params *preheat.UpdateInstanceParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.UpdateInstanceOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.UpdateInstanceOK
-	if rf, ok := ret.Get(0).(func(*preheat.UpdateInstanceParams, runtime.ClientAuthInfoWriter) *preheat.UpdateInstanceOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.UpdateInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.UpdateInstanceOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.UpdateInstanceOK)
@@ -423,8 +549,8 @@ func (_m *MockPreheatClientService) UpdateInstance(params *preheat.UpdateInstanc
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.UpdateInstanceParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.UpdateInstanceParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -432,13 +558,20 @@ func (_m *MockPreheatClientService) UpdateInstance(params *preheat.UpdateInstanc
 	return r0, r1
 }
 
-// UpdatePolicy provides a mock function with given fields: params, authInfo
-func (_m *MockPreheatClientService) UpdatePolicy(params *preheat.UpdatePolicyParams, authInfo runtime.ClientAuthInfoWriter) (*preheat.UpdatePolicyOK, error) {
-	ret := _m.Called(params, authInfo)
+// UpdatePolicy provides a mock function with given fields: params, authInfo, opts
+func (_m *MockPreheatClientService) UpdatePolicy(params *preheat.UpdatePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...preheat.ClientOption) (*preheat.UpdatePolicyOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *preheat.UpdatePolicyOK
-	if rf, ok := ret.Get(0).(func(*preheat.UpdatePolicyParams, runtime.ClientAuthInfoWriter) *preheat.UpdatePolicyOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*preheat.UpdatePolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) *preheat.UpdatePolicyOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*preheat.UpdatePolicyOK)
@@ -446,8 +579,8 @@ func (_m *MockPreheatClientService) UpdatePolicy(params *preheat.UpdatePolicyPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*preheat.UpdatePolicyParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*preheat.UpdatePolicyParams, runtime.ClientAuthInfoWriter, ...preheat.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/products_client_service.go
+++ b/apiv2/mocks/products_client_service.go
@@ -13,13 +13,20 @@ type MockProductsClientService struct {
 	mock.Mock
 }
 
-// DeleteChartrepoRepoChartsNameVersionLabelsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteChartrepoRepoChartsNameVersionLabelsID(params *products.DeleteChartrepoRepoChartsNameVersionLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteChartrepoRepoChartsNameVersionLabelsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteChartrepoRepoChartsNameVersionLabelsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteChartrepoRepoChartsNameVersionLabelsID(params *products.DeleteChartrepoRepoChartsNameVersionLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteChartrepoRepoChartsNameVersionLabelsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteChartrepoRepoChartsNameVersionLabelsIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteChartrepoRepoChartsNameVersionLabelsIDParams, runtime.ClientAuthInfoWriter) *products.DeleteChartrepoRepoChartsNameVersionLabelsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteChartrepoRepoChartsNameVersionLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteChartrepoRepoChartsNameVersionLabelsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteChartrepoRepoChartsNameVersionLabelsIDOK)
@@ -27,8 +34,8 @@ func (_m *MockProductsClientService) DeleteChartrepoRepoChartsNameVersionLabelsI
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteChartrepoRepoChartsNameVersionLabelsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteChartrepoRepoChartsNameVersionLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -36,13 +43,20 @@ func (_m *MockProductsClientService) DeleteChartrepoRepoChartsNameVersionLabelsI
 	return r0, r1
 }
 
-// DeleteLabelsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteLabelsID(params *products.DeleteLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteLabelsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteLabelsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteLabelsID(params *products.DeleteLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteLabelsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteLabelsIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteLabelsIDParams, runtime.ClientAuthInfoWriter) *products.DeleteLabelsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteLabelsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteLabelsIDOK)
@@ -50,8 +64,8 @@ func (_m *MockProductsClientService) DeleteLabelsID(params *products.DeleteLabel
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteLabelsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +73,20 @@ func (_m *MockProductsClientService) DeleteLabelsID(params *products.DeleteLabel
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDImmutabletagrulesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteProjectsProjectIDImmutabletagrulesID(params *products.DeleteProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDImmutabletagrulesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDImmutabletagrulesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteProjectsProjectIDImmutabletagrulesID(params *products.DeleteProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDImmutabletagrulesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDImmutabletagrulesIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDImmutabletagrulesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDImmutabletagrulesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDImmutabletagrulesIDOK)
@@ -73,8 +94,8 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDImmutabletagrulesID(
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -82,13 +103,20 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDImmutabletagrulesID(
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteProjectsProjectIDMembersMid(params *products.DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDMembersMidOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteProjectsProjectIDMembersMid(params *products.DeleteProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDMembersMidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDMembersMidOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDMembersMidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDMembersMidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDMembersMidOK)
@@ -96,8 +124,8 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDMembersMid(params *p
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -105,13 +133,20 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDMembersMid(params *p
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteProjectsProjectIDMetadatasMetaName(params *products.DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteProjectsProjectIDMetadatasMetaName(params *products.DeleteProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDMetadatasMetaNameOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDMetadatasMetaNameOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDMetadatasMetaNameOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDMetadatasMetaNameOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDMetadatasMetaNameOK)
@@ -119,8 +154,8 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDMetadatasMetaName(pa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -128,13 +163,20 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDMetadatasMetaName(pa
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDRobotsRobotID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteProjectsProjectIDRobotsRobotID(params *products.DeleteProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDRobotsRobotIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDRobotsRobotID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteProjectsProjectIDRobotsRobotID(params *products.DeleteProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDRobotsRobotIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDRobotsRobotIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDRobotsRobotIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDRobotsRobotIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDRobotsRobotIDOK)
@@ -142,8 +184,8 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDRobotsRobotID(params
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -151,13 +193,20 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDRobotsRobotID(params
 	return r0, r1
 }
 
-// DeleteProjectsProjectIDWebhookPoliciesPolicyID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProjectsProjectIDWebhookPoliciesPolicyID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteProjectsProjectIDWebhookPoliciesPolicyID(params *products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter) *products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK)
@@ -165,8 +214,8 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDWebhookPoliciesPolic
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -174,13 +223,20 @@ func (_m *MockProductsClientService) DeleteProjectsProjectIDWebhookPoliciesPolic
 	return r0, r1
 }
 
-// DeleteRegistriesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteRegistriesID(params *products.DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteRegistriesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteRegistriesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteRegistriesID(params *products.DeleteRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteRegistriesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteRegistriesIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter) *products.DeleteRegistriesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteRegistriesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteRegistriesIDOK)
@@ -188,8 +244,8 @@ func (_m *MockProductsClientService) DeleteRegistriesID(params *products.DeleteR
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -197,13 +253,20 @@ func (_m *MockProductsClientService) DeleteRegistriesID(params *products.DeleteR
 	return r0, r1
 }
 
-// DeleteReplicationPoliciesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteReplicationPoliciesID(params *products.DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteReplicationPoliciesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteReplicationPoliciesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteReplicationPoliciesID(params *products.DeleteReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteReplicationPoliciesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteReplicationPoliciesIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) *products.DeleteReplicationPoliciesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteReplicationPoliciesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteReplicationPoliciesIDOK)
@@ -211,8 +274,8 @@ func (_m *MockProductsClientService) DeleteReplicationPoliciesID(params *product
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -220,13 +283,20 @@ func (_m *MockProductsClientService) DeleteReplicationPoliciesID(params *product
 	return r0, r1
 }
 
-// DeleteUsergroupsGroupID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteUsergroupsGroupID(params *products.DeleteUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteUsergroupsGroupIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteUsergroupsGroupID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteUsergroupsGroupID(params *products.DeleteUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteUsergroupsGroupIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteUsergroupsGroupIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter) *products.DeleteUsergroupsGroupIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteUsergroupsGroupIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteUsergroupsGroupIDOK)
@@ -234,8 +304,8 @@ func (_m *MockProductsClientService) DeleteUsergroupsGroupID(params *products.De
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -243,13 +313,20 @@ func (_m *MockProductsClientService) DeleteUsergroupsGroupID(params *products.De
 	return r0, r1
 }
 
-// DeleteUsersUserID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) DeleteUsersUserID(params *products.DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.DeleteUsersUserIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteUsersUserID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) DeleteUsersUserID(params *products.DeleteUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.DeleteUsersUserIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.DeleteUsersUserIDOK
-	if rf, ok := ret.Get(0).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter) *products.DeleteUsersUserIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.DeleteUsersUserIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.DeleteUsersUserIDOK)
@@ -257,8 +334,8 @@ func (_m *MockProductsClientService) DeleteUsersUserID(params *products.DeleteUs
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.DeleteUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -266,13 +343,20 @@ func (_m *MockProductsClientService) DeleteUsersUserID(params *products.DeleteUs
 	return r0, r1
 }
 
-// GetChartrepoRepoChartsNameVersionLabels provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetChartrepoRepoChartsNameVersionLabels(params *products.GetChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetChartrepoRepoChartsNameVersionLabelsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetChartrepoRepoChartsNameVersionLabels provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetChartrepoRepoChartsNameVersionLabels(params *products.GetChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetChartrepoRepoChartsNameVersionLabelsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetChartrepoRepoChartsNameVersionLabelsOK
-	if rf, ok := ret.Get(0).(func(*products.GetChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter) *products.GetChartrepoRepoChartsNameVersionLabelsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetChartrepoRepoChartsNameVersionLabelsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetChartrepoRepoChartsNameVersionLabelsOK)
@@ -280,8 +364,8 @@ func (_m *MockProductsClientService) GetChartrepoRepoChartsNameVersionLabels(par
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -289,13 +373,20 @@ func (_m *MockProductsClientService) GetChartrepoRepoChartsNameVersionLabels(par
 	return r0, r1
 }
 
-// GetConfigurations provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetConfigurations(params *products.GetConfigurationsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetConfigurationsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetConfigurations provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetConfigurations(params *products.GetConfigurationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetConfigurationsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetConfigurationsOK
-	if rf, ok := ret.Get(0).(func(*products.GetConfigurationsParams, runtime.ClientAuthInfoWriter) *products.GetConfigurationsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetConfigurationsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetConfigurationsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetConfigurationsOK)
@@ -303,8 +394,8 @@ func (_m *MockProductsClientService) GetConfigurations(params *products.GetConfi
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetConfigurationsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetConfigurationsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -312,13 +403,20 @@ func (_m *MockProductsClientService) GetConfigurations(params *products.GetConfi
 	return r0, r1
 }
 
-// GetHealth provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetHealth(params *products.GetHealthParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetHealthOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetHealth provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetHealth(params *products.GetHealthParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetHealthOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetHealthOK
-	if rf, ok := ret.Get(0).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter) *products.GetHealthOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetHealthOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetHealthOK)
@@ -326,8 +424,8 @@ func (_m *MockProductsClientService) GetHealth(params *products.GetHealthParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetHealthParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -335,13 +433,20 @@ func (_m *MockProductsClientService) GetHealth(params *products.GetHealthParams,
 	return r0, r1
 }
 
-// GetLabels provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetLabels(params *products.GetLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetLabelsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetLabels provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetLabels(params *products.GetLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetLabelsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetLabelsOK
-	if rf, ok := ret.Get(0).(func(*products.GetLabelsParams, runtime.ClientAuthInfoWriter) *products.GetLabelsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetLabelsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetLabelsOK)
@@ -349,8 +454,8 @@ func (_m *MockProductsClientService) GetLabels(params *products.GetLabelsParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetLabelsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -358,13 +463,20 @@ func (_m *MockProductsClientService) GetLabels(params *products.GetLabelsParams,
 	return r0, r1
 }
 
-// GetLabelsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetLabelsID(params *products.GetLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetLabelsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetLabelsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetLabelsID(params *products.GetLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetLabelsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetLabelsIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetLabelsIDParams, runtime.ClientAuthInfoWriter) *products.GetLabelsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetLabelsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetLabelsIDOK)
@@ -372,8 +484,8 @@ func (_m *MockProductsClientService) GetLabelsID(params *products.GetLabelsIDPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetLabelsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -381,13 +493,20 @@ func (_m *MockProductsClientService) GetLabelsID(params *products.GetLabelsIDPar
 	return r0, r1
 }
 
-// GetLdapGroupsSearch provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetLdapGroupsSearch(params *products.GetLdapGroupsSearchParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetLdapGroupsSearchOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetLdapGroupsSearch provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetLdapGroupsSearch(params *products.GetLdapGroupsSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetLdapGroupsSearchOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetLdapGroupsSearchOK
-	if rf, ok := ret.Get(0).(func(*products.GetLdapGroupsSearchParams, runtime.ClientAuthInfoWriter) *products.GetLdapGroupsSearchOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetLdapGroupsSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetLdapGroupsSearchOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetLdapGroupsSearchOK)
@@ -395,8 +514,8 @@ func (_m *MockProductsClientService) GetLdapGroupsSearch(params *products.GetLda
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetLdapGroupsSearchParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetLdapGroupsSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -404,13 +523,20 @@ func (_m *MockProductsClientService) GetLdapGroupsSearch(params *products.GetLda
 	return r0, r1
 }
 
-// GetLdapUsersSearch provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetLdapUsersSearch(params *products.GetLdapUsersSearchParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetLdapUsersSearchOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetLdapUsersSearch provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetLdapUsersSearch(params *products.GetLdapUsersSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetLdapUsersSearchOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetLdapUsersSearchOK
-	if rf, ok := ret.Get(0).(func(*products.GetLdapUsersSearchParams, runtime.ClientAuthInfoWriter) *products.GetLdapUsersSearchOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetLdapUsersSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetLdapUsersSearchOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetLdapUsersSearchOK)
@@ -418,8 +544,8 @@ func (_m *MockProductsClientService) GetLdapUsersSearch(params *products.GetLdap
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetLdapUsersSearchParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetLdapUsersSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -427,13 +553,20 @@ func (_m *MockProductsClientService) GetLdapUsersSearch(params *products.GetLdap
 	return r0, r1
 }
 
-// GetProjectsProjectIDImmutabletagrules provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDImmutabletagrules(params *products.GetProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDImmutabletagrulesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDImmutabletagrules provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDImmutabletagrules(params *products.GetProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDImmutabletagrulesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDImmutabletagrulesOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDImmutabletagrulesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDImmutabletagrulesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDImmutabletagrulesOK)
@@ -441,8 +574,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDImmutabletagrules(param
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -450,13 +583,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDImmutabletagrules(param
 	return r0, r1
 }
 
-// GetProjectsProjectIDMembers provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDMembers(params *products.GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMembersOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMembers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDMembers(params *products.GetProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMembersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMembersOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMembersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMembersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMembersOK)
@@ -464,8 +604,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMembers(params *product
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -473,13 +613,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMembers(params *product
 	return r0, r1
 }
 
-// GetProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDMembersMid(params *products.GetProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMembersMidOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDMembersMid(params *products.GetProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMembersMidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMembersMidOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMembersMidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMembersMidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMembersMidOK)
@@ -487,8 +634,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMembersMid(params *prod
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -496,13 +643,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMembersMid(params *prod
 	return r0, r1
 }
 
-// GetProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDMetadatas(params *products.GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMetadatasOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDMetadatas(params *products.GetProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMetadatasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMetadatasOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMetadatasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMetadatasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMetadatasOK)
@@ -510,8 +664,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMetadatas(params *produ
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -519,13 +673,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMetadatas(params *produ
 	return r0, r1
 }
 
-// GetProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDMetadatasMetaName(params *products.GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDMetadatasMetaNameOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDMetadatasMetaName(params *products.GetProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDMetadatasMetaNameOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDMetadatasMetaNameOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDMetadatasMetaNameOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDMetadatasMetaNameOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDMetadatasMetaNameOK)
@@ -533,8 +694,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMetadatasMetaName(param
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -542,13 +703,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDMetadatasMetaName(param
 	return r0, r1
 }
 
-// GetProjectsProjectIDRobots provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDRobots(params *products.GetProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDRobotsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDRobots provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDRobots(params *products.GetProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDRobotsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDRobotsOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDRobotsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDRobotsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDRobotsOK)
@@ -556,8 +724,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDRobots(params *products
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -565,13 +733,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDRobots(params *products
 	return r0, r1
 }
 
-// GetProjectsProjectIDRobotsRobotID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDRobotsRobotID(params *products.GetProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDRobotsRobotIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDRobotsRobotID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDRobotsRobotID(params *products.GetProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDRobotsRobotIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDRobotsRobotIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDRobotsRobotIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDRobotsRobotIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDRobotsRobotIDOK)
@@ -579,8 +754,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDRobotsRobotID(params *p
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -588,13 +763,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDRobotsRobotID(params *p
 	return r0, r1
 }
 
-// GetProjectsProjectIDScanner provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDScanner(params *products.GetProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDScannerOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDScanner provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDScanner(params *products.GetProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDScannerOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDScannerOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDScannerOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDScannerOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDScannerOK)
@@ -602,8 +784,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDScanner(params *product
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -611,13 +793,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDScanner(params *product
 	return r0, r1
 }
 
-// GetProjectsProjectIDScannerCandidates provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDScannerCandidates(params *products.GetProjectsProjectIDScannerCandidatesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDScannerCandidatesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDScannerCandidates provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDScannerCandidates(params *products.GetProjectsProjectIDScannerCandidatesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDScannerCandidatesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDScannerCandidatesOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDScannerCandidatesParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDScannerCandidatesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDScannerCandidatesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDScannerCandidatesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDScannerCandidatesOK)
@@ -625,8 +814,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDScannerCandidates(param
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDScannerCandidatesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDScannerCandidatesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -634,13 +823,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDScannerCandidates(param
 	return r0, r1
 }
 
-// GetProjectsProjectIDWebhookEvents provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDWebhookEvents(params *products.GetProjectsProjectIDWebhookEventsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDWebhookEventsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDWebhookEvents provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDWebhookEvents(params *products.GetProjectsProjectIDWebhookEventsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDWebhookEventsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDWebhookEventsOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookEventsParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDWebhookEventsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookEventsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDWebhookEventsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDWebhookEventsOK)
@@ -648,8 +844,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookEvents(params *p
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookEventsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookEventsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -657,13 +853,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookEvents(params *p
 	return r0, r1
 }
 
-// GetProjectsProjectIDWebhookJobs provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDWebhookJobs(params *products.GetProjectsProjectIDWebhookJobsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDWebhookJobsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDWebhookJobs provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDWebhookJobs(params *products.GetProjectsProjectIDWebhookJobsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDWebhookJobsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDWebhookJobsOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookJobsParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDWebhookJobsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookJobsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDWebhookJobsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDWebhookJobsOK)
@@ -671,8 +874,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookJobs(params *pro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookJobsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookJobsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -680,13 +883,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookJobs(params *pro
 	return r0, r1
 }
 
-// GetProjectsProjectIDWebhookLasttrigger provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDWebhookLasttrigger(params *products.GetProjectsProjectIDWebhookLasttriggerParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDWebhookLasttriggerOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDWebhookLasttrigger provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDWebhookLasttrigger(params *products.GetProjectsProjectIDWebhookLasttriggerParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDWebhookLasttriggerOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDWebhookLasttriggerOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookLasttriggerParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDWebhookLasttriggerOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookLasttriggerParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDWebhookLasttriggerOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDWebhookLasttriggerOK)
@@ -694,8 +904,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookLasttrigger(para
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookLasttriggerParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookLasttriggerParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -703,13 +913,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookLasttrigger(para
 	return r0, r1
 }
 
-// GetProjectsProjectIDWebhookPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPolicies(params *products.GetProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDWebhookPoliciesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDWebhookPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPolicies(params *products.GetProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDWebhookPoliciesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDWebhookPoliciesOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDWebhookPoliciesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDWebhookPoliciesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDWebhookPoliciesOK)
@@ -717,8 +934,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPolicies(params 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -726,13 +943,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPolicies(params 
 	return r0, r1
 }
 
-// GetProjectsProjectIDWebhookPoliciesPolicyID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPoliciesPolicyID(params *products.GetProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectsProjectIDWebhookPoliciesPolicyID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPoliciesPolicyID(params *products.GetProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetProjectsProjectIDWebhookPoliciesPolicyIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter) *products.GetProjectsProjectIDWebhookPoliciesPolicyIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetProjectsProjectIDWebhookPoliciesPolicyIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetProjectsProjectIDWebhookPoliciesPolicyIDOK)
@@ -740,8 +964,8 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPoliciesPolicyID
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -749,13 +973,20 @@ func (_m *MockProductsClientService) GetProjectsProjectIDWebhookPoliciesPolicyID
 	return r0, r1
 }
 
-// GetQuotas provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetQuotas(params *products.GetQuotasParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetQuotasOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetQuotas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetQuotas(params *products.GetQuotasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetQuotasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetQuotasOK
-	if rf, ok := ret.Get(0).(func(*products.GetQuotasParams, runtime.ClientAuthInfoWriter) *products.GetQuotasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetQuotasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetQuotasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetQuotasOK)
@@ -763,8 +994,8 @@ func (_m *MockProductsClientService) GetQuotas(params *products.GetQuotasParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetQuotasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetQuotasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -772,13 +1003,20 @@ func (_m *MockProductsClientService) GetQuotas(params *products.GetQuotasParams,
 	return r0, r1
 }
 
-// GetQuotasID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetQuotasID(params *products.GetQuotasIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetQuotasIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetQuotasID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetQuotasID(params *products.GetQuotasIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetQuotasIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetQuotasIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetQuotasIDParams, runtime.ClientAuthInfoWriter) *products.GetQuotasIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetQuotasIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetQuotasIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetQuotasIDOK)
@@ -786,8 +1024,8 @@ func (_m *MockProductsClientService) GetQuotasID(params *products.GetQuotasIDPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetQuotasIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetQuotasIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -795,13 +1033,20 @@ func (_m *MockProductsClientService) GetQuotasID(params *products.GetQuotasIDPar
 	return r0, r1
 }
 
-// GetRegistries provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRegistries(params *products.GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRegistriesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRegistries provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRegistries(params *products.GetRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRegistriesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRegistriesOK
-	if rf, ok := ret.Get(0).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter) *products.GetRegistriesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRegistriesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRegistriesOK)
@@ -809,8 +1054,8 @@ func (_m *MockProductsClientService) GetRegistries(params *products.GetRegistrie
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -818,13 +1063,20 @@ func (_m *MockProductsClientService) GetRegistries(params *products.GetRegistrie
 	return r0, r1
 }
 
-// GetRegistriesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRegistriesID(params *products.GetRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRegistriesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRegistriesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRegistriesID(params *products.GetRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRegistriesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRegistriesIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetRegistriesIDParams, runtime.ClientAuthInfoWriter) *products.GetRegistriesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRegistriesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRegistriesIDOK)
@@ -832,8 +1084,8 @@ func (_m *MockProductsClientService) GetRegistriesID(params *products.GetRegistr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRegistriesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -841,13 +1093,20 @@ func (_m *MockProductsClientService) GetRegistriesID(params *products.GetRegistr
 	return r0, r1
 }
 
-// GetRegistriesIDInfo provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRegistriesIDInfo(params *products.GetRegistriesIDInfoParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRegistriesIDInfoOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRegistriesIDInfo provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRegistriesIDInfo(params *products.GetRegistriesIDInfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRegistriesIDInfoOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRegistriesIDInfoOK
-	if rf, ok := ret.Get(0).(func(*products.GetRegistriesIDInfoParams, runtime.ClientAuthInfoWriter) *products.GetRegistriesIDInfoOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRegistriesIDInfoParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRegistriesIDInfoOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRegistriesIDInfoOK)
@@ -855,8 +1114,8 @@ func (_m *MockProductsClientService) GetRegistriesIDInfo(params *products.GetReg
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRegistriesIDInfoParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRegistriesIDInfoParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -864,13 +1123,20 @@ func (_m *MockProductsClientService) GetRegistriesIDInfo(params *products.GetReg
 	return r0, r1
 }
 
-// GetRegistriesIDNamespace provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRegistriesIDNamespace(params *products.GetRegistriesIDNamespaceParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRegistriesIDNamespaceOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRegistriesIDNamespace provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRegistriesIDNamespace(params *products.GetRegistriesIDNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRegistriesIDNamespaceOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRegistriesIDNamespaceOK
-	if rf, ok := ret.Get(0).(func(*products.GetRegistriesIDNamespaceParams, runtime.ClientAuthInfoWriter) *products.GetRegistriesIDNamespaceOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRegistriesIDNamespaceParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRegistriesIDNamespaceOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRegistriesIDNamespaceOK)
@@ -878,8 +1144,8 @@ func (_m *MockProductsClientService) GetRegistriesIDNamespace(params *products.G
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRegistriesIDNamespaceParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRegistriesIDNamespaceParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -887,13 +1153,20 @@ func (_m *MockProductsClientService) GetRegistriesIDNamespace(params *products.G
 	return r0, r1
 }
 
-// GetReplicationAdapters provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationAdapters(params *products.GetReplicationAdaptersParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationAdaptersOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationAdapters provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationAdapters(params *products.GetReplicationAdaptersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationAdaptersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationAdaptersOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationAdaptersParams, runtime.ClientAuthInfoWriter) *products.GetReplicationAdaptersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationAdaptersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationAdaptersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationAdaptersOK)
@@ -901,8 +1174,8 @@ func (_m *MockProductsClientService) GetReplicationAdapters(params *products.Get
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationAdaptersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationAdaptersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -910,13 +1183,20 @@ func (_m *MockProductsClientService) GetReplicationAdapters(params *products.Get
 	return r0, r1
 }
 
-// GetReplicationExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationExecutions(params *products.GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationExecutionsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationExecutions(params *products.GetReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationExecutionsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationExecutionsOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter) *products.GetReplicationExecutionsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationExecutionsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationExecutionsOK)
@@ -924,8 +1204,8 @@ func (_m *MockProductsClientService) GetReplicationExecutions(params *products.G
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -933,13 +1213,20 @@ func (_m *MockProductsClientService) GetReplicationExecutions(params *products.G
 	return r0, r1
 }
 
-// GetReplicationExecutionsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationExecutionsID(params *products.GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationExecutionsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationExecutionsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationExecutionsID(params *products.GetReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationExecutionsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationExecutionsIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter) *products.GetReplicationExecutionsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationExecutionsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationExecutionsIDOK)
@@ -947,8 +1234,8 @@ func (_m *MockProductsClientService) GetReplicationExecutionsID(params *products
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -956,13 +1243,20 @@ func (_m *MockProductsClientService) GetReplicationExecutionsID(params *products
 	return r0, r1
 }
 
-// GetReplicationExecutionsIDTasks provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationExecutionsIDTasks(params *products.GetReplicationExecutionsIDTasksParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationExecutionsIDTasksOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationExecutionsIDTasks provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationExecutionsIDTasks(params *products.GetReplicationExecutionsIDTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationExecutionsIDTasksOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationExecutionsIDTasksOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDTasksParams, runtime.ClientAuthInfoWriter) *products.GetReplicationExecutionsIDTasksOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDTasksParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationExecutionsIDTasksOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationExecutionsIDTasksOK)
@@ -970,8 +1264,8 @@ func (_m *MockProductsClientService) GetReplicationExecutionsIDTasks(params *pro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDTasksParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDTasksParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -979,13 +1273,20 @@ func (_m *MockProductsClientService) GetReplicationExecutionsIDTasks(params *pro
 	return r0, r1
 }
 
-// GetReplicationExecutionsIDTasksTaskIDLog provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationExecutionsIDTasksTaskIDLog(params *products.GetReplicationExecutionsIDTasksTaskIDLogParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationExecutionsIDTasksTaskIDLogOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationExecutionsIDTasksTaskIDLog provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationExecutionsIDTasksTaskIDLog(params *products.GetReplicationExecutionsIDTasksTaskIDLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationExecutionsIDTasksTaskIDLogOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationExecutionsIDTasksTaskIDLogOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDTasksTaskIDLogParams, runtime.ClientAuthInfoWriter) *products.GetReplicationExecutionsIDTasksTaskIDLogOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationExecutionsIDTasksTaskIDLogParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationExecutionsIDTasksTaskIDLogOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationExecutionsIDTasksTaskIDLogOK)
@@ -993,8 +1294,8 @@ func (_m *MockProductsClientService) GetReplicationExecutionsIDTasksTaskIDLog(pa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDTasksTaskIDLogParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationExecutionsIDTasksTaskIDLogParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1002,13 +1303,20 @@ func (_m *MockProductsClientService) GetReplicationExecutionsIDTasksTaskIDLog(pa
 	return r0, r1
 }
 
-// GetReplicationPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationPolicies(params *products.GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationPoliciesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationPolicies(params *products.GetReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationPoliciesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationPoliciesOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter) *products.GetReplicationPoliciesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationPoliciesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationPoliciesOK)
@@ -1016,8 +1324,8 @@ func (_m *MockProductsClientService) GetReplicationPolicies(params *products.Get
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1025,13 +1333,20 @@ func (_m *MockProductsClientService) GetReplicationPolicies(params *products.Get
 	return r0, r1
 }
 
-// GetReplicationPoliciesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetReplicationPoliciesID(params *products.GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetReplicationPoliciesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReplicationPoliciesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetReplicationPoliciesID(params *products.GetReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetReplicationPoliciesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetReplicationPoliciesIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) *products.GetReplicationPoliciesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetReplicationPoliciesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetReplicationPoliciesIDOK)
@@ -1039,8 +1354,8 @@ func (_m *MockProductsClientService) GetReplicationPoliciesID(params *products.G
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1048,13 +1363,20 @@ func (_m *MockProductsClientService) GetReplicationPoliciesID(params *products.G
 	return r0, r1
 }
 
-// GetRetentionsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRetentionsID(params *products.GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRetentionsID(params *products.GetRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsIDOK)
@@ -1062,8 +1384,8 @@ func (_m *MockProductsClientService) GetRetentionsID(params *products.GetRetenti
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1071,13 +1393,20 @@ func (_m *MockProductsClientService) GetRetentionsID(params *products.GetRetenti
 	return r0, r1
 }
 
-// GetRetentionsIDExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRetentionsIDExecutions(params *products.GetRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsIDExecutionsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsIDExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRetentionsIDExecutions(params *products.GetRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsIDExecutionsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsIDExecutionsOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsIDExecutionsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsIDExecutionsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsIDExecutionsOK)
@@ -1085,8 +1414,8 @@ func (_m *MockProductsClientService) GetRetentionsIDExecutions(params *products.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1094,13 +1423,20 @@ func (_m *MockProductsClientService) GetRetentionsIDExecutions(params *products.
 	return r0, r1
 }
 
-// GetRetentionsIDExecutionsEidTasks provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasks(params *products.GetRetentionsIDExecutionsEidTasksParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsIDExecutionsEidTasksOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsIDExecutionsEidTasks provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasks(params *products.GetRetentionsIDExecutionsEidTasksParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsIDExecutionsEidTasksOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsIDExecutionsEidTasksOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDExecutionsEidTasksParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsIDExecutionsEidTasksOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDExecutionsEidTasksParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsIDExecutionsEidTasksOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsIDExecutionsEidTasksOK)
@@ -1108,8 +1444,8 @@ func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasks(params *p
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDExecutionsEidTasksParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDExecutionsEidTasksParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1117,13 +1453,20 @@ func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasks(params *p
 	return r0, r1
 }
 
-// GetRetentionsIDExecutionsEidTasksTid provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasksTid(params *products.GetRetentionsIDExecutionsEidTasksTidParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsIDExecutionsEidTasksTidOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsIDExecutionsEidTasksTid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasksTid(params *products.GetRetentionsIDExecutionsEidTasksTidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsIDExecutionsEidTasksTidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsIDExecutionsEidTasksTidOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDExecutionsEidTasksTidParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsIDExecutionsEidTasksTidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsIDExecutionsEidTasksTidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsIDExecutionsEidTasksTidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsIDExecutionsEidTasksTidOK)
@@ -1131,8 +1474,8 @@ func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasksTid(params
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDExecutionsEidTasksTidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsIDExecutionsEidTasksTidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1140,13 +1483,20 @@ func (_m *MockProductsClientService) GetRetentionsIDExecutionsEidTasksTid(params
 	return r0, r1
 }
 
-// GetRetentionsMetadatas provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetRetentionsMetadatas(params *products.GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetRetentionsMetadatasOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRetentionsMetadatas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetRetentionsMetadatas(params *products.GetRetentionsMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetRetentionsMetadatasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetRetentionsMetadatasOK
-	if rf, ok := ret.Get(0).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter) *products.GetRetentionsMetadatasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetRetentionsMetadatasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetRetentionsMetadatasOK)
@@ -1154,8 +1504,8 @@ func (_m *MockProductsClientService) GetRetentionsMetadatas(params *products.Get
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetRetentionsMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1163,13 +1513,20 @@ func (_m *MockProductsClientService) GetRetentionsMetadatas(params *products.Get
 	return r0, r1
 }
 
-// GetScanners provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetScanners(params *products.GetScannersParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetScannersOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetScanners provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetScanners(params *products.GetScannersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetScannersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetScannersOK
-	if rf, ok := ret.Get(0).(func(*products.GetScannersParams, runtime.ClientAuthInfoWriter) *products.GetScannersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetScannersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetScannersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetScannersOK)
@@ -1177,8 +1534,8 @@ func (_m *MockProductsClientService) GetScanners(params *products.GetScannersPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetScannersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetScannersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1186,13 +1543,20 @@ func (_m *MockProductsClientService) GetScanners(params *products.GetScannersPar
 	return r0, r1
 }
 
-// GetScannersRegistrationID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetScannersRegistrationID(params *products.GetScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetScannersRegistrationIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetScannersRegistrationID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetScannersRegistrationID(params *products.GetScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetScannersRegistrationIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetScannersRegistrationIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) *products.GetScannersRegistrationIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetScannersRegistrationIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetScannersRegistrationIDOK)
@@ -1200,8 +1564,8 @@ func (_m *MockProductsClientService) GetScannersRegistrationID(params *products.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1209,13 +1573,20 @@ func (_m *MockProductsClientService) GetScannersRegistrationID(params *products.
 	return r0, r1
 }
 
-// GetScannersRegistrationIDMetadata provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetScannersRegistrationIDMetadata(params *products.GetScannersRegistrationIDMetadataParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetScannersRegistrationIDMetadataOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetScannersRegistrationIDMetadata provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetScannersRegistrationIDMetadata(params *products.GetScannersRegistrationIDMetadataParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetScannersRegistrationIDMetadataOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetScannersRegistrationIDMetadataOK
-	if rf, ok := ret.Get(0).(func(*products.GetScannersRegistrationIDMetadataParams, runtime.ClientAuthInfoWriter) *products.GetScannersRegistrationIDMetadataOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetScannersRegistrationIDMetadataParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetScannersRegistrationIDMetadataOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetScannersRegistrationIDMetadataOK)
@@ -1223,8 +1594,8 @@ func (_m *MockProductsClientService) GetScannersRegistrationIDMetadata(params *p
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetScannersRegistrationIDMetadataParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetScannersRegistrationIDMetadataParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1232,13 +1603,20 @@ func (_m *MockProductsClientService) GetScannersRegistrationIDMetadata(params *p
 	return r0, r1
 }
 
-// GetScansAllMetrics provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetScansAllMetrics(params *products.GetScansAllMetricsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetScansAllMetricsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetScansAllMetrics provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetScansAllMetrics(params *products.GetScansAllMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetScansAllMetricsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetScansAllMetricsOK
-	if rf, ok := ret.Get(0).(func(*products.GetScansAllMetricsParams, runtime.ClientAuthInfoWriter) *products.GetScansAllMetricsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetScansAllMetricsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetScansAllMetricsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetScansAllMetricsOK)
@@ -1246,8 +1624,8 @@ func (_m *MockProductsClientService) GetScansAllMetrics(params *products.GetScan
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetScansAllMetricsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetScansAllMetricsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1255,13 +1633,20 @@ func (_m *MockProductsClientService) GetScansAllMetrics(params *products.GetScan
 	return r0, r1
 }
 
-// GetScansScheduleMetrics provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetScansScheduleMetrics(params *products.GetScansScheduleMetricsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetScansScheduleMetricsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetScansScheduleMetrics provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetScansScheduleMetrics(params *products.GetScansScheduleMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetScansScheduleMetricsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetScansScheduleMetricsOK
-	if rf, ok := ret.Get(0).(func(*products.GetScansScheduleMetricsParams, runtime.ClientAuthInfoWriter) *products.GetScansScheduleMetricsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetScansScheduleMetricsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetScansScheduleMetricsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetScansScheduleMetricsOK)
@@ -1269,8 +1654,8 @@ func (_m *MockProductsClientService) GetScansScheduleMetrics(params *products.Ge
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetScansScheduleMetricsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetScansScheduleMetricsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1278,13 +1663,20 @@ func (_m *MockProductsClientService) GetScansScheduleMetrics(params *products.Ge
 	return r0, r1
 }
 
-// GetSearch provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSearch(params *products.GetSearchParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSearchOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSearch provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSearch(params *products.GetSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSearchOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSearchOK
-	if rf, ok := ret.Get(0).(func(*products.GetSearchParams, runtime.ClientAuthInfoWriter) *products.GetSearchOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSearchOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSearchOK)
@@ -1292,8 +1684,8 @@ func (_m *MockProductsClientService) GetSearch(params *products.GetSearchParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSearchParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1301,13 +1693,20 @@ func (_m *MockProductsClientService) GetSearch(params *products.GetSearchParams,
 	return r0, r1
 }
 
-// GetStatistics provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetStatistics(params *products.GetStatisticsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetStatisticsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetStatistics provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetStatistics(params *products.GetStatisticsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetStatisticsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetStatisticsOK
-	if rf, ok := ret.Get(0).(func(*products.GetStatisticsParams, runtime.ClientAuthInfoWriter) *products.GetStatisticsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetStatisticsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetStatisticsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetStatisticsOK)
@@ -1315,8 +1714,8 @@ func (_m *MockProductsClientService) GetStatistics(params *products.GetStatistic
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetStatisticsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetStatisticsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1324,13 +1723,20 @@ func (_m *MockProductsClientService) GetStatistics(params *products.GetStatistic
 	return r0, r1
 }
 
-// GetSystemCVEAllowlist provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSystemCVEAllowlist(params *products.GetSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemCVEAllowlistOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemCVEAllowlist provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSystemCVEAllowlist(params *products.GetSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemCVEAllowlistOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemCVEAllowlistOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter) *products.GetSystemCVEAllowlistOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemCVEAllowlistOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemCVEAllowlistOK)
@@ -1338,8 +1744,8 @@ func (_m *MockProductsClientService) GetSystemCVEAllowlist(params *products.GetS
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1347,13 +1753,20 @@ func (_m *MockProductsClientService) GetSystemCVEAllowlist(params *products.GetS
 	return r0, r1
 }
 
-// GetSystemGc provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSystemGc(params *products.GetSystemGcParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemGcOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemGc provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSystemGc(params *products.GetSystemGcParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemGcOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemGcOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemGcParams, runtime.ClientAuthInfoWriter) *products.GetSystemGcOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemGcParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemGcOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemGcOK)
@@ -1361,8 +1774,8 @@ func (_m *MockProductsClientService) GetSystemGc(params *products.GetSystemGcPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemGcParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemGcParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1370,13 +1783,20 @@ func (_m *MockProductsClientService) GetSystemGc(params *products.GetSystemGcPar
 	return r0, r1
 }
 
-// GetSystemGcID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSystemGcID(params *products.GetSystemGcIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemGcIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemGcID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSystemGcID(params *products.GetSystemGcIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemGcIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemGcIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemGcIDParams, runtime.ClientAuthInfoWriter) *products.GetSystemGcIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemGcIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemGcIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemGcIDOK)
@@ -1384,8 +1804,8 @@ func (_m *MockProductsClientService) GetSystemGcID(params *products.GetSystemGcI
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemGcIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemGcIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1393,13 +1813,20 @@ func (_m *MockProductsClientService) GetSystemGcID(params *products.GetSystemGcI
 	return r0, r1
 }
 
-// GetSystemGcIDLog provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSystemGcIDLog(params *products.GetSystemGcIDLogParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemGcIDLogOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemGcIDLog provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSystemGcIDLog(params *products.GetSystemGcIDLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemGcIDLogOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemGcIDLogOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemGcIDLogParams, runtime.ClientAuthInfoWriter) *products.GetSystemGcIDLogOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemGcIDLogParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemGcIDLogOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemGcIDLogOK)
@@ -1407,8 +1834,8 @@ func (_m *MockProductsClientService) GetSystemGcIDLog(params *products.GetSystem
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemGcIDLogParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemGcIDLogParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1416,13 +1843,20 @@ func (_m *MockProductsClientService) GetSystemGcIDLog(params *products.GetSystem
 	return r0, r1
 }
 
-// GetSystemGcSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSystemGcSchedule(params *products.GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemGcScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemGcSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSystemGcSchedule(params *products.GetSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemGcScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemGcScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter) *products.GetSystemGcScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemGcScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemGcScheduleOK)
@@ -1430,8 +1864,8 @@ func (_m *MockProductsClientService) GetSystemGcSchedule(params *products.GetSys
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1439,13 +1873,20 @@ func (_m *MockProductsClientService) GetSystemGcSchedule(params *products.GetSys
 	return r0, r1
 }
 
-// GetSystemScanAllSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSystemScanAllSchedule(params *products.GetSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSystemScanAllScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSystemScanAllSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSystemScanAllSchedule(params *products.GetSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSystemScanAllScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSystemScanAllScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.GetSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter) *products.GetSystemScanAllScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSystemScanAllScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSystemScanAllScheduleOK)
@@ -1453,8 +1894,8 @@ func (_m *MockProductsClientService) GetSystemScanAllSchedule(params *products.G
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1462,13 +1903,20 @@ func (_m *MockProductsClientService) GetSystemScanAllSchedule(params *products.G
 	return r0, r1
 }
 
-// GetSysteminfo provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSysteminfo(params *products.GetSysteminfoParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSysteminfoOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSysteminfo provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSysteminfo(params *products.GetSysteminfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSysteminfoOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSysteminfoOK
-	if rf, ok := ret.Get(0).(func(*products.GetSysteminfoParams, runtime.ClientAuthInfoWriter) *products.GetSysteminfoOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSysteminfoParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSysteminfoOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSysteminfoOK)
@@ -1476,8 +1924,8 @@ func (_m *MockProductsClientService) GetSysteminfo(params *products.GetSysteminf
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSysteminfoParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSysteminfoParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1485,13 +1933,20 @@ func (_m *MockProductsClientService) GetSysteminfo(params *products.GetSysteminf
 	return r0, r1
 }
 
-// GetSysteminfoGetcert provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSysteminfoGetcert(params *products.GetSysteminfoGetcertParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSysteminfoGetcertOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSysteminfoGetcert provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSysteminfoGetcert(params *products.GetSysteminfoGetcertParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSysteminfoGetcertOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSysteminfoGetcertOK
-	if rf, ok := ret.Get(0).(func(*products.GetSysteminfoGetcertParams, runtime.ClientAuthInfoWriter) *products.GetSysteminfoGetcertOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSysteminfoGetcertParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSysteminfoGetcertOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSysteminfoGetcertOK)
@@ -1499,8 +1954,8 @@ func (_m *MockProductsClientService) GetSysteminfoGetcert(params *products.GetSy
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSysteminfoGetcertParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSysteminfoGetcertParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1508,13 +1963,20 @@ func (_m *MockProductsClientService) GetSysteminfoGetcert(params *products.GetSy
 	return r0, r1
 }
 
-// GetSysteminfoVolumes provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetSysteminfoVolumes(params *products.GetSysteminfoVolumesParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetSysteminfoVolumesOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetSysteminfoVolumes provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetSysteminfoVolumes(params *products.GetSysteminfoVolumesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetSysteminfoVolumesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetSysteminfoVolumesOK
-	if rf, ok := ret.Get(0).(func(*products.GetSysteminfoVolumesParams, runtime.ClientAuthInfoWriter) *products.GetSysteminfoVolumesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetSysteminfoVolumesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetSysteminfoVolumesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetSysteminfoVolumesOK)
@@ -1522,8 +1984,8 @@ func (_m *MockProductsClientService) GetSysteminfoVolumes(params *products.GetSy
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetSysteminfoVolumesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetSysteminfoVolumesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1531,13 +1993,20 @@ func (_m *MockProductsClientService) GetSysteminfoVolumes(params *products.GetSy
 	return r0, r1
 }
 
-// GetUsergroups provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsergroups(params *products.GetUsergroupsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsergroupsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsergroups provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsergroups(params *products.GetUsergroupsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsergroupsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsergroupsOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsergroupsParams, runtime.ClientAuthInfoWriter) *products.GetUsergroupsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsergroupsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsergroupsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsergroupsOK)
@@ -1545,8 +2014,8 @@ func (_m *MockProductsClientService) GetUsergroups(params *products.GetUsergroup
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsergroupsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsergroupsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1554,13 +2023,20 @@ func (_m *MockProductsClientService) GetUsergroups(params *products.GetUsergroup
 	return r0, r1
 }
 
-// GetUsergroupsGroupID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsergroupsGroupID(params *products.GetUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsergroupsGroupIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsergroupsGroupID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsergroupsGroupID(params *products.GetUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsergroupsGroupIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsergroupsGroupIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter) *products.GetUsergroupsGroupIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsergroupsGroupIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsergroupsGroupIDOK)
@@ -1568,8 +2044,8 @@ func (_m *MockProductsClientService) GetUsergroupsGroupID(params *products.GetUs
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1577,13 +2053,20 @@ func (_m *MockProductsClientService) GetUsergroupsGroupID(params *products.GetUs
 	return r0, r1
 }
 
-// GetUsers provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsers(params *products.GetUsersParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsersOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsers(params *products.GetUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsersOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsersOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter) *products.GetUsersOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsersOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsersOK)
@@ -1591,8 +2074,8 @@ func (_m *MockProductsClientService) GetUsers(params *products.GetUsersParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1600,13 +2083,20 @@ func (_m *MockProductsClientService) GetUsers(params *products.GetUsersParams, a
 	return r0, r1
 }
 
-// GetUsersCurrent provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsersCurrent(params *products.GetUsersCurrentParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsersCurrentOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsersCurrent provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsersCurrent(params *products.GetUsersCurrentParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsersCurrentOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsersCurrentOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsersCurrentParams, runtime.ClientAuthInfoWriter) *products.GetUsersCurrentOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsersCurrentParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsersCurrentOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsersCurrentOK)
@@ -1614,8 +2104,8 @@ func (_m *MockProductsClientService) GetUsersCurrent(params *products.GetUsersCu
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsersCurrentParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsersCurrentParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1623,13 +2113,20 @@ func (_m *MockProductsClientService) GetUsersCurrent(params *products.GetUsersCu
 	return r0, r1
 }
 
-// GetUsersCurrentPermissions provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsersCurrentPermissions(params *products.GetUsersCurrentPermissionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsersCurrentPermissionsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsersCurrentPermissions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsersCurrentPermissions(params *products.GetUsersCurrentPermissionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsersCurrentPermissionsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsersCurrentPermissionsOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsersCurrentPermissionsParams, runtime.ClientAuthInfoWriter) *products.GetUsersCurrentPermissionsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsersCurrentPermissionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsersCurrentPermissionsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsersCurrentPermissionsOK)
@@ -1637,8 +2134,8 @@ func (_m *MockProductsClientService) GetUsersCurrentPermissions(params *products
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsersCurrentPermissionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsersCurrentPermissionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1646,13 +2143,20 @@ func (_m *MockProductsClientService) GetUsersCurrentPermissions(params *products
 	return r0, r1
 }
 
-// GetUsersSearch provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsersSearch(params *products.GetUsersSearchParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsersSearchOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsersSearch provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsersSearch(params *products.GetUsersSearchParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsersSearchOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsersSearchOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsersSearchParams, runtime.ClientAuthInfoWriter) *products.GetUsersSearchOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsersSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsersSearchOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsersSearchOK)
@@ -1660,8 +2164,8 @@ func (_m *MockProductsClientService) GetUsersSearch(params *products.GetUsersSea
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsersSearchParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsersSearchParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1669,13 +2173,20 @@ func (_m *MockProductsClientService) GetUsersSearch(params *products.GetUsersSea
 	return r0, r1
 }
 
-// GetUsersUserID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) GetUsersUserID(params *products.GetUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.GetUsersUserIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetUsersUserID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) GetUsersUserID(params *products.GetUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.GetUsersUserIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.GetUsersUserIDOK
-	if rf, ok := ret.Get(0).(func(*products.GetUsersUserIDParams, runtime.ClientAuthInfoWriter) *products.GetUsersUserIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.GetUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.GetUsersUserIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.GetUsersUserIDOK)
@@ -1683,8 +2194,8 @@ func (_m *MockProductsClientService) GetUsersUserID(params *products.GetUsersUse
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.GetUsersUserIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.GetUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1692,13 +2203,20 @@ func (_m *MockProductsClientService) GetUsersUserID(params *products.GetUsersUse
 	return r0, r1
 }
 
-// PatchRetentionsIDExecutionsEid provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PatchRetentionsIDExecutionsEid(params *products.PatchRetentionsIDExecutionsEidParams, authInfo runtime.ClientAuthInfoWriter) (*products.PatchRetentionsIDExecutionsEidOK, error) {
-	ret := _m.Called(params, authInfo)
+// PatchRetentionsIDExecutionsEid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PatchRetentionsIDExecutionsEid(params *products.PatchRetentionsIDExecutionsEidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PatchRetentionsIDExecutionsEidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PatchRetentionsIDExecutionsEidOK
-	if rf, ok := ret.Get(0).(func(*products.PatchRetentionsIDExecutionsEidParams, runtime.ClientAuthInfoWriter) *products.PatchRetentionsIDExecutionsEidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PatchRetentionsIDExecutionsEidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PatchRetentionsIDExecutionsEidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PatchRetentionsIDExecutionsEidOK)
@@ -1706,8 +2224,8 @@ func (_m *MockProductsClientService) PatchRetentionsIDExecutionsEid(params *prod
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PatchRetentionsIDExecutionsEidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PatchRetentionsIDExecutionsEidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1715,13 +2233,20 @@ func (_m *MockProductsClientService) PatchRetentionsIDExecutionsEid(params *prod
 	return r0, r1
 }
 
-// PostChartrepoRepoChartsNameVersionLabels provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostChartrepoRepoChartsNameVersionLabels(params *products.PostChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostChartrepoRepoChartsNameVersionLabelsOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostChartrepoRepoChartsNameVersionLabels provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostChartrepoRepoChartsNameVersionLabels(params *products.PostChartrepoRepoChartsNameVersionLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostChartrepoRepoChartsNameVersionLabelsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostChartrepoRepoChartsNameVersionLabelsOK
-	if rf, ok := ret.Get(0).(func(*products.PostChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter) *products.PostChartrepoRepoChartsNameVersionLabelsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostChartrepoRepoChartsNameVersionLabelsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostChartrepoRepoChartsNameVersionLabelsOK)
@@ -1729,8 +2254,8 @@ func (_m *MockProductsClientService) PostChartrepoRepoChartsNameVersionLabels(pa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostChartrepoRepoChartsNameVersionLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1738,13 +2263,20 @@ func (_m *MockProductsClientService) PostChartrepoRepoChartsNameVersionLabels(pa
 	return r0, r1
 }
 
-// PostEmailPing provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostEmailPing(params *products.PostEmailPingParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostEmailPingOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostEmailPing provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostEmailPing(params *products.PostEmailPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostEmailPingOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostEmailPingOK
-	if rf, ok := ret.Get(0).(func(*products.PostEmailPingParams, runtime.ClientAuthInfoWriter) *products.PostEmailPingOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostEmailPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostEmailPingOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostEmailPingOK)
@@ -1752,8 +2284,8 @@ func (_m *MockProductsClientService) PostEmailPing(params *products.PostEmailPin
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostEmailPingParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostEmailPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1761,13 +2293,20 @@ func (_m *MockProductsClientService) PostEmailPing(params *products.PostEmailPin
 	return r0, r1
 }
 
-// PostLabels provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostLabels(params *products.PostLabelsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostLabelsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostLabels provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostLabels(params *products.PostLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostLabelsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostLabelsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostLabelsParams, runtime.ClientAuthInfoWriter) *products.PostLabelsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostLabelsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostLabelsCreated)
@@ -1775,8 +2314,8 @@ func (_m *MockProductsClientService) PostLabels(params *products.PostLabelsParam
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostLabelsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostLabelsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1784,13 +2323,20 @@ func (_m *MockProductsClientService) PostLabels(params *products.PostLabelsParam
 	return r0, r1
 }
 
-// PostLdapPing provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostLdapPing(params *products.PostLdapPingParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostLdapPingOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostLdapPing provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostLdapPing(params *products.PostLdapPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostLdapPingOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostLdapPingOK
-	if rf, ok := ret.Get(0).(func(*products.PostLdapPingParams, runtime.ClientAuthInfoWriter) *products.PostLdapPingOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostLdapPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostLdapPingOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostLdapPingOK)
@@ -1798,8 +2344,8 @@ func (_m *MockProductsClientService) PostLdapPing(params *products.PostLdapPingP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostLdapPingParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostLdapPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1807,13 +2353,20 @@ func (_m *MockProductsClientService) PostLdapPing(params *products.PostLdapPingP
 	return r0, r1
 }
 
-// PostLdapUsersImport provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostLdapUsersImport(params *products.PostLdapUsersImportParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostLdapUsersImportOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostLdapUsersImport provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostLdapUsersImport(params *products.PostLdapUsersImportParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostLdapUsersImportOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostLdapUsersImportOK
-	if rf, ok := ret.Get(0).(func(*products.PostLdapUsersImportParams, runtime.ClientAuthInfoWriter) *products.PostLdapUsersImportOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostLdapUsersImportParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostLdapUsersImportOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostLdapUsersImportOK)
@@ -1821,8 +2374,8 @@ func (_m *MockProductsClientService) PostLdapUsersImport(params *products.PostLd
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostLdapUsersImportParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostLdapUsersImportParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1830,13 +2383,20 @@ func (_m *MockProductsClientService) PostLdapUsersImport(params *products.PostLd
 	return r0, r1
 }
 
-// PostProjectsProjectIDImmutabletagrules provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostProjectsProjectIDImmutabletagrules(params *products.PostProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDImmutabletagrulesOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDImmutabletagrules provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostProjectsProjectIDImmutabletagrules(params *products.PostProjectsProjectIDImmutabletagrulesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDImmutabletagrulesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDImmutabletagrulesOK
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDImmutabletagrulesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDImmutabletagrulesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDImmutabletagrulesOK)
@@ -1844,8 +2404,8 @@ func (_m *MockProductsClientService) PostProjectsProjectIDImmutabletagrules(para
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDImmutabletagrulesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1853,13 +2413,20 @@ func (_m *MockProductsClientService) PostProjectsProjectIDImmutabletagrules(para
 	return r0, r1
 }
 
-// PostProjectsProjectIDMembers provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostProjectsProjectIDMembers(params *products.PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDMembersCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDMembers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostProjectsProjectIDMembers(params *products.PostProjectsProjectIDMembersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDMembersCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDMembersCreated
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDMembersCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDMembersCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDMembersCreated)
@@ -1867,8 +2434,8 @@ func (_m *MockProductsClientService) PostProjectsProjectIDMembers(params *produc
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMembersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1876,13 +2443,20 @@ func (_m *MockProductsClientService) PostProjectsProjectIDMembers(params *produc
 	return r0, r1
 }
 
-// PostProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostProjectsProjectIDMetadatas(params *products.PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDMetadatasOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDMetadatas provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostProjectsProjectIDMetadatas(params *products.PostProjectsProjectIDMetadatasParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDMetadatasOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDMetadatasOK
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDMetadatasOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDMetadatasOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDMetadatasOK)
@@ -1890,8 +2464,8 @@ func (_m *MockProductsClientService) PostProjectsProjectIDMetadatas(params *prod
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDMetadatasParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1899,13 +2473,20 @@ func (_m *MockProductsClientService) PostProjectsProjectIDMetadatas(params *prod
 	return r0, r1
 }
 
-// PostProjectsProjectIDRobots provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostProjectsProjectIDRobots(params *products.PostProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDRobotsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDRobots provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostProjectsProjectIDRobots(params *products.PostProjectsProjectIDRobotsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDRobotsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDRobotsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDRobotsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDRobotsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDRobotsCreated)
@@ -1913,8 +2494,8 @@ func (_m *MockProductsClientService) PostProjectsProjectIDRobots(params *product
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDRobotsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1922,13 +2503,20 @@ func (_m *MockProductsClientService) PostProjectsProjectIDRobots(params *product
 	return r0, r1
 }
 
-// PostProjectsProjectIDWebhookPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPolicies(params *products.PostProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDWebhookPoliciesCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDWebhookPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPolicies(params *products.PostProjectsProjectIDWebhookPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDWebhookPoliciesCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDWebhookPoliciesCreated
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDWebhookPoliciesCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDWebhookPoliciesCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDWebhookPoliciesCreated)
@@ -1936,8 +2524,8 @@ func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPolicies(params
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDWebhookPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1945,13 +2533,20 @@ func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPolicies(params
 	return r0, r1
 }
 
-// PostProjectsProjectIDWebhookPoliciesTest provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPoliciesTest(params *products.PostProjectsProjectIDWebhookPoliciesTestParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostProjectsProjectIDWebhookPoliciesTestOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostProjectsProjectIDWebhookPoliciesTest provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPoliciesTest(params *products.PostProjectsProjectIDWebhookPoliciesTestParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostProjectsProjectIDWebhookPoliciesTestOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostProjectsProjectIDWebhookPoliciesTestOK
-	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDWebhookPoliciesTestParams, runtime.ClientAuthInfoWriter) *products.PostProjectsProjectIDWebhookPoliciesTestOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostProjectsProjectIDWebhookPoliciesTestParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostProjectsProjectIDWebhookPoliciesTestOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostProjectsProjectIDWebhookPoliciesTestOK)
@@ -1959,8 +2554,8 @@ func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPoliciesTest(pa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDWebhookPoliciesTestParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostProjectsProjectIDWebhookPoliciesTestParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1968,13 +2563,20 @@ func (_m *MockProductsClientService) PostProjectsProjectIDWebhookPoliciesTest(pa
 	return r0, r1
 }
 
-// PostRegistries provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostRegistries(params *products.PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostRegistriesCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostRegistries provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostRegistries(params *products.PostRegistriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostRegistriesCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostRegistriesCreated
-	if rf, ok := ret.Get(0).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter) *products.PostRegistriesCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostRegistriesCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostRegistriesCreated)
@@ -1982,8 +2584,8 @@ func (_m *MockProductsClientService) PostRegistries(params *products.PostRegistr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostRegistriesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1991,13 +2593,20 @@ func (_m *MockProductsClientService) PostRegistries(params *products.PostRegistr
 	return r0, r1
 }
 
-// PostRegistriesPing provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostRegistriesPing(params *products.PostRegistriesPingParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostRegistriesPingOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostRegistriesPing provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostRegistriesPing(params *products.PostRegistriesPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostRegistriesPingOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostRegistriesPingOK
-	if rf, ok := ret.Get(0).(func(*products.PostRegistriesPingParams, runtime.ClientAuthInfoWriter) *products.PostRegistriesPingOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostRegistriesPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostRegistriesPingOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostRegistriesPingOK)
@@ -2005,8 +2614,8 @@ func (_m *MockProductsClientService) PostRegistriesPing(params *products.PostReg
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostRegistriesPingParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostRegistriesPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2014,13 +2623,20 @@ func (_m *MockProductsClientService) PostRegistriesPing(params *products.PostReg
 	return r0, r1
 }
 
-// PostReplicationExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostReplicationExecutions(params *products.PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostReplicationExecutionsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostReplicationExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostReplicationExecutions(params *products.PostReplicationExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostReplicationExecutionsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostReplicationExecutionsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter) *products.PostReplicationExecutionsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostReplicationExecutionsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostReplicationExecutionsCreated)
@@ -2028,8 +2644,8 @@ func (_m *MockProductsClientService) PostReplicationExecutions(params *products.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostReplicationExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2037,13 +2653,20 @@ func (_m *MockProductsClientService) PostReplicationExecutions(params *products.
 	return r0, r1
 }
 
-// PostReplicationPolicies provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostReplicationPolicies(params *products.PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostReplicationPoliciesCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostReplicationPolicies provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostReplicationPolicies(params *products.PostReplicationPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostReplicationPoliciesCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostReplicationPoliciesCreated
-	if rf, ok := ret.Get(0).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter) *products.PostReplicationPoliciesCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostReplicationPoliciesCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostReplicationPoliciesCreated)
@@ -2051,8 +2674,8 @@ func (_m *MockProductsClientService) PostReplicationPolicies(params *products.Po
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostReplicationPoliciesParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2060,13 +2683,20 @@ func (_m *MockProductsClientService) PostReplicationPolicies(params *products.Po
 	return r0, r1
 }
 
-// PostRetentions provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostRetentions(params *products.PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostRetentionsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostRetentions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostRetentions(params *products.PostRetentionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostRetentionsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostRetentionsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter) *products.PostRetentionsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostRetentionsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostRetentionsCreated)
@@ -2074,8 +2704,8 @@ func (_m *MockProductsClientService) PostRetentions(params *products.PostRetenti
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostRetentionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2083,13 +2713,20 @@ func (_m *MockProductsClientService) PostRetentions(params *products.PostRetenti
 	return r0, r1
 }
 
-// PostRetentionsIDExecutions provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostRetentionsIDExecutions(params *products.PostRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostRetentionsIDExecutionsOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostRetentionsIDExecutions provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostRetentionsIDExecutions(params *products.PostRetentionsIDExecutionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostRetentionsIDExecutionsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostRetentionsIDExecutionsOK
-	if rf, ok := ret.Get(0).(func(*products.PostRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter) *products.PostRetentionsIDExecutionsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostRetentionsIDExecutionsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostRetentionsIDExecutionsOK)
@@ -2097,8 +2734,8 @@ func (_m *MockProductsClientService) PostRetentionsIDExecutions(params *products
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostRetentionsIDExecutionsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2106,13 +2743,20 @@ func (_m *MockProductsClientService) PostRetentionsIDExecutions(params *products
 	return r0, r1
 }
 
-// PostScannersPing provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostScannersPing(params *products.PostScannersPingParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostScannersPingOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostScannersPing provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostScannersPing(params *products.PostScannersPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostScannersPingOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostScannersPingOK
-	if rf, ok := ret.Get(0).(func(*products.PostScannersPingParams, runtime.ClientAuthInfoWriter) *products.PostScannersPingOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostScannersPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostScannersPingOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostScannersPingOK)
@@ -2120,8 +2764,8 @@ func (_m *MockProductsClientService) PostScannersPing(params *products.PostScann
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostScannersPingParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostScannersPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2129,13 +2773,20 @@ func (_m *MockProductsClientService) PostScannersPing(params *products.PostScann
 	return r0, r1
 }
 
-// PostSystemGcSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostSystemGcSchedule(params *products.PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostSystemGcScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostSystemGcSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostSystemGcSchedule(params *products.PostSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostSystemGcScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostSystemGcScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter) *products.PostSystemGcScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostSystemGcScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostSystemGcScheduleOK)
@@ -2143,8 +2794,8 @@ func (_m *MockProductsClientService) PostSystemGcSchedule(params *products.PostS
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2152,13 +2803,20 @@ func (_m *MockProductsClientService) PostSystemGcSchedule(params *products.PostS
 	return r0, r1
 }
 
-// PostSystemOidcPing provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostSystemOidcPing(params *products.PostSystemOidcPingParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostSystemOidcPingOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostSystemOidcPing provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostSystemOidcPing(params *products.PostSystemOidcPingParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostSystemOidcPingOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostSystemOidcPingOK
-	if rf, ok := ret.Get(0).(func(*products.PostSystemOidcPingParams, runtime.ClientAuthInfoWriter) *products.PostSystemOidcPingOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostSystemOidcPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostSystemOidcPingOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostSystemOidcPingOK)
@@ -2166,8 +2824,8 @@ func (_m *MockProductsClientService) PostSystemOidcPing(params *products.PostSys
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostSystemOidcPingParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostSystemOidcPingParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2175,13 +2833,20 @@ func (_m *MockProductsClientService) PostSystemOidcPing(params *products.PostSys
 	return r0, r1
 }
 
-// PostSystemScanAllSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostSystemScanAllSchedule(params *products.PostSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostSystemScanAllScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// PostSystemScanAllSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostSystemScanAllSchedule(params *products.PostSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostSystemScanAllScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostSystemScanAllScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.PostSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter) *products.PostSystemScanAllScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostSystemScanAllScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostSystemScanAllScheduleOK)
@@ -2189,8 +2854,8 @@ func (_m *MockProductsClientService) PostSystemScanAllSchedule(params *products.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2198,13 +2863,20 @@ func (_m *MockProductsClientService) PostSystemScanAllSchedule(params *products.
 	return r0, r1
 }
 
-// PostUsergroups provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostUsergroups(params *products.PostUsergroupsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostUsergroupsCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostUsergroups provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostUsergroups(params *products.PostUsergroupsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostUsergroupsCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostUsergroupsCreated
-	if rf, ok := ret.Get(0).(func(*products.PostUsergroupsParams, runtime.ClientAuthInfoWriter) *products.PostUsergroupsCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostUsergroupsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostUsergroupsCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostUsergroupsCreated)
@@ -2212,8 +2884,8 @@ func (_m *MockProductsClientService) PostUsergroups(params *products.PostUsergro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostUsergroupsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostUsergroupsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2221,13 +2893,20 @@ func (_m *MockProductsClientService) PostUsergroups(params *products.PostUsergro
 	return r0, r1
 }
 
-// PostUsers provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PostUsers(params *products.PostUsersParams, authInfo runtime.ClientAuthInfoWriter) (*products.PostUsersCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostUsers provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PostUsers(params *products.PostUsersParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PostUsersCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PostUsersCreated
-	if rf, ok := ret.Get(0).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter) *products.PostUsersCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PostUsersCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PostUsersCreated)
@@ -2235,8 +2914,8 @@ func (_m *MockProductsClientService) PostUsers(params *products.PostUsersParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PostUsersParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2244,13 +2923,20 @@ func (_m *MockProductsClientService) PostUsers(params *products.PostUsersParams,
 	return r0, r1
 }
 
-// PutConfigurations provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutConfigurations(params *products.PutConfigurationsParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutConfigurationsOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutConfigurations provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutConfigurations(params *products.PutConfigurationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutConfigurationsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutConfigurationsOK
-	if rf, ok := ret.Get(0).(func(*products.PutConfigurationsParams, runtime.ClientAuthInfoWriter) *products.PutConfigurationsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutConfigurationsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutConfigurationsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutConfigurationsOK)
@@ -2258,8 +2944,8 @@ func (_m *MockProductsClientService) PutConfigurations(params *products.PutConfi
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutConfigurationsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutConfigurationsParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2267,13 +2953,20 @@ func (_m *MockProductsClientService) PutConfigurations(params *products.PutConfi
 	return r0, r1
 }
 
-// PutLabelsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutLabelsID(params *products.PutLabelsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutLabelsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutLabelsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutLabelsID(params *products.PutLabelsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutLabelsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutLabelsIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutLabelsIDParams, runtime.ClientAuthInfoWriter) *products.PutLabelsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutLabelsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutLabelsIDOK)
@@ -2281,8 +2974,8 @@ func (_m *MockProductsClientService) PutLabelsID(params *products.PutLabelsIDPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutLabelsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutLabelsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2290,13 +2983,20 @@ func (_m *MockProductsClientService) PutLabelsID(params *products.PutLabelsIDPar
 	return r0, r1
 }
 
-// PutProjectsProjectIDImmutabletagrulesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutProjectsProjectIDImmutabletagrulesID(params *products.PutProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDImmutabletagrulesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDImmutabletagrulesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutProjectsProjectIDImmutabletagrulesID(params *products.PutProjectsProjectIDImmutabletagrulesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDImmutabletagrulesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDImmutabletagrulesIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDImmutabletagrulesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDImmutabletagrulesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDImmutabletagrulesIDOK)
@@ -2304,8 +3004,8 @@ func (_m *MockProductsClientService) PutProjectsProjectIDImmutabletagrulesID(par
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDImmutabletagrulesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2313,13 +3013,20 @@ func (_m *MockProductsClientService) PutProjectsProjectIDImmutabletagrulesID(par
 	return r0, r1
 }
 
-// PutProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutProjectsProjectIDMembersMid(params *products.PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDMembersMidOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDMembersMid provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutProjectsProjectIDMembersMid(params *products.PutProjectsProjectIDMembersMidParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDMembersMidOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDMembersMidOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDMembersMidOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDMembersMidOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDMembersMidOK)
@@ -2327,8 +3034,8 @@ func (_m *MockProductsClientService) PutProjectsProjectIDMembersMid(params *prod
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMembersMidParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2336,13 +3043,20 @@ func (_m *MockProductsClientService) PutProjectsProjectIDMembersMid(params *prod
 	return r0, r1
 }
 
-// PutProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutProjectsProjectIDMetadatasMetaName(params *products.PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDMetadatasMetaNameOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDMetadatasMetaName provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutProjectsProjectIDMetadatasMetaName(params *products.PutProjectsProjectIDMetadatasMetaNameParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDMetadatasMetaNameOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDMetadatasMetaNameOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDMetadatasMetaNameOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDMetadatasMetaNameOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDMetadatasMetaNameOK)
@@ -2350,8 +3064,8 @@ func (_m *MockProductsClientService) PutProjectsProjectIDMetadatasMetaName(param
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDMetadatasMetaNameParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2359,13 +3073,20 @@ func (_m *MockProductsClientService) PutProjectsProjectIDMetadatasMetaName(param
 	return r0, r1
 }
 
-// PutProjectsProjectIDRobotsRobotID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutProjectsProjectIDRobotsRobotID(params *products.PutProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDRobotsRobotIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDRobotsRobotID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutProjectsProjectIDRobotsRobotID(params *products.PutProjectsProjectIDRobotsRobotIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDRobotsRobotIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDRobotsRobotIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDRobotsRobotIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDRobotsRobotIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDRobotsRobotIDOK)
@@ -2373,8 +3094,8 @@ func (_m *MockProductsClientService) PutProjectsProjectIDRobotsRobotID(params *p
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDRobotsRobotIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2382,13 +3103,20 @@ func (_m *MockProductsClientService) PutProjectsProjectIDRobotsRobotID(params *p
 	return r0, r1
 }
 
-// PutProjectsProjectIDWebhookPoliciesPolicyID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutProjectsProjectIDWebhookPoliciesPolicyID(params *products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDWebhookPoliciesPolicyID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutProjectsProjectIDWebhookPoliciesPolicyID(params *products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter) *products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK)
@@ -2396,8 +3124,8 @@ func (_m *MockProductsClientService) PutProjectsProjectIDWebhookPoliciesPolicyID
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2405,13 +3133,20 @@ func (_m *MockProductsClientService) PutProjectsProjectIDWebhookPoliciesPolicyID
 	return r0, r1
 }
 
-// PutQuotasID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutQuotasID(params *products.PutQuotasIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutQuotasIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutQuotasID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutQuotasID(params *products.PutQuotasIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutQuotasIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutQuotasIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutQuotasIDParams, runtime.ClientAuthInfoWriter) *products.PutQuotasIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutQuotasIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutQuotasIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutQuotasIDOK)
@@ -2419,8 +3154,8 @@ func (_m *MockProductsClientService) PutQuotasID(params *products.PutQuotasIDPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutQuotasIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutQuotasIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2428,13 +3163,20 @@ func (_m *MockProductsClientService) PutQuotasID(params *products.PutQuotasIDPar
 	return r0, r1
 }
 
-// PutRegistriesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutRegistriesID(params *products.PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutRegistriesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutRegistriesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutRegistriesID(params *products.PutRegistriesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutRegistriesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutRegistriesIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter) *products.PutRegistriesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutRegistriesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutRegistriesIDOK)
@@ -2442,8 +3184,8 @@ func (_m *MockProductsClientService) PutRegistriesID(params *products.PutRegistr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutRegistriesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2451,13 +3193,20 @@ func (_m *MockProductsClientService) PutRegistriesID(params *products.PutRegistr
 	return r0, r1
 }
 
-// PutReplicationExecutionsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutReplicationExecutionsID(params *products.PutReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutReplicationExecutionsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutReplicationExecutionsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutReplicationExecutionsID(params *products.PutReplicationExecutionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutReplicationExecutionsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutReplicationExecutionsIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter) *products.PutReplicationExecutionsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutReplicationExecutionsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutReplicationExecutionsIDOK)
@@ -2465,8 +3214,8 @@ func (_m *MockProductsClientService) PutReplicationExecutionsID(params *products
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutReplicationExecutionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2474,13 +3223,20 @@ func (_m *MockProductsClientService) PutReplicationExecutionsID(params *products
 	return r0, r1
 }
 
-// PutReplicationPoliciesID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutReplicationPoliciesID(params *products.PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutReplicationPoliciesIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutReplicationPoliciesID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutReplicationPoliciesID(params *products.PutReplicationPoliciesIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutReplicationPoliciesIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutReplicationPoliciesIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) *products.PutReplicationPoliciesIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutReplicationPoliciesIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutReplicationPoliciesIDOK)
@@ -2488,8 +3244,8 @@ func (_m *MockProductsClientService) PutReplicationPoliciesID(params *products.P
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutReplicationPoliciesIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2497,13 +3253,20 @@ func (_m *MockProductsClientService) PutReplicationPoliciesID(params *products.P
 	return r0, r1
 }
 
-// PutRetentionsID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutRetentionsID(params *products.PutRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutRetentionsIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutRetentionsID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutRetentionsID(params *products.PutRetentionsIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutRetentionsIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutRetentionsIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutRetentionsIDParams, runtime.ClientAuthInfoWriter) *products.PutRetentionsIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutRetentionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutRetentionsIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutRetentionsIDOK)
@@ -2511,8 +3274,8 @@ func (_m *MockProductsClientService) PutRetentionsID(params *products.PutRetenti
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutRetentionsIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutRetentionsIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2520,13 +3283,20 @@ func (_m *MockProductsClientService) PutRetentionsID(params *products.PutRetenti
 	return r0, r1
 }
 
-// PutSystemCVEAllowlist provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutSystemCVEAllowlist(params *products.PutSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutSystemCVEAllowlistOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutSystemCVEAllowlist provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutSystemCVEAllowlist(params *products.PutSystemCVEAllowlistParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutSystemCVEAllowlistOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutSystemCVEAllowlistOK
-	if rf, ok := ret.Get(0).(func(*products.PutSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter) *products.PutSystemCVEAllowlistOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutSystemCVEAllowlistOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutSystemCVEAllowlistOK)
@@ -2534,8 +3304,8 @@ func (_m *MockProductsClientService) PutSystemCVEAllowlist(params *products.PutS
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutSystemCVEAllowlistParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2543,13 +3313,20 @@ func (_m *MockProductsClientService) PutSystemCVEAllowlist(params *products.PutS
 	return r0, r1
 }
 
-// PutSystemGcSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutSystemGcSchedule(params *products.PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutSystemGcScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutSystemGcSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutSystemGcSchedule(params *products.PutSystemGcScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutSystemGcScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutSystemGcScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter) *products.PutSystemGcScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutSystemGcScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutSystemGcScheduleOK)
@@ -2557,8 +3334,8 @@ func (_m *MockProductsClientService) PutSystemGcSchedule(params *products.PutSys
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutSystemGcScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2566,13 +3343,20 @@ func (_m *MockProductsClientService) PutSystemGcSchedule(params *products.PutSys
 	return r0, r1
 }
 
-// PutSystemScanAllSchedule provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutSystemScanAllSchedule(params *products.PutSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutSystemScanAllScheduleOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutSystemScanAllSchedule provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutSystemScanAllSchedule(params *products.PutSystemScanAllScheduleParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutSystemScanAllScheduleOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutSystemScanAllScheduleOK
-	if rf, ok := ret.Get(0).(func(*products.PutSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter) *products.PutSystemScanAllScheduleOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutSystemScanAllScheduleOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutSystemScanAllScheduleOK)
@@ -2580,8 +3364,8 @@ func (_m *MockProductsClientService) PutSystemScanAllSchedule(params *products.P
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutSystemScanAllScheduleParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2589,13 +3373,20 @@ func (_m *MockProductsClientService) PutSystemScanAllSchedule(params *products.P
 	return r0, r1
 }
 
-// PutUsergroupsGroupID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutUsergroupsGroupID(params *products.PutUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsergroupsGroupIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsergroupsGroupID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutUsergroupsGroupID(params *products.PutUsergroupsGroupIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsergroupsGroupIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsergroupsGroupIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter) *products.PutUsergroupsGroupIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsergroupsGroupIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsergroupsGroupIDOK)
@@ -2603,8 +3394,8 @@ func (_m *MockProductsClientService) PutUsergroupsGroupID(params *products.PutUs
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsergroupsGroupIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2612,13 +3403,20 @@ func (_m *MockProductsClientService) PutUsergroupsGroupID(params *products.PutUs
 	return r0, r1
 }
 
-// PutUsersUserID provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutUsersUserID(params *products.PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsersUserIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsersUserID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutUsersUserID(params *products.PutUsersUserIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsersUserIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsersUserIDOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter) *products.PutUsersUserIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsersUserIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsersUserIDOK)
@@ -2626,8 +3424,8 @@ func (_m *MockProductsClientService) PutUsersUserID(params *products.PutUsersUse
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2635,13 +3433,20 @@ func (_m *MockProductsClientService) PutUsersUserID(params *products.PutUsersUse
 	return r0, r1
 }
 
-// PutUsersUserIDCliSecret provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutUsersUserIDCliSecret(params *products.PutUsersUserIDCliSecretParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsersUserIDCliSecretOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsersUserIDCliSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutUsersUserIDCliSecret(params *products.PutUsersUserIDCliSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsersUserIDCliSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsersUserIDCliSecretOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDCliSecretParams, runtime.ClientAuthInfoWriter) *products.PutUsersUserIDCliSecretOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDCliSecretParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsersUserIDCliSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsersUserIDCliSecretOK)
@@ -2649,8 +3454,8 @@ func (_m *MockProductsClientService) PutUsersUserIDCliSecret(params *products.Pu
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDCliSecretParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDCliSecretParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2658,13 +3463,20 @@ func (_m *MockProductsClientService) PutUsersUserIDCliSecret(params *products.Pu
 	return r0, r1
 }
 
-// PutUsersUserIDPassword provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutUsersUserIDPassword(params *products.PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsersUserIDPasswordOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsersUserIDPassword provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutUsersUserIDPassword(params *products.PutUsersUserIDPasswordParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsersUserIDPasswordOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsersUserIDPasswordOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter) *products.PutUsersUserIDPasswordOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsersUserIDPasswordOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsersUserIDPasswordOK)
@@ -2672,8 +3484,8 @@ func (_m *MockProductsClientService) PutUsersUserIDPassword(params *products.Put
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDPasswordParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2681,13 +3493,20 @@ func (_m *MockProductsClientService) PutUsersUserIDPassword(params *products.Put
 	return r0, r1
 }
 
-// PutUsersUserIDSysadmin provides a mock function with given fields: params, authInfo
-func (_m *MockProductsClientService) PutUsersUserIDSysadmin(params *products.PutUsersUserIDSysadminParams, authInfo runtime.ClientAuthInfoWriter) (*products.PutUsersUserIDSysadminOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutUsersUserIDSysadmin provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProductsClientService) PutUsersUserIDSysadmin(params *products.PutUsersUserIDSysadminParams, authInfo runtime.ClientAuthInfoWriter, opts ...products.ClientOption) (*products.PutUsersUserIDSysadminOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *products.PutUsersUserIDSysadminOK
-	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDSysadminParams, runtime.ClientAuthInfoWriter) *products.PutUsersUserIDSysadminOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*products.PutUsersUserIDSysadminParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) *products.PutUsersUserIDSysadminOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*products.PutUsersUserIDSysadminOK)
@@ -2695,8 +3514,8 @@ func (_m *MockProductsClientService) PutUsersUserIDSysadmin(params *products.Put
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDSysadminParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*products.PutUsersUserIDSysadminParams, runtime.ClientAuthInfoWriter, ...products.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/project_client_service.go
+++ b/apiv2/mocks/project_client_service.go
@@ -13,13 +13,20 @@ type MockProjectClientService struct {
 	mock.Mock
 }
 
-// CreateProject provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) CreateProject(params *project.CreateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*project.CreateProjectCreated, error) {
-	ret := _m.Called(params, authInfo)
+// CreateProject provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) CreateProject(params *project.CreateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.CreateProjectCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.CreateProjectCreated
-	if rf, ok := ret.Get(0).(func(*project.CreateProjectParams, runtime.ClientAuthInfoWriter) *project.CreateProjectCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.CreateProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.CreateProjectCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.CreateProjectCreated)
@@ -27,8 +34,8 @@ func (_m *MockProjectClientService) CreateProject(params *project.CreateProjectP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.CreateProjectParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.CreateProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -36,13 +43,20 @@ func (_m *MockProjectClientService) CreateProject(params *project.CreateProjectP
 	return r0, r1
 }
 
-// DeleteProject provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) DeleteProject(params *project.DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter) (*project.DeleteProjectOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteProject provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) DeleteProject(params *project.DeleteProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.DeleteProjectOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.DeleteProjectOK
-	if rf, ok := ret.Get(0).(func(*project.DeleteProjectParams, runtime.ClientAuthInfoWriter) *project.DeleteProjectOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.DeleteProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.DeleteProjectOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.DeleteProjectOK)
@@ -50,8 +64,8 @@ func (_m *MockProjectClientService) DeleteProject(params *project.DeleteProjectP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.DeleteProjectParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.DeleteProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +73,20 @@ func (_m *MockProjectClientService) DeleteProject(params *project.DeleteProjectP
 	return r0, r1
 }
 
-// GetLogs provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) GetLogs(params *project.GetLogsParams, authInfo runtime.ClientAuthInfoWriter) (*project.GetLogsOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetLogs provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) GetLogs(params *project.GetLogsParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.GetLogsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.GetLogsOK
-	if rf, ok := ret.Get(0).(func(*project.GetLogsParams, runtime.ClientAuthInfoWriter) *project.GetLogsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.GetLogsParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.GetLogsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.GetLogsOK)
@@ -73,8 +94,8 @@ func (_m *MockProjectClientService) GetLogs(params *project.GetLogsParams, authI
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.GetLogsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.GetLogsParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -82,13 +103,20 @@ func (_m *MockProjectClientService) GetLogs(params *project.GetLogsParams, authI
 	return r0, r1
 }
 
-// GetProject provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) GetProject(params *project.GetProjectParams, authInfo runtime.ClientAuthInfoWriter) (*project.GetProjectOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProject provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) GetProject(params *project.GetProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.GetProjectOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.GetProjectOK
-	if rf, ok := ret.Get(0).(func(*project.GetProjectParams, runtime.ClientAuthInfoWriter) *project.GetProjectOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.GetProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.GetProjectOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.GetProjectOK)
@@ -96,8 +124,8 @@ func (_m *MockProjectClientService) GetProject(params *project.GetProjectParams,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.GetProjectParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.GetProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -105,13 +133,20 @@ func (_m *MockProjectClientService) GetProject(params *project.GetProjectParams,
 	return r0, r1
 }
 
-// GetProjectDeletable provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) GetProjectDeletable(params *project.GetProjectDeletableParams, authInfo runtime.ClientAuthInfoWriter) (*project.GetProjectDeletableOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectDeletable provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) GetProjectDeletable(params *project.GetProjectDeletableParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.GetProjectDeletableOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.GetProjectDeletableOK
-	if rf, ok := ret.Get(0).(func(*project.GetProjectDeletableParams, runtime.ClientAuthInfoWriter) *project.GetProjectDeletableOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.GetProjectDeletableParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.GetProjectDeletableOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.GetProjectDeletableOK)
@@ -119,8 +154,8 @@ func (_m *MockProjectClientService) GetProjectDeletable(params *project.GetProje
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.GetProjectDeletableParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.GetProjectDeletableParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -128,13 +163,20 @@ func (_m *MockProjectClientService) GetProjectDeletable(params *project.GetProje
 	return r0, r1
 }
 
-// GetProjectSummary provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) GetProjectSummary(params *project.GetProjectSummaryParams, authInfo runtime.ClientAuthInfoWriter) (*project.GetProjectSummaryOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetProjectSummary provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) GetProjectSummary(params *project.GetProjectSummaryParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.GetProjectSummaryOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.GetProjectSummaryOK
-	if rf, ok := ret.Get(0).(func(*project.GetProjectSummaryParams, runtime.ClientAuthInfoWriter) *project.GetProjectSummaryOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.GetProjectSummaryParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.GetProjectSummaryOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.GetProjectSummaryOK)
@@ -142,8 +184,8 @@ func (_m *MockProjectClientService) GetProjectSummary(params *project.GetProject
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.GetProjectSummaryParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.GetProjectSummaryParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -151,13 +193,20 @@ func (_m *MockProjectClientService) GetProjectSummary(params *project.GetProject
 	return r0, r1
 }
 
-// HeadProject provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) HeadProject(params *project.HeadProjectParams, authInfo runtime.ClientAuthInfoWriter) (*project.HeadProjectOK, error) {
-	ret := _m.Called(params, authInfo)
+// HeadProject provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) HeadProject(params *project.HeadProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.HeadProjectOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.HeadProjectOK
-	if rf, ok := ret.Get(0).(func(*project.HeadProjectParams, runtime.ClientAuthInfoWriter) *project.HeadProjectOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.HeadProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.HeadProjectOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.HeadProjectOK)
@@ -165,8 +214,8 @@ func (_m *MockProjectClientService) HeadProject(params *project.HeadProjectParam
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.HeadProjectParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.HeadProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -174,13 +223,20 @@ func (_m *MockProjectClientService) HeadProject(params *project.HeadProjectParam
 	return r0, r1
 }
 
-// ListProjects provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) ListProjects(params *project.ListProjectsParams, authInfo runtime.ClientAuthInfoWriter) (*project.ListProjectsOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListProjects provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) ListProjects(params *project.ListProjectsParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.ListProjectsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.ListProjectsOK
-	if rf, ok := ret.Get(0).(func(*project.ListProjectsParams, runtime.ClientAuthInfoWriter) *project.ListProjectsOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.ListProjectsParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.ListProjectsOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.ListProjectsOK)
@@ -188,8 +244,8 @@ func (_m *MockProjectClientService) ListProjects(params *project.ListProjectsPar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.ListProjectsParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.ListProjectsParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -202,13 +258,20 @@ func (_m *MockProjectClientService) SetTransport(transport runtime.ClientTranspo
 	_m.Called(transport)
 }
 
-// UpdateProject provides a mock function with given fields: params, authInfo
-func (_m *MockProjectClientService) UpdateProject(params *project.UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter) (*project.UpdateProjectOK, error) {
-	ret := _m.Called(params, authInfo)
+// UpdateProject provides a mock function with given fields: params, authInfo, opts
+func (_m *MockProjectClientService) UpdateProject(params *project.UpdateProjectParams, authInfo runtime.ClientAuthInfoWriter, opts ...project.ClientOption) (*project.UpdateProjectOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *project.UpdateProjectOK
-	if rf, ok := ret.Get(0).(func(*project.UpdateProjectParams, runtime.ClientAuthInfoWriter) *project.UpdateProjectOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*project.UpdateProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) *project.UpdateProjectOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*project.UpdateProjectOK)
@@ -216,8 +279,8 @@ func (_m *MockProjectClientService) UpdateProject(params *project.UpdateProjectP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*project.UpdateProjectParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*project.UpdateProjectParams, runtime.ClientAuthInfoWriter, ...project.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/repository_client_service.go
+++ b/apiv2/mocks/repository_client_service.go
@@ -13,13 +13,20 @@ type MockRepositoryClientService struct {
 	mock.Mock
 }
 
-// DeleteRepository provides a mock function with given fields: params, authInfo
-func (_m *MockRepositoryClientService) DeleteRepository(params *repository.DeleteRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*repository.DeleteRepositoryOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteRepository provides a mock function with given fields: params, authInfo, opts
+func (_m *MockRepositoryClientService) DeleteRepository(params *repository.DeleteRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...repository.ClientOption) (*repository.DeleteRepositoryOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *repository.DeleteRepositoryOK
-	if rf, ok := ret.Get(0).(func(*repository.DeleteRepositoryParams, runtime.ClientAuthInfoWriter) *repository.DeleteRepositoryOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*repository.DeleteRepositoryParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) *repository.DeleteRepositoryOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*repository.DeleteRepositoryOK)
@@ -27,8 +34,8 @@ func (_m *MockRepositoryClientService) DeleteRepository(params *repository.Delet
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*repository.DeleteRepositoryParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*repository.DeleteRepositoryParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -36,13 +43,20 @@ func (_m *MockRepositoryClientService) DeleteRepository(params *repository.Delet
 	return r0, r1
 }
 
-// GetRepository provides a mock function with given fields: params, authInfo
-func (_m *MockRepositoryClientService) GetRepository(params *repository.GetRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*repository.GetRepositoryOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetRepository provides a mock function with given fields: params, authInfo, opts
+func (_m *MockRepositoryClientService) GetRepository(params *repository.GetRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...repository.ClientOption) (*repository.GetRepositoryOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *repository.GetRepositoryOK
-	if rf, ok := ret.Get(0).(func(*repository.GetRepositoryParams, runtime.ClientAuthInfoWriter) *repository.GetRepositoryOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*repository.GetRepositoryParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) *repository.GetRepositoryOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*repository.GetRepositoryOK)
@@ -50,8 +64,8 @@ func (_m *MockRepositoryClientService) GetRepository(params *repository.GetRepos
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*repository.GetRepositoryParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*repository.GetRepositoryParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +73,20 @@ func (_m *MockRepositoryClientService) GetRepository(params *repository.GetRepos
 	return r0, r1
 }
 
-// ListRepositories provides a mock function with given fields: params, authInfo
-func (_m *MockRepositoryClientService) ListRepositories(params *repository.ListRepositoriesParams, authInfo runtime.ClientAuthInfoWriter) (*repository.ListRepositoriesOK, error) {
-	ret := _m.Called(params, authInfo)
+// ListRepositories provides a mock function with given fields: params, authInfo, opts
+func (_m *MockRepositoryClientService) ListRepositories(params *repository.ListRepositoriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...repository.ClientOption) (*repository.ListRepositoriesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *repository.ListRepositoriesOK
-	if rf, ok := ret.Get(0).(func(*repository.ListRepositoriesParams, runtime.ClientAuthInfoWriter) *repository.ListRepositoriesOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*repository.ListRepositoriesParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) *repository.ListRepositoriesOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*repository.ListRepositoriesOK)
@@ -73,8 +94,8 @@ func (_m *MockRepositoryClientService) ListRepositories(params *repository.ListR
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*repository.ListRepositoriesParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*repository.ListRepositoriesParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -87,13 +108,20 @@ func (_m *MockRepositoryClientService) SetTransport(transport runtime.ClientTran
 	_m.Called(transport)
 }
 
-// UpdateRepository provides a mock function with given fields: params, authInfo
-func (_m *MockRepositoryClientService) UpdateRepository(params *repository.UpdateRepositoryParams, authInfo runtime.ClientAuthInfoWriter) (*repository.UpdateRepositoryOK, error) {
-	ret := _m.Called(params, authInfo)
+// UpdateRepository provides a mock function with given fields: params, authInfo, opts
+func (_m *MockRepositoryClientService) UpdateRepository(params *repository.UpdateRepositoryParams, authInfo runtime.ClientAuthInfoWriter, opts ...repository.ClientOption) (*repository.UpdateRepositoryOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *repository.UpdateRepositoryOK
-	if rf, ok := ret.Get(0).(func(*repository.UpdateRepositoryParams, runtime.ClientAuthInfoWriter) *repository.UpdateRepositoryOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*repository.UpdateRepositoryParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) *repository.UpdateRepositoryOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*repository.UpdateRepositoryOK)
@@ -101,8 +129,8 @@ func (_m *MockRepositoryClientService) UpdateRepository(params *repository.Updat
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*repository.UpdateRepositoryParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*repository.UpdateRepositoryParams, runtime.ClientAuthInfoWriter, ...repository.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/scan_client_service.go
+++ b/apiv2/mocks/scan_client_service.go
@@ -14,13 +14,20 @@ type MockScanClientService struct {
 	mock.Mock
 }
 
-// GetReportLog provides a mock function with given fields: params, authInfo
-func (_m *MockScanClientService) GetReportLog(params *scan.GetReportLogParams, authInfo runtime.ClientAuthInfoWriter) (*scan.GetReportLogOK, error) {
-	ret := _m.Called(params, authInfo)
+// GetReportLog provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScanClientService) GetReportLog(params *scan.GetReportLogParams, authInfo runtime.ClientAuthInfoWriter, opts ...scan.ClientOption) (*scan.GetReportLogOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scan.GetReportLogOK
-	if rf, ok := ret.Get(0).(func(*scan.GetReportLogParams, runtime.ClientAuthInfoWriter) *scan.GetReportLogOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scan.GetReportLogParams, runtime.ClientAuthInfoWriter, ...scan.ClientOption) *scan.GetReportLogOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scan.GetReportLogOK)
@@ -28,8 +35,8 @@ func (_m *MockScanClientService) GetReportLog(params *scan.GetReportLogParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scan.GetReportLogParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scan.GetReportLogParams, runtime.ClientAuthInfoWriter, ...scan.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -37,13 +44,20 @@ func (_m *MockScanClientService) GetReportLog(params *scan.GetReportLogParams, a
 	return r0, r1
 }
 
-// ScanArtifact provides a mock function with given fields: params, authInfo
-func (_m *MockScanClientService) ScanArtifact(params *scan.ScanArtifactParams, authInfo runtime.ClientAuthInfoWriter) (*scan.ScanArtifactAccepted, error) {
-	ret := _m.Called(params, authInfo)
+// ScanArtifact provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScanClientService) ScanArtifact(params *scan.ScanArtifactParams, authInfo runtime.ClientAuthInfoWriter, opts ...scan.ClientOption) (*scan.ScanArtifactAccepted, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scan.ScanArtifactAccepted
-	if rf, ok := ret.Get(0).(func(*scan.ScanArtifactParams, runtime.ClientAuthInfoWriter) *scan.ScanArtifactAccepted); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scan.ScanArtifactParams, runtime.ClientAuthInfoWriter, ...scan.ClientOption) *scan.ScanArtifactAccepted); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scan.ScanArtifactAccepted)
@@ -51,8 +65,8 @@ func (_m *MockScanClientService) ScanArtifact(params *scan.ScanArtifactParams, a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scan.ScanArtifactParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scan.ScanArtifactParams, runtime.ClientAuthInfoWriter, ...scan.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/apiv2/mocks/scanners_client_service.go
+++ b/apiv2/mocks/scanners_client_service.go
@@ -14,13 +14,20 @@ type MockScannersClientService struct {
 	mock.Mock
 }
 
-// DeleteScannersRegistrationID provides a mock function with given fields: params, authInfo
-func (_m *MockScannersClientService) DeleteScannersRegistrationID(params *scanners.DeleteScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*scanners.DeleteScannersRegistrationIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// DeleteScannersRegistrationID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScannersClientService) DeleteScannersRegistrationID(params *scanners.DeleteScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...scanners.ClientOption) (*scanners.DeleteScannersRegistrationIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scanners.DeleteScannersRegistrationIDOK
-	if rf, ok := ret.Get(0).(func(*scanners.DeleteScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) *scanners.DeleteScannersRegistrationIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scanners.DeleteScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) *scanners.DeleteScannersRegistrationIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scanners.DeleteScannersRegistrationIDOK)
@@ -28,8 +35,8 @@ func (_m *MockScannersClientService) DeleteScannersRegistrationID(params *scanne
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scanners.DeleteScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scanners.DeleteScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -37,13 +44,20 @@ func (_m *MockScannersClientService) DeleteScannersRegistrationID(params *scanne
 	return r0, r1
 }
 
-// PatchScannersRegistrationID provides a mock function with given fields: params, authInfo
-func (_m *MockScannersClientService) PatchScannersRegistrationID(params *scanners.PatchScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*scanners.PatchScannersRegistrationIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PatchScannersRegistrationID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScannersClientService) PatchScannersRegistrationID(params *scanners.PatchScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...scanners.ClientOption) (*scanners.PatchScannersRegistrationIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scanners.PatchScannersRegistrationIDOK
-	if rf, ok := ret.Get(0).(func(*scanners.PatchScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) *scanners.PatchScannersRegistrationIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scanners.PatchScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) *scanners.PatchScannersRegistrationIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scanners.PatchScannersRegistrationIDOK)
@@ -51,8 +65,8 @@ func (_m *MockScannersClientService) PatchScannersRegistrationID(params *scanner
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scanners.PatchScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scanners.PatchScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -60,13 +74,20 @@ func (_m *MockScannersClientService) PatchScannersRegistrationID(params *scanner
 	return r0, r1
 }
 
-// PostScanners provides a mock function with given fields: params, authInfo
-func (_m *MockScannersClientService) PostScanners(params *scanners.PostScannersParams, authInfo runtime.ClientAuthInfoWriter) (*scanners.PostScannersCreated, error) {
-	ret := _m.Called(params, authInfo)
+// PostScanners provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScannersClientService) PostScanners(params *scanners.PostScannersParams, authInfo runtime.ClientAuthInfoWriter, opts ...scanners.ClientOption) (*scanners.PostScannersCreated, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scanners.PostScannersCreated
-	if rf, ok := ret.Get(0).(func(*scanners.PostScannersParams, runtime.ClientAuthInfoWriter) *scanners.PostScannersCreated); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scanners.PostScannersParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) *scanners.PostScannersCreated); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scanners.PostScannersCreated)
@@ -74,8 +95,8 @@ func (_m *MockScannersClientService) PostScanners(params *scanners.PostScannersP
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scanners.PostScannersParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scanners.PostScannersParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -83,13 +104,20 @@ func (_m *MockScannersClientService) PostScanners(params *scanners.PostScannersP
 	return r0, r1
 }
 
-// PutProjectsProjectIDScanner provides a mock function with given fields: params, authInfo
-func (_m *MockScannersClientService) PutProjectsProjectIDScanner(params *scanners.PutProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter) (*scanners.PutProjectsProjectIDScannerOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutProjectsProjectIDScanner provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScannersClientService) PutProjectsProjectIDScanner(params *scanners.PutProjectsProjectIDScannerParams, authInfo runtime.ClientAuthInfoWriter, opts ...scanners.ClientOption) (*scanners.PutProjectsProjectIDScannerOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scanners.PutProjectsProjectIDScannerOK
-	if rf, ok := ret.Get(0).(func(*scanners.PutProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter) *scanners.PutProjectsProjectIDScannerOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scanners.PutProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) *scanners.PutProjectsProjectIDScannerOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scanners.PutProjectsProjectIDScannerOK)
@@ -97,8 +125,8 @@ func (_m *MockScannersClientService) PutProjectsProjectIDScanner(params *scanner
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scanners.PutProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scanners.PutProjectsProjectIDScannerParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -106,13 +134,20 @@ func (_m *MockScannersClientService) PutProjectsProjectIDScanner(params *scanner
 	return r0, r1
 }
 
-// PutScannersRegistrationID provides a mock function with given fields: params, authInfo
-func (_m *MockScannersClientService) PutScannersRegistrationID(params *scanners.PutScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter) (*scanners.PutScannersRegistrationIDOK, error) {
-	ret := _m.Called(params, authInfo)
+// PutScannersRegistrationID provides a mock function with given fields: params, authInfo, opts
+func (_m *MockScannersClientService) PutScannersRegistrationID(params *scanners.PutScannersRegistrationIDParams, authInfo runtime.ClientAuthInfoWriter, opts ...scanners.ClientOption) (*scanners.PutScannersRegistrationIDOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *scanners.PutScannersRegistrationIDOK
-	if rf, ok := ret.Get(0).(func(*scanners.PutScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) *scanners.PutScannersRegistrationIDOK); ok {
-		r0 = rf(params, authInfo)
+	if rf, ok := ret.Get(0).(func(*scanners.PutScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) *scanners.PutScannersRegistrationIDOK); ok {
+		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scanners.PutScannersRegistrationIDOK)
@@ -120,8 +155,8 @@ func (_m *MockScannersClientService) PutScannersRegistrationID(params *scanners.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*scanners.PutScannersRegistrationIDParams, runtime.ClientAuthInfoWriter) error); ok {
-		r1 = rf(params, authInfo)
+	if rf, ok := ret.Get(1).(func(*scanners.PutScannersRegistrationIDParams, runtime.ClientAuthInfoWriter, ...scanners.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This PR bumps the go-swagger image used for code generation to the latest [v0.26.1](https://github.com/go-swagger/go-swagger/releases/tag/v0.26.1) version.
Code has been re-generated using the above version.