### PR TITLE
implement fetching users by id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,14 @@ integration-test-v1: harbor-v1
 integration-test-v2: harbor-v2
 	CGO_ENABLED=0 go test -p 1 -count 1 -v github.com/mittwald/goharbor-client/v3/apiv2/... -tags integration
 
-# Exclude auto-generated code to be formatted by gofmt
+# Exclude auto-generated code to be formatted by gofmt, gofumpt & goimports.
+FIND=find . \( -path "./apiv*/internal" -o -path "./apiv*/mocks" -o -path "./apiv*/model" \) -prune -false -o -name '*.go'
+
 gofmt:
-	find . \( -path "./apiv*/internal" -o -path "./apiv*/mocks" -o -path "./apiv*/model" \)  \
-	-prune -false -o -name '*.go' -exec gofmt -l -w {} \;
+	$(FIND) -exec gofmt -l -w {} \;
+
+gofumpt:
+	$(FIND) -exec gofumpt -w {} \;
+
+goimports:
+	$(FIND) -exec goimports -w {} \;

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -89,6 +89,11 @@ func (c *RESTClient) GetUser(ctx context.Context, username string) (*legacymodel
 	return c.user.GetUser(ctx, username)
 }
 
+// GetUserByID wraps the GetUserByID method of the user sub-package.
+func (c *RESTClient) GetUserByID(ctx context.Context, id int64) (*legacymodel.User, error) {
+	return c.user.GetUserByID(ctx, id)
+}
+
 // DeleteUser wraps the DeleteUser method of the user sub-package.
 func (c *RESTClient) DeleteUser(ctx context.Context, u *legacymodel.User) error {
 	return c.user.DeleteUser(ctx, u)

--- a/apiv2/project/project.go
+++ b/apiv2/project/project.go
@@ -136,7 +136,6 @@ func (c *RESTClient) GetProjectByName(ctx context.Context, name string) (*modelv
 	}
 
 	projectList, err := c.ListProjects(ctx, name)
-
 	if err != nil {
 		return nil, handleSwaggerProjectErrors(err)
 	}
@@ -153,7 +152,6 @@ func (c *RESTClient) GetProjectByName(ctx context.Context, name string) (*modelv
 		ProjectID: projectID,
 		Context:   ctx,
 	}, c.AuthInfo)
-
 	if err != nil {
 		return nil, handleSwaggerProjectErrors(err)
 	}
@@ -171,7 +169,6 @@ func (c *RESTClient) GetProjectByID(ctx context.Context, projectID int64) (*mode
 		ProjectID: projectID,
 		Context:   ctx,
 	}, c.AuthInfo)
-
 	if err != nil {
 		return nil, handleSwaggerProjectErrors(err)
 	}
@@ -191,7 +188,6 @@ func (c *RESTClient) ListProjects(ctx context.Context, nameFilter string) ([]*mo
 		Name:    &nameFilter,
 		Context: ctx,
 	}, c.AuthInfo)
-
 	if err != nil {
 		return nil, handleSwaggerProjectErrors(err)
 	}
