### PR TITLE
Add webhook policy support

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -211,6 +211,26 @@ func (c *RESTClient) DeleteProjectRobot(ctx context.Context, p *modelv2.Project,
 	return c.project.DeleteProjectRobot(ctx, p, robotID)
 }
 
+// ListProjectWebhookPolicies wraps the ListProjectWebhookPolicies method of the project sub-package.
+func (c *RESTClient) ListProjectWebhookPolicies(ctx context.Context, p *modelv2.Project) ([]*legacymodel.WebhookPolicy, error) {
+	return c.project.ListProjectWebhookPolicies(ctx, p)
+}
+
+// UpdateProjectWebhookPolicy wraps the UpdateProjectWebhookPolicy method of the project sub-package.
+func (c *RESTClient) UpdateProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policyID int, policy *legacymodel.WebhookPolicy) error {
+	return c.project.UpdateProjectWebhookPolicy(ctx, p, policyID, policy)
+}
+
+// AddProjectWebhookPolicy wraps the AddProjectWebhookPolicy method of the project sub-package.
+func (c *RESTClient) AddProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policy *legacymodel.WebhookPolicy) error {
+	return c.project.AddProjectWebhookPolicy(ctx, p, policy)
+}
+
+// DeleteProjectWebhookPolicy wraps the DeleteProjectWebhookPolicy method of the project sub-package.
+func (c *RESTClient) DeleteProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policyID int) error {
+	return c.project.DeleteProjectWebhookPolicy(ctx, p, policyID)
+}
+
 // Registry Client
 
 // NewRegistry wraps the NewRegistry method of the registry sub-package.

--- a/apiv2/project/project.go
+++ b/apiv2/project/project.go
@@ -641,6 +641,10 @@ func (c *RESTClient) UpdateProjectWebhookPolicy(ctx context.Context, p *modelv2.
 		return &ErrProjectNotProvided{}
 	}
 
+	if policy == nil {
+		return &ErrProjectNoWebhookPolicyProvided{}
+	}
+
 	_, err := c.LegacyClient.Products.PutProjectsProjectIDWebhookPoliciesPolicyID(
 		&products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams{
 			ProjectID: int64(p.ProjectID),

--- a/apiv2/project/project.go
+++ b/apiv2/project/project.go
@@ -70,6 +70,11 @@ type Client interface {
 	AddProjectRobot(ctx context.Context, p *modelv2.Project, robot *model.RobotAccountCreate) (string, error)
 	UpdateProjectRobot(ctx context.Context, p *modelv2.Project, robotID int, robot *model.RobotAccountUpdate) error
 	DeleteProjectRobot(ctx context.Context, p *modelv2.Project, robotID int) error
+
+	ListProjectWebhookPolicies(ctx context.Context, p *modelv2.Project) ([]*model.WebhookPolicy, error)
+	AddProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, webhookPolicy *model.WebhookPolicy) error
+	UpdateProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policyID int, policy *model.WebhookPolicy) error
+	DeleteProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policyID int) error
 }
 
 type MetadataKey string
