### PR TITLE
add robot client

### DIFF
--- a/apiv1/project/project_errors.go
+++ b/apiv1/project/project_errors.go
@@ -197,7 +197,7 @@ func (e *ErrProjectMetadataAlreadyExists) Error() string {
 }
 
 // ErrProjectUnknownResource describes which happens,
-// when requesting an unknown ressource.
+// when requesting an unknown resource.
 type ErrProjectUnknownResource struct{}
 
 // Error returns the error message.

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -9,12 +9,14 @@ import (
 	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
 	"github.com/mittwald/goharbor-client/v4/apiv2/quota"
 	"github.com/mittwald/goharbor-client/v4/apiv2/retention"
+	"github.com/mittwald/goharbor-client/v4/apiv2/robot"
 
 	"github.com/go-openapi/runtime"
 	runtimeclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
 	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"
 	legacymodel "github.com/mittwald/goharbor-client/v4/apiv2/model/legacy"
 	"github.com/mittwald/goharbor-client/v4/apiv2/project"
@@ -47,6 +49,7 @@ type RESTClient struct {
 	retention   *retention.RESTClient
 	quota       *quota.RESTClient
 	gc          *gc.RESTClient
+	robot       *robot.RESTClient
 }
 
 // NewRESTClient constructs a new REST client containing each sub client.
@@ -60,6 +63,7 @@ func NewRESTClient(legacyClient *client.Harbor, v2Client *v2client.Harbor, authI
 		retention:   retention.NewClient(legacyClient, v2Client, authInfo),
 		quota:       quota.NewClient(legacyClient, v2Client, authInfo),
 		gc:          gc.NewClient(legacyClient, v2Client, authInfo),
+		robot:       robot.NewClient(v2Client, authInfo),
 	}
 }
 
@@ -295,12 +299,12 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context, r *modelv2.Re
 	return c.replication.GetReplicationExecutions(ctx, r)
 }
 
-// GetReplicationExecutionsByID wraps the GetReplicationExecutionsByID method of the replication sub-package.
+// GetReplicationExecutionByID GetReplicationExecutionsByID wraps the GetReplicationExecutionsByID method of the replication sub-package.
 func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context, id int64) (*modelv2.ReplicationExecution, error) {
 	return c.replication.GetReplicationExecutionByID(ctx, id)
 }
 
