### PR TITLE
Add auditlog client

### DIFF
--- a/apiv1/project/project_errors.go
+++ b/apiv1/project/project_errors.go
@@ -207,7 +207,7 @@ func (e *ErrProjectUnknownResource) Error() string {
 
 // handleProjectErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerProjectErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv1/registry/registry_errors.go
+++ b/apiv1/registry/registry_errors.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/mittwald/goharbor-client/v4/apiv1/internal/api/client/products"
 )
 
@@ -110,7 +111,7 @@ func (e *ErrRegistryNotProvided) Error() string {
 
 // handleRegistryErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerRegistryErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv1/replication/replication_errors.go
+++ b/apiv1/replication/replication_errors.go
@@ -138,7 +138,7 @@ func (e *ErrReplicationExecutionReplicationIDMismatch) Error() string {
 
 // handleReplicationErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerReplicationErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv1/system/system_errors.go
+++ b/apiv1/system/system_errors.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/mittwald/goharbor-client/v4/apiv1/internal/api/client/products"
 )
 
@@ -99,7 +100,7 @@ func (e *ErrSystemGcScheduleNotProvided) Error() string {
 
 // handleSystemErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerSystemErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv1/user/user_errors.go
+++ b/apiv1/user/user_errors.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/mittwald/goharbor-client/v4/apiv1/internal/api/client/products"
 )
 
@@ -12,7 +13,7 @@ const (
 	ErrUserNotFoundMsg = "user not found on server side"
 
 	// ErrUserBadRequestMsg is the error message for ErrUserBadRequest error.
-	ErrUserBadRequestMsg = "Unsatisfied with constraints of the user creation/modification."
+	ErrUserBadRequestMsg = "unsatisfied with constraints of the user creation/modification."
 
 	// ErrUserMismatchMsg is the error message for ErrUserMismatch error.
 	ErrUserMismatchMsg = "id/name pair not found on server side"
@@ -76,7 +77,7 @@ func (e *ErrUserPasswordInvalid) Error() string {
 
 // handleUserErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerUserErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/auditlog/auditlog.go
+++ b/apiv2/auditlog/auditlog.go
@@ -7,15 +7,11 @@ import (
 
 	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/auditlog"
-	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"
 	"github.com/mittwald/goharbor-client/v4/apiv2/model"
 )
 
 // RESTClient is a subclient for handling user related actions.
 type RESTClient struct {
-	// The legacy swagger client
-	LegacyClient *client.Harbor
-
 	// The new client of the harbor v2 API
 	V2Client *v2client.Harbor
 
@@ -34,6 +30,12 @@ type Client interface {
 	ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*model.AuditLog, error)
 }
 
+// ListAuditLogs lists the audit logs of all projects the current user is a member of.
+// The 'pageSize' specifies how many audit log entries will be listed, where ...
+// a value > '0' will list the specified number of log entries,
+// a value of <= '0' will list all audit log entries,
+// a 'nil' value will list the ten most recent log entries.
+// Specifying 'query' will return the audit logs matching the specified query, e.g. 'operation=create'.
 func (c *RESTClient) ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*model.AuditLog, error) {
 	params := auditlog.ListAuditLogsParams{
 		Context:  ctx,

--- a/apiv2/auditlog/auditlog.go
+++ b/apiv2/auditlog/auditlog.go
@@ -1,0 +1,50 @@
+package auditlog
+
+import (
+	"context"
+
+	"github.com/go-openapi/runtime"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/auditlog"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/model"
+)
+
+// RESTClient is a subclient for handling user related actions.
+type RESTClient struct {
+	// The legacy swagger client
+	LegacyClient *client.Harbor
+
+	// The new client of the harbor v2 API
+	V2Client *v2client.Harbor
+
+	// AuthInfo contains the auth information that is provided on API calls.
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func NewClient(v2Client *v2client.Harbor, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
+	return &RESTClient{
+		V2Client: v2Client,
+		AuthInfo: authInfo,
+	}
+}
+
+type Client interface {
+	ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*model.AuditLog, error)
+}
+
+func (c *RESTClient) ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*model.AuditLog, error) {
+	params := auditlog.ListAuditLogsParams{
+		Context:  ctx,
+		PageSize: pageSize,
+		Q:        query,
+	}
+
+	resp, err := c.V2Client.Auditlog.ListAuditLogs(&params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerAuditLogErrors(err)
+	}
+
+	return resp.Payload, nil
+}

--- a/apiv2/auditlog/auditlog_errors.go
+++ b/apiv2/auditlog/auditlog_errors.go
@@ -1,0 +1,72 @@
+package auditlog
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/auditlog"
+)
+
+const (
+	// ErrAuditLogBadRequestMsg is the error message for ErrAuditLogBadRequest error.
+	ErrAuditLogBadRequestMsg = "unsatisfied with constraints of the auditlog request"
+
+	// ErrAuditLogUnauthorizedMsg is the error message for ErrAuditLogUnauthorized error.
+	ErrAuditLogUnauthorizedMsg = "unauthorized"
+
+	// ErrAuditLogInternalServerErrorMsg is the error message for ErrAuditLogInternalServerError error.
+	ErrAuditLogInternalServerErrorMsg = "unexpected internal errors"
+)
+
+// ErrAuditLogBadRequest describes an error when a request to the auditlog API is malformed.
+type ErrAuditLogBadRequest struct{}
+
+// Error returns the error message.
+func (e *ErrAuditLogBadRequest) Error() string {
+	return ErrAuditLogBadRequestMsg
+}
+
+// ErrAuditLogUnauthorized describes an unauthorized request.
+type ErrAuditLogUnauthorized struct{}
+
+// Error returns the error message.
+func (e *ErrAuditLogUnauthorized) Error() string {
+	return ErrAuditLogUnauthorizedMsg
+}
+
+// ErrAuditLogInternalServerError describes server-side internal errors.
+type ErrAuditLogInternalServerError struct{}
+
+// Error returns the error message.
+func (e *ErrAuditLogInternalServerError) Error() string {
+	return ErrAuditLogInternalServerErrorMsg
+}
+
+// handleProjectErrors takes a swagger generated error as input,
+// which usually does not contain any form of error message,
+// and outputs a new error with a proper message.
+func handleSwaggerAuditLogErrors(in error) error {
+	t, ok := in.(*runtime.APIError)
+	if ok {
+		switch t.Code {
+		case http.StatusBadRequest:
+			return &ErrAuditLogBadRequest{}
+		case http.StatusUnauthorized:
+			return &ErrAuditLogUnauthorized{}
+		case http.StatusInternalServerError:
+			return &ErrAuditLogInternalServerError{}
+		}
+	}
+
+	switch in.(type) {
+	case *auditlog.ListAuditLogsInternalServerError:
+		return &ErrAuditLogInternalServerError{}
+	case *auditlog.ListAuditLogsBadRequest:
+		return &ErrAuditLogBadRequest{}
+	case *auditlog.ListAuditLogsUnauthorized:
+		return &ErrAuditLogUnauthorized{}
+	default:
+		return in
+	}
+}

--- a/apiv2/auditlog/auditlog_integration_test.go
+++ b/apiv2/auditlog/auditlog_integration_test.go
@@ -72,3 +72,24 @@ func TestAPIListAuditLogs_BigPageSize(t *testing.T) {
 
 	require.Equal(t, 42, len(a))
 }
+
+func TestAPIListAuditLogs_NilPageSize(t *testing.T) {
+	ctx := context.Background()
+	storageLimit := int64(0)
+
+	c := NewClient(v2SwaggerClient, authInfo)
+
+	pc := project.NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+
+	for i := 0; i < 10; i++ {
+		p, err := pc.NewProject(ctx, "test-auditlog-"+strconv.Itoa(i), &storageLimit)
+		require.NoError(t, err)
+
+		defer pc.DeleteProject(ctx, p)
+	}
+
+	a, err := c.ListAuditLogs(ctx, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 10, len(a))
+}

--- a/apiv2/auditlog/auditlog_integration_test.go
+++ b/apiv2/auditlog/auditlog_integration_test.go
@@ -1,0 +1,47 @@
+package auditlog
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/project"
+	integrationtest "github.com/mittwald/goharbor-client/v4/apiv2/testing"
+)
+
+var (
+	u, _                = url.Parse(integrationtest.Host)
+	legacySwaggerClient = client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
+	v2SwaggerClient     = v2client.New(runtimeclient.New(u.Host, u.Path, []string{u.Scheme}), strfmt.Default)
+	authInfo            = runtimeclient.BasicAuth(integrationtest.User, integrationtest.Password)
+)
+
+func TestAPIListAuditLogs(t *testing.T) {
+	ctx := context.Background()
+	pageSize := int64(1)
+	storageLimit := int64(0)
+
+	c := NewClient(v2SwaggerClient, authInfo)
+
+	pc := project.NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+
+	p, err := pc.NewProject(ctx, "test-auditlog", &storageLimit)
+
+	defer pc.DeleteProject(ctx, p)
+
+	a, err := c.ListAuditLogs(ctx, &pageSize, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(a))
+
+	require.Equal(t, "create", a[0].Operation)
+	require.Equal(t, "test-auditlog", a[0].Resource)
+	require.Equal(t, "project", a[0].ResourceType)
+	require.Equal(t, "admin", a[0].Username)
+}

--- a/apiv2/auditlog/auditlog_test.go
+++ b/apiv2/auditlog/auditlog_test.go
@@ -1,0 +1,49 @@
+// +build !integration
+
+package auditlog
+
+import (
+	"context"
+	"testing"
+
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/auditlog"
+	"github.com/mittwald/goharbor-client/v4/apiv2/mocks"
+)
+
+var authInfo = runtimeclient.BasicAuth("foo", "bar")
+
+func BuildV2ClientWithMocks(audit *mocks.MockAuditlogClientService) *v2client.Harbor {
+	return &v2client.Harbor{
+		Auditlog: audit,
+	}
+}
+
+func TestRESTClient_ListAuditLogs(t *testing.T) {
+	a := &mocks.MockAuditlogClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	listAuditLogsParams := &auditlog.ListAuditLogsParams{
+		PageSize: nil,
+		Q:        nil,
+		Context:  ctx,
+	}
+
+	a.On("ListAuditLogs", listAuditLogsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&auditlog.ListAuditLogsOK{}, nil)
+
+	_, err := cl.ListAuditLogs(ctx, nil, nil)
+
+	assert.NoError(t, err)
+
+	a.AssertExpectations(t)
+}

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/mittwald/goharbor-client/v4/apiv2/auditlog"
 	"github.com/mittwald/goharbor-client/v4/apiv2/gc"
 	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
 	"github.com/mittwald/goharbor-client/v4/apiv2/quota"
@@ -41,6 +42,7 @@ type Client interface {
 
 // RESTClient implements the Client interface as a REST client
 type RESTClient struct {
+	auditlog    *auditlog.RESTClient
 	user        *user.RESTClient
 	project     *project.RESTClient
 	registry    *registry.RESTClient
@@ -55,6 +57,7 @@ type RESTClient struct {
 // NewRESTClient constructs a new REST client containing each sub client.
 func NewRESTClient(legacyClient *client.Harbor, v2Client *v2client.Harbor, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
 	return &RESTClient{
+		auditlog:    auditlog.NewClient(v2Client, authInfo),
 		user:        user.NewClient(legacyClient, v2Client, authInfo),
 		project:     project.NewClient(legacyClient, v2Client, authInfo),
 		registry:    registry.NewClient(legacyClient, v2Client, authInfo),
@@ -407,4 +410,11 @@ func (c *RESTClient) DeleteRobotAccountByID(ctx context.Context, id int64) error
 // UpdateRobotAccount wraps the UpdateRobotAccount method of the robot sub-package.
 func (c *RESTClient) UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) error {
 	return c.robot.UpdateRobotAccount(ctx, r)
+}
+
+// AuditLog Client
+
+// ListAuditLogs wraps the ListAuditLogs method of the robot sub-package.
+func (c *RESTClient) ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*modelv2.AuditLog, error) {
+	return c.auditlog.ListAuditLogs(ctx, pageSize, query)
 }

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -414,7 +414,7 @@ func (c *RESTClient) UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) e
 
 // AuditLog Client
 
-// ListAuditLogs wraps the ListAuditLogs method of the robot sub-package.
+// ListAuditLogs wraps the ListAuditLogs method of the auditlog sub-package.
 func (c *RESTClient) ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*modelv2.AuditLog, error) {
 	return c.auditlog.ListAuditLogs(ctx, pageSize, query)
 }

--- a/apiv2/gc/gc_errors.go
+++ b/apiv2/gc/gc_errors.go
@@ -121,7 +121,7 @@ func (e *ErrSystemGcScheduleParametersUndefined) Error() string {
 
 // handleSystemErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerSystemErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/project/project_errors.go
+++ b/apiv2/project/project_errors.go
@@ -192,7 +192,7 @@ func (e *ErrProjectUserIsNoMember) Error() string {
 	return ErrProjectUserIsNoMemberMsg
 }
 
-// ErrProjectMemberIllegalFormat describes an communication
+// ErrProjectInvalidRequest describes a communication
 // error when performing project member operations.
 type ErrProjectInvalidRequest struct{}
 
@@ -209,7 +209,7 @@ func (e *ErrProjectMetadataUndefined) Error() string {
 	return ErrProjectMetadataUndefinedMsg
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValueEnableContentTrustUndefined struct{}
 
 // Error returns the error message.
@@ -217,7 +217,7 @@ func (e *ErrProjectMetadataValueEnableContentTrustUndefined) Error() string {
 	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyEnableContentTrust)
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValueAutoScanUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValueAutoScanUndefined struct{}
 
 // Error returns the error message.
@@ -225,7 +225,7 @@ func (e *ErrProjectMetadataValueAutoScanUndefined) Error() string {
 	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyAutoScan)
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValueSeverityUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValueSeverityUndefined struct{}
 
 // Error returns the error message.
@@ -233,7 +233,7 @@ func (e *ErrProjectMetadataValueSeverityUndefined) Error() string {
 	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeySeverity)
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValueReuseSysCveAllowlistUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValueReuseSysCveAllowlistUndefined struct{}
 
 // Error returns the error message.
@@ -241,7 +241,7 @@ func (e *ErrProjectMetadataValueReuseSysCveAllowlistUndefined) Error() string {
 	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyReuseSysCveAllowlist)
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValuePublicUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValuePublicUndefined struct{}
 
 // Error returns the error message.
@@ -249,7 +249,7 @@ func (e *ErrProjectMetadataValuePublicUndefined) Error() string {
 	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyPublic)
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValuePreventVulUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValuePreventVulUndefined struct{}
 
 // Error returns the error message.
@@ -257,7 +257,7 @@ func (e *ErrProjectMetadataValuePreventVulUndefined) Error() string {
 	return string(ErrProjectMetadataValueUndefinedMsg + ProjectMetadataKeyPreventVul)
 }
 
-// ProjectMetadataValueEnableContentTrustUndefined describes an error regarding a metadata value being undefined or nil.
+// ErrProjectMetadataValueRetentionIDUndefined describes an error regarding a metadata value being undefined or nil.
 type ErrProjectMetadataValueRetentionIDUndefined struct{}
 
 // Error returns the error message.
@@ -342,7 +342,7 @@ func retrieveMetadataValue(k MetadataKey, m *modelv2.ProjectMetadata) (string, e
 
 // handleProjectErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerProjectErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/quota/quota_errors.go
+++ b/apiv2/quota/quota_errors.go
@@ -74,7 +74,7 @@ func (e *ErrQuotaRefNotFound) Error() string {
 
 // handleSwaggerQuotaErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerQuotaErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/registry/registry_errors.go
+++ b/apiv2/registry/registry_errors.go
@@ -110,7 +110,7 @@ func (e *ErrRegistryNotProvided) Error() string {
 
 // handleRegistryErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerRegistryErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/replication/replication_errors.go
+++ b/apiv2/replication/replication_errors.go
@@ -138,7 +138,7 @@ func (e *ErrReplicationExecutionReplicationIDMismatch) Error() string {
 
 // handleReplicationErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerReplicationErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/retention/retention_errors.go
+++ b/apiv2/retention/retention_errors.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/retention"
 )
 
@@ -66,7 +67,7 @@ func (e *ErrRetentionInternalErrors) Error() string {
 
 // handleProjectErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerRetentionErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/robot/robot_errors.go
+++ b/apiv2/robot/robot_errors.go
@@ -64,7 +64,7 @@ func (e *ErrRobotAccountInternalErrors) Error() string {
 
 // handleSwaggerRobotErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerRobotErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/apiv2/user/user_errors.go
+++ b/apiv2/user/user_errors.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client/products"
 )
 
@@ -12,12 +13,12 @@ const (
 	ErrUserNotFoundMsg = "user not found on server side"
 
 	// ErrUserBadRequestMsg is the error message for ErrUserBadRequest error.
-	ErrUserBadRequestMsg = "Unsatisfied with constraints of the user creation/modification."
+	ErrUserBadRequestMsg = "unsatisfied with constraints of the user creation/modification."
 
 	// ErrUserMismatchMsg is the error message for ErrUserMismatch error.
 	ErrUserMismatchMsg = "id/name pair not found on server side"
 
-	// ErrUserAlreadyExistMsg is the error message for ErrUserAlreadyExists error.
+	// ErrUserAlreadyExistsMsg is the error message for ErrUserAlreadyExists error.
 	ErrUserAlreadyExistsMsg = "user with this username already exists"
 
 	// ErrUserInvalidIDMsg is the error message for ErrUserInvalidID error.
@@ -26,7 +27,7 @@ const (
 	// ErrUserIDNotExistsMsg is the error message for ErrUserIDNotExists error.
 	ErrUserIDNotExistsMsg = "user id does not exist"
 
-	// ErrUserPasswordInvalid  is the error message for ErrUserPasswordInvalid error.
+	// ErrUserPasswordInvalidMsg  is the error message for ErrUserPasswordInvalid error.
 	ErrUserPasswordInvalidMsg = "invalid user password"
 )
 
@@ -88,7 +89,7 @@ func (e *ErrUserPasswordInvalid) Error() string {
 
 // handleUserErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
-// and outputs a new error with proper message.
+// and outputs a new error with a proper message.
 func handleSwaggerUserErrors(in error) error {
 	t, ok := in.(*runtime.APIError)
 	if ok {

--- a/scripts/setup-harbor.sh
+++ b/scripts/setup-harbor.sh
@@ -75,7 +75,7 @@ if [[ "$?" -ne "0" ]]; then
     exit 1
 fi
 
-echo "Installing seperate docker registry for integration tests..."
+echo "Installing separate docker registry for integration tests..."
 helm repo add stable https://charts.helm.sh/stable && helm repo update
 helm install registry stable/docker-registry \
     --set service.port=5000,image.tag=${REGISTRY_IMAGE_TAG}


### PR DESCRIPTION
Fixes #100 

This PR adds the `auditlog` client which (currently) supports the `GET ​/audit-logs` endpoint.
It also contains some typo fixes throughout all `v2` clients.