@@ -431,7 +427,6 @@ func (c *RESTClient) AddProjectMetadata(ctx context.Context, p *modelv2.Project,
 // GetProjectMetadataValue retrieves metadata with key of project p.
 func (c *RESTClient) GetProjectMetadataValue(ctx context.Context, projectID int64, key MetadataKey) (string, error) {
 	project, err := c.GetProjectByID(ctx, projectID)
-
 	if err != nil {
 		return "", handleSwaggerProjectErrors(err)
 	}

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -1,10 +1,10 @@
 package project
 
 import (
+	"net/http"
+
 	projectapi "github.com/mittwald/goharbor-client/v3/apiv2/internal/api/client/project"
 	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
-
-	"net/http"
 
 	"github.com/go-openapi/runtime"
 	"github.com/mittwald/goharbor-client/v3/apiv2/internal/legacyapi/client/products"

--- a/apiv2/project/project_integration_test.go
+++ b/apiv2/project/project_integration_test.go
@@ -366,9 +366,9 @@ func TestAPIProjectMetadataList(t *testing.T) {
 	m, err := c.ListProjectMetadata(ctx, p)
 	require.NoError(t, err)
 
-	var sPtrTrue = "true"
-	var sPtrMedium = "medium"
-	var sPtrRID = "1"
+	sPtrTrue := "true"
+	sPtrMedium := "medium"
+	sPtrRID := "1"
 
 	assert.Equal(t, &sPtrTrue, m.AutoScan)
 	assert.Equal(t, &sPtrTrue, m.EnableContentTrust)

--- a/apiv2/project/project_test.go
+++ b/apiv2/project/project_test.go
@@ -1513,7 +1513,7 @@ func TestRESTClient_AddProjectMetadata(t *testing.T) {
 
 	ctx := context.Background()
 
-	var mPtr = "true"
+	mPtr := "true"
 
 	pReq.Metadata = &modelv2.ProjectMetadata{}
 	pReq.Metadata.EnableContentTrust = &mPtr
@@ -1545,7 +1545,7 @@ func TestRESTClient_AddProjectMetadata_ErrProjectMetadataAlreadyExists(t *testin
 
 	ctx := context.Background()
 
-	var mPtr = "true"
+	mPtr := "true"
 	pReq.Metadata.EnableContentTrust = &mPtr
 	pReq.StorageLimit = nil
 
@@ -1587,7 +1587,7 @@ func TestRESTClient_GetProjectMetadataValue(t *testing.T) {
 		ProjectMetadataKeyPreventVul,
 	}
 
-	var sPtr = "test"
+	sPtr := "test"
 
 	for _, k := range keys {
 		getProjectsParams := &projectapi.GetProjectParams{
@@ -1787,7 +1787,7 @@ func TestRESTClient_GetProjectMetadataValue_ErrProjectUnknownResource(t *testing
 		ProjectMetadataKeyPreventVul,
 	}
 
-	var sPtr = "test"
+	sPtr := "test"
 
 	exampleProject.Metadata = &modelv2.ProjectMetadata{
 		AutoScan:             &sPtr,
@@ -1828,7 +1828,7 @@ func TestRESTClient_ListProjectMetadata(t *testing.T) {
 
 	ctx := context.Background()
 
-	var sPtr = "true"
+	sPtr := "true"
 
 	exampleProject2 := exampleProject
 
@@ -1882,7 +1882,7 @@ func TestRESTClient_UpdateProjectMetadata(t *testing.T) {
 		Context:   ctx,
 	}
 
-	var mPtr = "true"
+	mPtr := "true"
 	pReq2.Metadata.EnableContentTrust = &mPtr
 	updateProjectParams := &projectapi.UpdateProjectParams{
 		Project:   pReq2,
@@ -1923,7 +1923,7 @@ func TestRESTClient_UpdateProjectMetadata_GetProjectMeta_ErrProjectUnknownResour
 
 	ctx := context.Background()
 
-	var metaPtr = "true"
+	metaPtr := "true"
 
 	project := &modelv2.Project{
 		ProjectID: int32(exampleProjectID),
@@ -1964,7 +1964,7 @@ func TestRESTClient_UpdateProjectMetadata_DeleteProjectMeta_ErrProjectUnknownRes
 
 	ctx := context.Background()
 
-	var metaPtr = "true"
+	metaPtr := "true"
 
 	project := &modelv2.Project{
 		ProjectID: int32(exampleProjectID),
@@ -2014,7 +2014,7 @@ func TestRESTClient_DeleteProjectMetadataValue(t *testing.T) {
 
 	ctx := context.Background()
 
-	var metaPtr = "true"
+	metaPtr := "true"
 
 	project := &modelv2.Project{
 		ProjectID: int32(exampleProjectID),
@@ -2051,7 +2051,7 @@ func TestRESTClient_ListProjectRobots(t *testing.T) {
 	ctx := context.Background()
 
 	expectedRobots := []*model.RobotAccount{
-		&model.RobotAccount{
+		{
 			Description: "some robot account",
 			Disabled:    false,
 			ID:          42,

--- a/apiv2/quota/quota.go
+++ b/apiv2/quota/quota.go
@@ -66,7 +66,6 @@ func (c *RESTClient) UpdateStorageQuotaByProjectID(ctx context.Context, projectI
 	}
 
 	_, err := c.LegacyClient.Products.PutQuotasID(params, c.AuthInfo)
-
 	if err != nil {
 		return handleSwaggerQuotaErrors(err)
 	}

--- a/apiv2/retention/retention.go
+++ b/apiv2/retention/retention.go
@@ -178,7 +178,6 @@ func (c *RESTClient) DisableRetentionPolicy(ctx context.Context, ret *model.Rete
 	}
 
 	return nil
-
 }
 
 // UpdateRetentionPolicy updates the specified retention policy ret.

--- a/apiv2/retention/retention.go
+++ b/apiv2/retention/retention.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
 	"strconv"
+
+	modelv2 "github.com/mittwald/goharbor-client/v3/apiv2/model"
 
 	"github.com/go-openapi/runtime"
 	v2client "github.com/mittwald/goharbor-client/v3/apiv2/internal/api/client"

--- a/apiv2/retention/retention_integration_test.go
+++ b/apiv2/retention/retention_integration_test.go
@@ -45,7 +45,8 @@ func newTestRetention(projectID int64) model.RetentionPolicy {
 					Kind:       SelectorTypeDefault,
 					Pattern:    "**",
 					Extras:     "", // The "Extras" field is unused for scope selectors.
-				}}},
+				}},
+			},
 			TagSelectors: []*model.RetentionSelector{{
 				Decoration: TagSelectorMatches.String(),
 				Extras:     ToTagSelectorExtras(true),
@@ -142,27 +143,29 @@ func TestAPIRetentionUpdate(t *testing.T) {
 
 	changed := rp
 
-	changed.Rules = []*model.RetentionRule{{
-		Action:   "retain",
-		Disabled: true,
-		Params: map[string]interface{}{
-			PolicyTemplateDaysSinceLastPull.String(): 2,
-		},
-		ScopeSelectors: map[string][]model.RetentionSelector{
-			"repository": {{
-				Decoration: ScopeSelectorRepoExcludes.String(),
+	changed.Rules = []*model.RetentionRule{
+		{
+			Action:   "retain",
+			Disabled: true,
+			Params: map[string]interface{}{
+				PolicyTemplateDaysSinceLastPull.String(): 2,
+			},
+			ScopeSelectors: map[string][]model.RetentionSelector{
+				"repository": {{
+					Decoration: ScopeSelectorRepoExcludes.String(),
+					Kind:       SelectorTypeDefault,
+					Pattern:    "**",
+					Extras:     "", // The "Extras" field is unused for scope selectors.
+				}},
+			},
+			TagSelectors: []*model.RetentionSelector{{
+				Decoration: TagSelectorExcludes.String(),
+				Extras:     ToTagSelectorExtras(false),
 				Kind:       SelectorTypeDefault,
 				Pattern:    "**",
-				Extras:     "", // The "Extras" field is unused for scope selectors.
-			}}},
-		TagSelectors: []*model.RetentionSelector{{
-			Decoration: TagSelectorExcludes.String(),
-			Extras:     ToTagSelectorExtras(false),
-			Kind:       SelectorTypeDefault,
-			Pattern:    "**",
-		}},
-		Template: PolicyTemplateDaysSinceLastPull.String(),
-	},
+			}},
+			Template: PolicyTemplateDaysSinceLastPull.String(),
+		},
 	}
 
 	err = c.UpdateRetentionPolicy(ctx, changed)

--- a/apiv2/retention/retention_integration_test.go
+++ b/apiv2/retention/retention_integration_test.go
@@ -4,9 +4,10 @@ package retention
 
 import (
 	"context"
-	model "github.com/mittwald/goharbor-client/v3/apiv2/model/legacy"
 	"net/url"
 	"testing"
+
+	model "github.com/mittwald/goharbor-client/v3/apiv2/model/legacy"
 
 	runtimeclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"

--- a/apiv2/retention/retention_test.go
+++ b/apiv2/retention/retention_test.go
@@ -48,6 +48,7 @@ func BuildProjectClientWithMocks(project *mocks.MockProjectClientService) *v2cli
 		Project: project,
 	}
 }
+
 func TestNewClient(t *testing.T) {
 	p := &mocks.MockProductsClientService{}
 
@@ -163,7 +164,7 @@ func TestRESTClient_GetRetentionPolicy(t *testing.T) {
 
 	ctx := context.Background()
 
-	var retentionIDPtr = "1"
+	retentionIDPtr := "1"
 
 	project := &modelv2.Project{
 		Deleted: false,
@@ -205,7 +206,7 @@ func TestRESTClient_GetRetentionPolicy_ErrProjectNotFound(t *testing.T) {
 
 	ctx := context.Background()
 
-	var retentionIDPtr = "1"
+	retentionIDPtr := "1"
 
 	project := &modelv2.Project{
 		Deleted: false,
@@ -242,7 +243,7 @@ func TestRESTClient_GetRetentionPolicy_ErrRetentionUnauthorized(t *testing.T) {
 
 	ctx := context.Background()
 
-	var retentionIDPtr = "10"
+	retentionIDPtr := "10"
 
 	project := &modelv2.Project{
 		Deleted: false,
@@ -434,16 +435,19 @@ func TestErrRetentionNotProvided_Error(t *testing.T) {
 
 	assert.Equal(t, ErrRetentionNotProvidedMsg, e.Error())
 }
+
 func TestErrRetentionNoPermission_Error(t *testing.T) {
 	var e ErrRetentionNoPermission
 
 	assert.Equal(t, ErrRetentionNoPermissionMsg, e.Error())
 }
+
 func TestErrRetentionDoesNotExist_Error(t *testing.T) {
 	var e ErrRetentionDoesNotExist
 
 	assert.Equal(t, ErrRetentionDoesNotExistMsg, e.Error())
 }
+
 func TestErrRetentionInternalErrors_Error(t *testing.T) {
 	var e ErrRetentionInternalErrors
 

--- a/apiv2/user/user.go
+++ b/apiv2/user/user.go
@@ -102,7 +102,7 @@ func (c *RESTClient) GetUser(ctx context.Context, username string) (*model.User,
 // GetUserByID fetches a registered user by the provided user id.
 // Returns an error if no user could be found, or if the id is '0'.
 func (c *RESTClient) GetUserByID(ctx context.Context, id int64) (*model.User, error) {
-	if id == 0 {
+	if id <= 0 {
 		return nil, &ErrUserInvalidID{}
 	}
 

--- a/apiv2/user/user.go
+++ b/apiv2/user/user.go
@@ -37,6 +37,7 @@ type Client interface {
 	NewUser(ctx context.Context, username, email, realname, password,
 		comments string) (*model.User, error)
 	GetUser(ctx context.Context, username string) (*model.User, error)
+	GetUserByID(ctx context.Context, id int64) (*model.User, error)
 	DeleteUser(ctx context.Context, u *model.User) error
 	UpdateUser(ctx context.Context, u *model.User) error
 	UpdateUserPassword(ctx context.Context, id int64, password *model.Password) error
@@ -96,6 +97,28 @@ func (c *RESTClient) GetUser(ctx context.Context, username string) (*model.User,
 	}
 
 	return nil, &ErrUserNotFound{}
+}
+
+// GetUserByID fetches a registered user by the provided user id.
+// Returns an error if no user could be found, or if the id is '0'.
+func (c *RESTClient) GetUserByID(ctx context.Context, id int64) (*model.User, error) {
+	if id == 0 {
+		return nil, &ErrUserInvalidID{}
+	}
+
+	resp, err := c.LegacyClient.Products.GetUsersUserID(&products.GetUsersUserIDParams{
+		UserID:  id,
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerUserErrors(err)
+	}
+
+	if resp.Payload.UserID != id {
+		return nil, &ErrUserMismatch{}
+	}
+
+	return resp.Payload, nil
 }
 
 // DeleteUser deletes the specified user.

--- a/apiv2/user/user_errors.go
+++ b/apiv2/user/user_errors.go
@@ -23,6 +23,9 @@ const (
 	// ErrUserInvalidIDMsg is the error message for ErrUserInvalidID error.
 	ErrUserInvalidIDMsg = "invalid user ID"
 
+	// ErrUserIDNotExistsMsg is the error message for ErrUserIDNotExists error.
+	ErrUserIDNotExistsMsg = "user id does not exist"
+
 	// ErrUserPasswordInvalid  is the error message for ErrUserPasswordInvalid error.
 	ErrUserPasswordInvalidMsg = "invalid user password"
 )
@@ -67,9 +70,18 @@ func (e *ErrUserInvalidID) Error() string {
 	return ErrUserInvalidIDMsg
 }
 
+// ErrUserIDNotExists describes an error indicating a non existing user id.
+type ErrUserIDNotExists struct{}
+
+// Error returns the error message.
+func (e *ErrUserIDNotExists) Error() string {
+	return ErrUserIDNotExistsMsg
+}
+
 // ErrUserPasswordInvalid describes an error indicating an invalid password
 type ErrUserPasswordInvalid struct{}
 
+// Error returns the error message.
 func (e *ErrUserPasswordInvalid) Error() string {
 	return ErrUserPasswordInvalidMsg
 }

--- a/apiv2/user/user_integration_test.go
+++ b/apiv2/user/user_integration_test.go
@@ -92,6 +92,35 @@ func TestAPIUserGet(t *testing.T) {
 	assert.Equal(t, user, user2)
 }
 
+func TestAPIUserGet_2(t *testing.T) {
+	ctx := context.Background()
+	username := "foobar"
+	email := "foo@bar.com"
+	realname := "Foo Bar"
+	password := "1VerySeriousPassword"
+	comments := "Some comments"
+
+	c := NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+	user, err := c.NewUser(ctx, username, email, realname, password, comments)
+
+	require.NoError(t, err)
+	require.NotNil(t, user)
+
+	defer c.DeleteUser(ctx, user)
+
+	user2, err := c.GetUser(ctx, username)
+
+	require.NoError(t, err)
+	require.NotNil(t, user2)
+
+	user3, err := c.GetUserByID(ctx, user2.UserID)
+
+	require.NoError(t, err)
+	require.NotNil(t, user3)
+
+	assert.Equal(t, user, user3)
+}
+
 func TestAPIUserDelete(t *testing.T) {
 	ctx := context.Background()
 	username := "foobar"

--- a/apiv2/user/user_test.go
+++ b/apiv2/user/user_test.go
@@ -300,8 +300,18 @@ func TestRESTClient_GetUserByID_ID_Mismatch(t *testing.T) {
 		p.AssertExpectations(t)
 	})
 
-	t.Run("InvalidID", func(t *testing.T) {
+	t.Run("InvalidID_Null", func(t *testing.T) {
 		_, err := cl.GetUserByID(ctx, 0)
+
+		if assert.Error(t, err) {
+			assert.IsType(t, &ErrUserInvalidID{}, err)
+		}
+
+		p.AssertExpectations(t)
+	})
+
+	t.Run("InvalidID_Negative", func(t *testing.T) {
+		_, err := cl.GetUserByID(ctx, -1)
 
 		if assert.Error(t, err) {
 			assert.IsType(t, &ErrUserInvalidID{}, err)

--- a/apiv2/user/user_test.go
+++ b/apiv2/user/user_test.go
@@ -25,7 +25,7 @@ var (
 	exampleUser     = "example-user"
 	examplePassword = "password"
 	exampleEmail    = "test@example.com"
-	exampleUserID   = int64(0)
+	exampleUserID   = int64(1)
 )
 
 func BuildLegacyClientWithMock(service *mocks.MockProductsClientService) *client.Harbor {
@@ -237,6 +237,78 @@ func TestRESTClient_GetUser(t *testing.T) {
 	assert.NoError(t, err)
 
 	p.AssertExpectations(t)
+}
+
+func TestRESTClient_GetUserByID(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+	v2Client := BuildV2ClientWithMocks()
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	getUserIDParams := &products.GetUsersUserIDParams{
+		UserID:  exampleUserID,
+		Context: ctx,
+	}
+
+	p.On("GetUsersUserID", getUserIDParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.GetUsersUserIDOK{
+			Payload: &model.User{
+				UserID: exampleUserID,
+			},
+		}, nil)
+
+	_, err := cl.GetUserByID(ctx, exampleUserID)
+
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+}
+
+func TestRESTClient_GetUserByID_ID_Mismatch(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+	v2Client := BuildV2ClientWithMocks()
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	getUserIDParams := &products.GetUsersUserIDParams{
+		UserID:  exampleUserID,
+		Context: ctx,
+	}
+
+	t.Run("IDMismatch", func(t *testing.T) {
+		p.On("GetUsersUserID", getUserIDParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+			Return(&products.GetUsersUserIDOK{
+				Payload: &model.User{
+					UserID: 0,
+				},
+			}, nil)
+
+		_, err := cl.GetUserByID(ctx, exampleUserID)
+
+		if assert.Error(t, err) {
+			assert.IsType(t, &ErrUserMismatch{}, err)
+		}
+
+		p.AssertExpectations(t)
+	})
+
+	t.Run("InvalidID", func(t *testing.T) {
+		_, err := cl.GetUserByID(ctx, 0)
+
+		if assert.Error(t, err) {
+			assert.IsType(t, &ErrUserInvalidID{}, err)
+		}
+
+		p.AssertExpectations(t)
+	})
 }
 
 func TestRESTClient_GetUser_EmptyUserName(t *testing.T) {
@@ -769,4 +841,10 @@ func TestErrUserPasswordInvalid_Error(t *testing.T) {
 	var e ErrUserPasswordInvalid
 
 	assert.Equal(t, ErrUserPasswordInvalidMsg, e.Error())
+}
+
+func TestErrUserIDNotExists_Error(t *testing.T) {
+	var e ErrUserIDNotExists
+
+	assert.Equal(t, ErrUserIDNotExistsMsg, e.Error())
 }


### PR DESCRIPTION
This PR adds a functionality `GetUserByID()` to the user client, enabling the client to fetch goharbor users by their ID.
Previously, this was only possible via `GetUser()`, which required passing a `user` struct as argument. 