@@ -584,6 +589,82 @@ func (c *RESTClient) DeleteProjectRobot(ctx context.Context, p *modelv2.Project,
 		&products.DeleteProjectsProjectIDRobotsRobotIDParams{
 			ProjectID: int64(p.ProjectID),
 			RobotID:   int64(robotID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerProjectErrors(err)
+	}
+
+	return nil
+}
+
+// ListProjectWebhookPolicies returns a list of all webhook policies in project p.
+func (c *RESTClient) ListProjectWebhookPolicies(ctx context.Context, p *modelv2.Project) ([]*model.WebhookPolicy, error) {
+	if p == nil {
+		return nil, &ErrProjectNotProvided{}
+	}
+
+	resp, err := c.LegacyClient.Products.GetProjectsProjectIDWebhookPolicies(
+		&products.GetProjectsProjectIDWebhookPoliciesParams{
+			ProjectID: int64(p.ProjectID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerProjectErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// AddProjectWebhookPolicy adds a webhook policy to project p.
+func (c *RESTClient) AddProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policy *model.WebhookPolicy) error {
+	if p == nil {
+		return &ErrProjectNotProvided{}
+	}
+
+	if policy == nil {
+		return &ErrProjectNoWebhookPolicyProvided{}
+	}
+
+	_, err := c.LegacyClient.Products.PostProjectsProjectIDWebhookPolicies(
+		&products.PostProjectsProjectIDWebhookPoliciesParams{
+			Policy:    policy,
+			ProjectID: int64(p.ProjectID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	return handleSwaggerProjectErrors(err)
+}
+
+// UpdateProjectWebhookPolicy updates a webhook policy in project p.
+func (c *RESTClient) UpdateProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policyID int, policy *model.WebhookPolicy) error {
+	if p == nil {
+		return &ErrProjectNotProvided{}
+	}
+
+	_, err := c.LegacyClient.Products.PutProjectsProjectIDWebhookPoliciesPolicyID(
+		&products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams{
+			ProjectID: int64(p.ProjectID),
+			Policy:    policy,
+			PolicyID:  int64(policyID),
+			Context:   ctx,
+		}, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerProjectErrors(err)
+	}
+
+	return nil
+}
+
+// DeleteProjectWebhookPolicy deletes a webhook policy from project p.
+func (c *RESTClient) DeleteProjectWebhookPolicy(ctx context.Context, p *modelv2.Project, policyID int) error {
+	if p == nil {
+		return &ErrProjectNotProvided{}
+	}
+
+	_, err := c.LegacyClient.Products.DeleteProjectsProjectIDWebhookPoliciesPolicyID(
+		&products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams{
+			ProjectID: int64(p.ProjectID),
+			PolicyID:  int64(policyID),
 			Context:   ctx,
 		}, c.AuthInfo)
 	if err != nil {

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -67,6 +67,9 @@ const (
 
 	// ErrProjectMetadataValueUndefinedMsg is the error message used for MetadataKey's being undefined or nil.
 	ErrProjectMetadataValueUndefinedMsg = "project metadata value is nil: "
+
+	// ErrProjectNoWebhookPolicyProvidedMsg is the error message for ErrProjectNoWebhookPolicyProvided error.
+	ErrProjectNoWebhookPolicyProvidedMsg = "no project member provided"
 )
 
 // ErrProjectNameNotProvided describes a missing project name.
@@ -276,6 +279,15 @@ type ErrProjectUnknownResource struct{}
 // Error returns the error message.
 func (e *ErrProjectUnknownResource) Error() string {
 	return ErrProjectUnknownResourceMsg
+}
+
+// ErrProjectNoWebhookPolicyProvided describes which happens,
+// when no webhook policy is provided.
+type ErrProjectNoWebhookPolicyProvided struct{}
+
+// Error returns the error message.
+func (e *ErrProjectNoWebhookPolicyProvided) Error() string {
+	return ErrProjectNoWebhookPolicyProvidedMsg
 }
 
 // retrieveMetadataValue returns the value of the metadata k that is contained in the project metadata m.

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -69,7 +69,7 @@ const (
 	ErrProjectMetadataValueUndefinedMsg = "project metadata value is nil: "
 
 	// ErrProjectNoWebhookPolicyProvidedMsg is the error message for ErrProjectNoWebhookPolicyProvided error.
-	ErrProjectNoWebhookPolicyProvidedMsg = "no project member provided"
+	ErrProjectNoWebhookPolicyProvidedMsg = "no webhook policy provided"
 )
 
 // ErrProjectNameNotProvided describes a missing project name.

--- a/apiv2/project/project_test.go
+++ b/apiv2/project/project_test.go
@@ -2183,6 +2183,148 @@ func TestRESTClient_DeleteProjectRobot(t *testing.T) {
 	p.AssertExpectations(t)
 }
 
+func TestRESTClient_ListProjectWebhookPolicies(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+	v2Client := BuildProjectClientWithMocks(nil)
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	expectedWebhookPolicies := []*model.WebhookPolicy{
+		{
+			ID:        42,
+			Name:      "example-policy",
+			ProjectID: exampleProjectID,
+		},
+	}
+
+	params := &products.GetProjectsProjectIDWebhookPoliciesParams{
+		ProjectID: exampleProjectID,
+		Context:   ctx,
+	}
+
+	p.On("GetProjectsProjectIDWebhookPolicies", params, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.GetProjectsProjectIDWebhookPoliciesOK{Payload: expectedWebhookPolicies}, nil)
+
+	webhookPolicies, err := cl.ListProjectWebhookPolicies(ctx, exampleProject)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedWebhookPolicies, webhookPolicies)
+
+	p.AssertExpectations(t)
+}
+
+func TestRESTClient_AddProjectWebhookPolicy(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+	v2Client := BuildProjectClientWithMocks(nil)
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	newPolicy := &model.WebhookPolicy{
+		Enabled: true,
+		Name:    "my-policy",
+		Targets: []*model.WebhookTargetObject{{
+			Address: "http://example-webhook.com",
+		}},
+		EventTypes: []string{
+			"SCANNING_FAILED",
+			"SCANNING_COMPLETED",
+		},
+	}
+
+	params := &products.PostProjectsProjectIDWebhookPoliciesParams{
+		ProjectID: exampleProjectID,
+		Policy:    newPolicy,
+		Context:   ctx,
+	}
+
+	p.On("PostProjectsProjectIDWebhookPolicies", params, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.PostProjectsProjectIDWebhookPoliciesCreated{}, nil)
+
+	err := cl.AddProjectWebhookPolicy(ctx, exampleProject, newPolicy)
+
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+}
+
+func TestRESTClient_UpdateProjectWebhookPolicy(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+	v2Client := BuildProjectClientWithMocks(nil)
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	const examplePolicyID = 42
+
+	updatePolicy := &model.WebhookPolicy{
+		Enabled: false,
+		Name:    "my-policy",
+		Targets: []*model.WebhookTargetObject{{
+			Address: "http://example-webhook.com",
+		}},
+		EventTypes: []string{
+			"SCANNING_FAILED",
+			"SCANNING_COMPLETED",
+		},
+	}
+
+	params := &products.PutProjectsProjectIDWebhookPoliciesPolicyIDParams{
+		ProjectID: exampleProjectID,
+		PolicyID:  examplePolicyID,
+		Policy:    updatePolicy,
+		Context:   ctx,
+	}
+
+	p.On("PutProjectsProjectIDWebhookPoliciesPolicyID", params, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.PutProjectsProjectIDWebhookPoliciesPolicyIDOK{}, nil)
+
+	err := cl.UpdateProjectWebhookPolicy(ctx, exampleProject, examplePolicyID, updatePolicy)
+
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteProjectWebhookPolicy(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+	v2Client := BuildProjectClientWithMocks(nil)
+
+	cl := NewClient(legacyClient, v2Client, authInfo)
+
+	ctx := context.Background()
+
+	const examplePolicyID = 42
+
+	params := &products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDParams{
+		ProjectID: exampleProjectID,
+		PolicyID:  examplePolicyID,
+		Context:   ctx,
+	}
+
+	p.On("DeleteProjectsProjectIDWebhookPoliciesPolicyID", params, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.DeleteProjectsProjectIDWebhookPoliciesPolicyIDOK{}, nil)
+
+	err := cl.DeleteProjectWebhookPolicy(ctx, exampleProject, examplePolicyID)
+
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+}
+
 func TestErrProjectNameNotProvided_Error(t *testing.T) {
 	var e ErrProjectNameNotProvided
 


### PR DESCRIPTION
I'm working on a project that requires us to be able to list, delete, add, or update webhook policies for projects.
This PR is to add support for that. It only adds it to the V2 client as this is what we're using.

Let me know if any issues. Thanks