-// System Client
+// GarbageCollection Client
 
 // NewGarbageCollection wraps the NewSystemGarbageCollection method of the system sub-package.
 func (c *RESTClient) NewGarbageCollection(ctx context.Context, gcSchedule *modelv2.Schedule) error {
@@ -322,6 +326,8 @@ func (c *RESTClient) ResetGarbageCollection(ctx context.Context) error {
 	return c.gc.ResetGarbageCollection(ctx)
 }
 
+// System Client
+
 // Health wraps the Health method of the system sub-package.
 func (c *RESTClient) Health(ctx context.Context) (*legacymodel.OverallHealthStatus, error) {
 	return c.system.Health(ctx)
@@ -334,7 +340,7 @@ func (c *RESTClient) NewRetentionPolicy(ctx context.Context, ret *modelv2.Retent
 	return c.retention.NewRetentionPolicy(ctx, ret)
 }
 
-// GetRetentionPolicyByProjectID wraps the GetRetentionPolicyByProject method of the retention sub-package.
+// GetRetentionPolicyByProject GetRetentionPolicyByProjectID wraps the GetRetentionPolicyByProject method of the retention sub-package.
 func (c *RESTClient) GetRetentionPolicyByProject(ctx context.Context, project *modelv2.Project) (*modelv2.RetentionPolicy, error) {
 	return c.retention.GetRetentionPolicyByProject(ctx, project)
 }
@@ -364,4 +370,41 @@ func (c *RESTClient) GetQuotaByProjectID(ctx context.Context, projectID int64) (
 // UpdateStorageQuotaByProjectID wraps the UpdateStorageQuotaByProjectID method of the quota sub-package.
 func (c *RESTClient) UpdateStorageQuotaByProjectID(ctx context.Context, projectID int64, storageLimit int64) error {
 	return c.quota.UpdateStorageQuotaByProjectID(ctx, projectID, storageLimit)
+}
+
+// Robot Client
+
+// ListRobotAccounts wraps the ListRobotAccounts method of the robot sub-package.
+func (c *RESTClient) ListRobotAccounts(ctx context.Context) ([]*modelv2.Robot, error) {
+	return c.robot.ListRobotAccounts(ctx)
+}
+
+// GetRobotAccountByName wraps the GetRobotAccountByName method of the robot sub-package.
+func (c *RESTClient) GetRobotAccountByName(ctx context.Context, name string) (*modelv2.Robot, error) {
+	return c.robot.GetRobotAccountByName(ctx, name)
+}
+
+// GetRobotAccountByID wraps the GetRobotAccountByID method of the robot sub-package.
+func (c *RESTClient) GetRobotAccountByID(ctx context.Context, id int64) (*modelv2.Robot, error) {
+	return c.robot.GetRobotAccountByID(ctx, id)
+}
+
+// NewRobotAccount wraps the NewRobotAccount method of the robot sub-package.
+func (c *RESTClient) NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) (*modelv2.RobotCreated, error) {
+	return c.robot.NewRobotAccount(ctx, r)
+}
+
+// DeleteRobotAccountByName wraps the DeleteRobotAccountByName method of the robot sub-package.
+func (c *RESTClient) DeleteRobotAccountByName(ctx context.Context, name string) error {
+	return c.robot.DeleteRobotAccountByName(ctx, name)
+}
+
+// DeleteRobotAccountByID wraps the DeleteRobotAccountByID method of the robot sub-package.
+func (c *RESTClient) DeleteRobotAccountByID(ctx context.Context, id int64) error {
+	return c.robot.DeleteRobotAccountByID(ctx, id)
+}
+
+// UpdateRobotAccount wraps the UpdateRobotAccount method of the robot sub-package.
+func (c *RESTClient) UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) error {
+	return c.robot.UpdateRobotAccount(ctx, r)
 }

--- a/apiv2/gc/gc.go
+++ b/apiv2/gc/gc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-openapi/runtime"
+
 	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/gc"
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -7,6 +7,7 @@ import (
 	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client/products"
 )
 
@@ -154,7 +155,8 @@ func (e *ErrProjectNotProvided) Error() string {
 	return ErrProjectNotProvidedMsg
 }
 
-// ErrProjectNoMemberProvided
+// ErrProjectNoMemberProvided describes an error
+// when a project's member is not provided.
 type ErrProjectNoMemberProvided struct{}
 
 // Error returns the error message.
@@ -273,7 +275,7 @@ func (e *ErrProjectMetadataAlreadyExists) Error() string {
 }
 
 // ErrProjectUnknownResource describes which happens,
-// when requesting an unknown ressource.
+// when requesting an unknown resource.
 type ErrProjectUnknownResource struct{}
 
 // Error returns the error message.

--- a/apiv2/robot/robot.go
+++ b/apiv2/robot/robot.go
@@ -1,0 +1,178 @@
+package robot
+
+import (
+	"context"
+
+	"github.com/go-openapi/runtime"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/robot"
+	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
+)
+
+const (
+	// Definitions in this block may be used to interact with the package methods.
+
+	// LevelProject defines a project-wide access level for a robot account.
+	LevelProject Level = "project"
+	// LevelSystem defines a system-wide access level for a robot account.
+	LevelSystem Level = "system"
+
+	ResourceRepository       AccessResource = "repository"
+	ResourceArtifact         AccessResource = "artifact"
+	ResourceHelmChart        AccessResource = "helm-chart"
+	ResourceHelmChartVersion AccessResource = "helm-chart-version"
+	ResourceTag              AccessResource = "tag"
+	ResourceArtifactLabel    AccessResource = "artifact-label"
+	ResourceScan             AccessResource = "scan"
+
+	ActionPush   AccessAction = "push"
+	ActionPull   AccessAction = "pull"
+	ActionCreate AccessAction = "create"
+	ActionDelete AccessAction = "delete"
+	ActionRead   AccessAction = "read"
+)
+
+// RESTClient is a subclient for handling project related actions.
+type RESTClient struct {
+	// The new client of the harbor v2 API
+	V2Client *v2client.Harbor
+
+	// AuthInfo contains the auth information that is provided on API calls.
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func NewClient(v2Client *v2client.Harbor, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
+	return &RESTClient{
+		V2Client: v2Client,
+		AuthInfo: authInfo,
+	}
+}
+
+type Client interface {
+	ListRobotAccounts(ctx context.Context) ([]*modelv2.Robot, error)
+	GetRobotAccountByName(ctx context.Context, name string) (*modelv2.Robot, error)
+	GetRobotAccountByID(ctx context.Context, id int64) (*modelv2.Robot, error)
+	NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) (*modelv2.RobotCreated, error)
+	DeleteRobotAccountByName(ctx context.Context, name string) error
+	DeleteRobotAccountByID(ctx context.Context, id int64) error
+	UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) error
+}
+
+type Level string
+
+func (in Level) String() string {
+	return string(in)
+}
+
+type AccessResource string
+
+func (in AccessResource) String() string {
+	return string(in)
+}
+
+type AccessAction string
+
+func (in AccessAction) String() string {
+	return string(in)
+}
+
+// ListRobotAccounts ListProjectRobots returns a list of all robot accounts.
+func (c *RESTClient) ListRobotAccounts(ctx context.Context) ([]*modelv2.Robot, error) {
+	resp, err := c.V2Client.Robot.ListRobot(&robot.ListRobotParams{
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerRobotErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// GetRobotAccountByName GetRobotByName lists all existing robot accounts and returns the one matching the provided name.
+// Note that the generic 'robot$'-prefix of the robot name is implicitly used for getting the resource.
+func (c *RESTClient) GetRobotAccountByName(ctx context.Context, name string) (*modelv2.Robot, error) {
+	robots, err := c.ListRobotAccounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range robots {
+		if r.Name == "robot$"+name {
+			return r, nil
+		}
+	}
+
+	return nil, &ErrRobotAccountUnknownResource{}
+}
+
+// GetRobotAccountByID GetRobotByID returns a robot account identified by its 'id'.
+func (c *RESTClient) GetRobotAccountByID(ctx context.Context, id int64) (*modelv2.Robot, error) {
+	resp, err := c.V2Client.Robot.GetRobotByID(&robot.GetRobotByIDParams{
+		RobotID: id,
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerRobotErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// NewRobotAccount creates a new robot account from the specification of 'r' and returns a 'RobotCreated' response.
+func (c *RESTClient) NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) (*modelv2.RobotCreated, error) {
+	resp, err := c.V2Client.Robot.CreateRobot(&robot.CreateRobotParams{
+		Robot:   r,
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerRobotErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// DeleteRobotAccountByName deletes a robot account identified by its 'name'.
+// Note that the generic 'robot$'-prefix of the robot name is implicitly used for deletion.
+func (c *RESTClient) DeleteRobotAccountByName(ctx context.Context, name string) error {
+	robots, err := c.ListRobotAccounts(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range robots {
+		if r.Name == "robot$"+name {
+			return c.DeleteRobotAccountByID(ctx, r.ID)
+		}
+	}
+
+	return &ErrRobotAccountUnknownResource{}
+}
+
+// DeleteRobotAccountByID DeleteProjectRobotByID deletes a robot account identified by its id.
+func (c *RESTClient) DeleteRobotAccountByID(ctx context.Context, id int64) error {
+	_, err := c.V2Client.Robot.DeleteRobot(&robot.DeleteRobotParams{
+		RobotID: id,
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerRobotErrors(err)
+	}
+
+	return nil
+}
+
+// UpdateRobotAccount updates the robot account 'r' with the provided specification.
+// Note that modelv2.Robot.Name & modelv2.Robot.Level are immutable by API definitions.
+func (c *RESTClient) UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) error {
+	_, err := c.V2Client.Robot.UpdateRobot(&robot.UpdateRobotParams{
+		Robot:   r,
+		RobotID: r.ID,
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerRobotErrors(err)
+	}
+
+	return nil
+}

--- a/apiv2/robot/robot_errors.go
+++ b/apiv2/robot/robot_errors.go
@@ -1,0 +1,99 @@
+package robot
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/robot"
+)
+
+const (
+	// ErrRobotAccountInvalidMsg is the error message for ErrRobotAccountInvalid error.
+	ErrRobotAccountInvalidMsg = "the robot account is invalid"
+	// ErrRobotAccountUnauthorizedMsg is the error message for ErrRobotAccountUnauthorized error.
+	ErrRobotAccountUnauthorizedMsg = "unauthorized"
+	// ErrRobotAccountNoPermissionMsg is the error message for ErrRobotAccountNoPermission error.
+	ErrRobotAccountNoPermissionMsg = "user does not have permission to the robot account"
+	// ErrRobotAccountUnknownResourceMsg is the error message for ErrRobotAccountUnknownResource error.
+	ErrRobotAccountUnknownResourceMsg = "resource unknown"
+	// ErrRobotAccountInternalErrorsMsg is the error message for ErrRobotAccountInternalErrors error.
+	ErrRobotAccountInternalErrorsMsg = "internal server error"
+)
+
+// ErrRobotAccountInvalid describes an invalid robot account error.
+type ErrRobotAccountInvalid struct{}
+
+// Error returns the error message.
+func (e *ErrRobotAccountInvalid) Error() string {
+	return ErrRobotAccountInvalidMsg
+}
+
+// ErrRobotAccountUnauthorized describes an unauthorized request to the 'robots' API.
+type ErrRobotAccountUnauthorized struct{}
+
+// Error returns the error message.
+func (e *ErrRobotAccountUnauthorized) Error() string {
+	return ErrRobotAccountUnauthorizedMsg
+}
+
+// ErrRobotAccountNoPermission describes a request error without permission.
+type ErrRobotAccountNoPermission struct{}
+
+// Error returns the error message.
+func (e *ErrRobotAccountNoPermission) Error() string {
+	return ErrRobotAccountNoPermissionMsg
+}
+
+// ErrRobotAccountUnknownResource describes an error when
+// the specified robot account could not be found.
+type ErrRobotAccountUnknownResource struct{}
+
+// Error returns the error message.
+func (e *ErrRobotAccountUnknownResource) Error() string {
+	return ErrRobotAccountUnknownResourceMsg
+}
+
+// ErrRobotAccountInternalErrors describes server-sided internal errors.
+type ErrRobotAccountInternalErrors struct{}
+
+// Error returns the error message.
+func (e *ErrRobotAccountInternalErrors) Error() string {
+	return ErrRobotAccountInternalErrorsMsg
+}
+
+// handleSwaggerRobotErrors takes a swagger generated error as input,
+// which usually does not contain any form of error message,
+// and outputs a new error with proper message.
+func handleSwaggerRobotErrors(in error) error {
+	t, ok := in.(*runtime.APIError)
+	if ok {
+		switch t.Code {
+		case http.StatusOK:
+			return nil
+		case http.StatusCreated:
+			return nil
+		case http.StatusBadRequest:
+			return &ErrRobotAccountInvalid{}
+		case http.StatusUnauthorized:
+			return &ErrRobotAccountUnauthorized{}
+		case http.StatusForbidden:
+			return &ErrRobotAccountNoPermission{}
+		case http.StatusNotFound:
+			return &ErrRobotAccountUnknownResource{}
+		case http.StatusInternalServerError:
+			return &ErrRobotAccountInternalErrors{}
+		}
+	}
+
+	switch in.(type) {
+	case *robot.CreateRobotBadRequest:
+		return &ErrRobotAccountInvalid{}
+	case *robot.UpdateRobotNotFound:
+		return &ErrRobotAccountUnknownResource{}
+	case *robot.UpdateRobotConflict:
+		return &ErrRobotAccountInvalid{}
+	default:
+		return in
+	}
+}

--- a/apiv2/robot/robot_integration_test.go
+++ b/apiv2/robot/robot_integration_test.go
@@ -1,0 +1,119 @@
+// +build integration
+
+package robot
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
+	integrationtest "github.com/mittwald/goharbor-client/v4/apiv2/testing"
+)
+
+var (
+	u, _                   = url.Parse(integrationtest.Host)
+	v2SwaggerClient        = v2client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
+	authInfo               = runtimeclient.BasicAuth(integrationtest.User, integrationtest.Password)
+	testRobotAccountCreate = &modelv2.RobotCreate{
+		Description: "test",
+		Disable:     false,
+		Duration:    30,
+		Level:       LevelSystem.String(),
+		Name:        "test-robot",
+		Permissions: []*modelv2.RobotPermission{{
+			Access: []*modelv2.Access{{
+				Action:   ActionPull.String(),
+				Resource: ResourceRepository.String(),
+			}},
+			Kind:      LevelProject.String(),
+			Namespace: "library",
+		}},
+		Secret: "",
+	}
+)
+
+func TestAPINewRobotAccount(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(v2SwaggerClient, authInfo)
+
+	defer c.DeleteRobotAccountByName(ctx, "test-robot")
+
+	r, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+
+	require.NoError(t, err)
+	require.NotNil(t, r)
+}
+
+func TestAPIListRobots(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(v2SwaggerClient, authInfo)
+
+	defer c.DeleteRobotAccountByName(ctx, "test-robot")
+
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	require.NoError(t, err)
+
+	robots, err := c.ListRobotAccounts(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, robots)
+
+	require.Equal(t, 1, len(robots))
+}
+
+func TestAPIGetRobotByName(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(v2SwaggerClient, authInfo)
+
+	defer c.DeleteRobotAccountByName(ctx, "test-robot")
+
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	require.NoError(t, err)
+
+	robot, err := c.GetRobotAccountByName(ctx, "test-robot")
+	require.NoError(t, err)
+	require.NotNil(t, robot)
+}
+
+func TestAPIUpdateRobotAccount(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(v2SwaggerClient, authInfo)
+
+	defer c.DeleteRobotAccountByName(ctx, "test-robot")
+
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	require.NoError(t, err)
+
+	r, err := c.GetRobotAccountByName(ctx, "test-robot")
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	err = c.UpdateRobotAccount(ctx, &modelv2.Robot{
+		Name:        r.Name,
+		Level:       r.Level,
+		ID:          r.ID,
+		Description: "test-updated",
+		Disable:     false,
+		Duration:    30,
+		Permissions: []*modelv2.RobotPermission{{
+			Access: []*modelv2.Access{{
+				Action:   ActionPush.String(),
+				Resource: ResourceRepository.String(),
+			}},
+			Namespace: "*",
+		}},
+	})
+
+	require.NoError(t, err)
+
+	r, err = c.GetRobotAccountByName(ctx, "test-robot")
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	require.Equal(t, "test-updated", r.Description)
+}

--- a/apiv2/robot/robot_test.go
+++ b/apiv2/robot/robot_test.go
@@ -1,0 +1,213 @@
+// +build !integration
+
+package robot
+
+import (
+	"context"
+	"testing"
+
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/robot"
+	"github.com/mittwald/goharbor-client/v4/apiv2/mocks"
+	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
+)
+
+var (
+	authInfo            = runtimeclient.BasicAuth("foo", "bar")
+	exampleRobotAccount = &modelv2.Robot{
+		Description: "test-robot",
+		Disable:     false,
+		Duration:    30,
+		Editable:    true,
+		ID:          1,
+		Level:       LevelProject.String(),
+		Name:        "robot$test-robot",
+		Permissions: []*modelv2.RobotPermission{{
+			Access: []*modelv2.Access{
+				{
+					Action:   ActionPush.String(),
+					Resource: ResourceRepository.String(),
+				},
+				{
+					Action:   ActionPull.String(),
+					Resource: ResourceRepository.String(),
+				},
+			},
+			Kind:      LevelProject.String(),
+			Namespace: "library",
+		}},
+	}
+	exampleRobotCreate = &modelv2.RobotCreate{
+		Description: exampleRobotAccount.Description,
+		Disable:     exampleRobotAccount.Disable,
+		Duration:    exampleRobotAccount.Duration,
+		Level:       exampleRobotAccount.Level,
+		Name:        exampleRobotAccount.Name,
+		Permissions: exampleRobotAccount.Permissions,
+		Secret:      exampleRobotAccount.Secret,
+	}
+	exampleRobotUpdate = &modelv2.Robot{
+		Description: "test-updated",
+		Disable:     true,
+		ID:          exampleRobotAccount.ID,
+		Duration:    10,
+		Editable:    false,
+		Level:       exampleRobotAccount.Level,
+		Name:        "robot$test-robot",
+		Permissions: []*modelv2.RobotPermission{{
+			Access:    []*modelv2.Access{},
+			Kind:      exampleRobotAccount.Level,
+			Namespace: "library",
+		}},
+	}
+)
+
+func BuildV2ClientWithMock(r *mocks.MockRobotClientService) *client.Harbor {
+	return &client.Harbor{
+		Robot: r,
+	}
+}
+
+func TestRESTClient_ListRobotAccounts(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("ListRobot", &robot.ListRobotParams{Context: ctx}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
+
+	robots, err := cl.ListRobotAccounts(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, robots)
+	require.Equal(t, 1, len(robots))
+
+	r.AssertExpectations(t)
+}
+
+func TestRESTClient_GetRobotAccountByName(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("ListRobot", &robot.ListRobotParams{Context: ctx}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
+
+	rAcc, err := cl.GetRobotAccountByName(ctx, "test-robot")
+	require.NoError(t, err)
+	require.NotNil(t, rAcc)
+
+	r.AssertExpectations(t)
+}
+
+func TestRESTClient_GetRobotAccountByID(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("GetRobotByID", &robot.GetRobotByIDParams{Context: ctx, RobotID: 1}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.GetRobotByIDOK{Payload: exampleRobotAccount}, nil)
+
+	rAcc, err := cl.GetRobotAccountByID(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, rAcc)
+
+	r.AssertExpectations(t)
+}
+
+func TestRESTClient_NewRobotAccount(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("CreateRobot", &robot.CreateRobotParams{Context: ctx, Robot: exampleRobotCreate},
+		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.CreateRobotCreated{Payload: &modelv2.RobotCreated{
+			ExpiresAt: exampleRobotAccount.ExpiresAt,
+			ID:        exampleRobotAccount.ID,
+			Name:      exampleRobotAccount.Name,
+			Secret:    exampleRobotCreate.Secret,
+		}}, nil)
+
+	rCreated, err := cl.NewRobotAccount(ctx, exampleRobotCreate)
+	require.NoError(t, err)
+	require.NotNil(t, rCreated)
+
+	r.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteRobotAccountByName(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("ListRobot", &robot.ListRobotParams{Context: ctx}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
+
+	r.On("DeleteRobot", &robot.DeleteRobotParams{Context: ctx, RobotID: exampleRobotAccount.ID}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.DeleteRobotOK{}, nil)
+
+	err := cl.DeleteRobotAccountByName(ctx, "test-robot")
+	require.NoError(t, err)
+
+	r.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteRobotAccountByID(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("DeleteRobot", &robot.DeleteRobotParams{Context: ctx, RobotID: exampleRobotAccount.ID}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.DeleteRobotOK{}, nil)
+
+	err := cl.DeleteRobotAccountByID(ctx, 1)
+	require.NoError(t, err)
+
+	r.AssertExpectations(t)
+}
+
+func TestRESTClient_UpdateRobotAccount(t *testing.T) {
+	r := &mocks.MockRobotClientService{}
+
+	v2Client := BuildV2ClientWithMock(r)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	r.On("UpdateRobot", &robot.UpdateRobotParams{Context: ctx, RobotID: exampleRobotAccount.ID, Robot: exampleRobotUpdate}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&robot.UpdateRobotOK{}, nil)
+
+	err := cl.UpdateRobotAccount(ctx, exampleRobotUpdate)
+	require.NoError(t, err)
+
+	r.AssertExpectations(t)
+}


### PR DESCRIPTION
This PR introduces a new sub-client to interact with Goharbor's `robot` API that was introduced in `v2.2`.

More about robot accounts can be read here: https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/create-robot-accounts/

Fixes #85 