### PR TITLE
add artifact client

### DIFF
--- a/apiv2/artifact/artifact.go
+++ b/apiv2/artifact/artifact.go
@@ -1,0 +1,223 @@
+package artifact
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/go-openapi/runtime"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/artifact"
+	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
+)
+
+type (
+	MIMEType       string
+	RepositoryName string
+)
+
+const (
+	MIMETypeV10 MIMEType = "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+	MIMETypeV11 MIMEType = "application/vnd.security.vulnerability.report; version=1.1"
+)
+
+// RESTClient is a subclient for handling user related actions.
+type RESTClient struct {
+	// The new client of the harbor v2 API
+	V2Client *v2client.Harbor
+
+	// AuthInfo contains the auth information that is provided on API calls.
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func NewClient(v2Client *v2client.Harbor, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
+	return &RESTClient{
+		V2Client: v2Client,
+		AuthInfo: authInfo,
+	}
+}
+
+type Client interface {
+	GetArtifact(ctx context.Context, options ParamOptions) (*modelv2.Artifact, error)
+	ListArtifacts(ctx context.Context, options ParamOptions) ([]*modelv2.Artifact, error)
+	DeleteArtifact(ctx context.Context, options ParamOptions) error
+	CreateTag(ctx context.Context, options ParamOptions) error
+	DeleteTag(ctx context.Context, options ParamOptions) error
+	GetRepositoryVulnerabilities(ctx context.Context, projectName, repositoryName, reference string,
+		MIMETypes []MIMEType) (string, error)
+}
+
+// ParamOptions holds the necessary options for artifact API requests.
+type ParamOptions struct {
+	PageSize               int64
+	ProjectName            string
+	RepositoryName         string
+	Reference              string
+	WithLabel              bool
+	WithScanOverview       bool
+	WithSignature          bool
+	WithTag                bool
+	WithImmutableStatus    bool
+	XAcceptVulnerabilities string
+	Query                  string
+	Tag                    *modelv2.Tag
+}
+
+// setParamOptions sets the default params for 'in', assuming 'in' is a parameter type used by the artifact API.
+// This comes in handy as the different request param types share most of their fields.
+func setParamOptions(in interface{}, opts ParamOptions) error {
+	truePtr := true
+
+	switch in := in.(type) {
+	default:
+		return fmt.Errorf("could not assert %T type", in)
+	case *artifact.GetArtifactParams:
+		in.ProjectName = opts.ProjectName
+		in.Reference = opts.Reference
+		in.RepositoryName = url.QueryEscape(opts.RepositoryName)
+		in.WithScanOverview = &opts.WithScanOverview
+		in.PageSize = &opts.PageSize
+		in.WithLabel = &opts.WithLabel
+		in.WithSignature = &opts.WithSignature
+		in.WithTag = &opts.WithTag
+		// Implicitly set 'WithImmutableStatus' when 'WithTag' is set.
+		if opts.WithTag {
+			in.WithImmutableStatus = &truePtr
+		}
+		in.XAcceptVulnerabilities = &opts.XAcceptVulnerabilities
+	case *artifact.ListArtifactsParams:
+		in.ProjectName = opts.ProjectName
+		in.RepositoryName = url.QueryEscape(opts.RepositoryName)
+		in.WithScanOverview = &opts.WithScanOverview
+		in.PageSize = &opts.PageSize
+		in.WithLabel = &opts.WithLabel
+		// Implicitly set 'WithImmutableStatus' when 'WithTag' is set.
+		if opts.WithTag {
+			in.WithImmutableStatus = &truePtr
+		}
+		in.WithSignature = &opts.WithSignature
+		in.WithTag = &opts.WithTag
+		in.XAcceptVulnerabilities = &opts.XAcceptVulnerabilities
+		in.Q = &opts.Query
+	case *artifact.DeleteArtifactParams:
+		in.ProjectName = opts.ProjectName
+		in.Reference = opts.Reference
+		in.RepositoryName = url.QueryEscape(opts.RepositoryName)
+	case *artifact.CreateTagParams:
+		in.ProjectName = opts.ProjectName
+		in.Reference = opts.Reference
+		in.RepositoryName = url.QueryEscape(opts.RepositoryName)
+		in.Tag = opts.Tag
+	case *artifact.DeleteTagParams:
+		in.ProjectName = opts.ProjectName
+		in.Reference = opts.Reference
+		in.RepositoryName = url.QueryEscape(opts.RepositoryName)
+		in.TagName = opts.Tag.Name
+	}
+
+	return nil
+}
+
+// GetArtifact returns a specific artifact of a project's repository based on the provided 'options'.
+func (c *RESTClient) GetArtifact(ctx context.Context, options ParamOptions) (*modelv2.Artifact, error) {
+	params := &artifact.GetArtifactParams{}
+
+	if err := setParamOptions(params.WithDefaults().WithContext(ctx), options); err != nil {
+		return nil, fmt.Errorf("error setting parameter options: %w", err)
+	}
+
+	resp, err := c.V2Client.Artifact.GetArtifact(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerArtifactErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// ListArtifacts lists the artifacts of a project's repository based on the provided 'options'.
+func (c *RESTClient) ListArtifacts(ctx context.Context, options ParamOptions) ([]*modelv2.Artifact, error) {
+	params := &artifact.ListArtifactsParams{}
+
+	if err := setParamOptions(params.WithDefaults().WithContext(ctx), options); err != nil {
+		return nil, fmt.Errorf("error setting parameter options: %w", err)
+	}
+
+	resp, err := c.V2Client.Artifact.ListArtifacts(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerArtifactErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+// DeleteArtifact deletes a specific artifact of a repository based on the provided 'options'.
+func (c *RESTClient) DeleteArtifact(ctx context.Context, options ParamOptions) error {
+	params := &artifact.DeleteArtifactParams{}
+
+	if err := setParamOptions(params.WithDefaults().WithContext(ctx), options); err != nil {
+		return fmt.Errorf("error setting parameter options: %w", err)
+	}
+
+	if _, err := c.V2Client.Artifact.DeleteArtifact(params, c.AuthInfo); err != nil {
+		return handleSwaggerArtifactErrors(err)
+	}
+
+	return nil
+}
+
+// CreateTag creates a tag (options.Tag) for the repository specified in 'options'.
+func (c *RESTClient) CreateTag(ctx context.Context, options ParamOptions) error {
+	params := &artifact.CreateTagParams{}
+
+	if err := setParamOptions(params.WithDefaults().WithContext(ctx), options); err != nil {
+		return fmt.Errorf("error setting parameter options: %w", err)
+	}
+
+	if _, err := c.V2Client.Artifact.CreateTag(params, c.AuthInfo); err != nil {
+		return handleSwaggerArtifactErrors(err)
+	}
+
+	return nil
+}
+
+// DeleteTag deletes the tag (options.Tag.Name) of the repository specified in 'options'.
+func (c *RESTClient) DeleteTag(ctx context.Context, options ParamOptions) error {
+	params := &artifact.DeleteTagParams{}
+
+	if err := setParamOptions(params.WithDefaults().WithContext(ctx), options); err != nil {
+		return fmt.Errorf("error setting parameter options: %w", err)
+	}
+
+	if _, err := c.V2Client.Artifact.DeleteTag(params, c.AuthInfo); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetRepositoryVulnerabilities returns a JSON formatted string containing vulnerability reports for the specified artifact.
+func (c *RESTClient) GetRepositoryVulnerabilities(ctx context.Context, projectName, repositoryName, reference string,
+	MIMETypes []MIMEType) (string, error) {
+	var m []string
+
+	for i := range MIMETypes {
+		m = append(m, string(MIMETypes[i]))
+	}
+
+	requestedMIMETypes := strings.Join(m, ",")
+
+	v, err := c.V2Client.Artifact.GetVulnerabilitiesAddition(&artifact.GetVulnerabilitiesAdditionParams{
+		XAcceptVulnerabilities: &requestedMIMETypes,
+		ProjectName:            projectName,
+		Reference:              reference,
+		RepositoryName:         url.QueryEscape(repositoryName),
+		Context:                ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return "", handleSwaggerArtifactErrors(err)
+	}
+
+	return v.Payload, nil
+}

--- a/apiv2/artifact/artifact_errors.go
+++ b/apiv2/artifact/artifact_errors.go
@@ -1,0 +1,67 @@
+package artifact
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/artifact"
+)
+
+const (
+	ErrArtifactBadRequestMsg          = "bad request"
+	ErrArtifactUnauthorizedMsg        = "unauthorized"
+	ErrArtifactInternalServerErrorMsg = "internal server error"
+	ErrArtifactTagNotFoundMsg         = "could not find project, repository or reference"
+)
+
+type ErrArtifactBadRequest struct{}
+
+func (e *ErrArtifactBadRequest) Error() string {
+	return ErrArtifactBadRequestMsg
+}
+
+type ErrArtifactUnauthorized struct{}
+
+func (e *ErrArtifactUnauthorized) Error() string {
+	return ErrArtifactUnauthorizedMsg
+}
+
+type ErrArtifactInternalServerError struct{}
+
+func (e *ErrArtifactInternalServerError) Error() string {
+	return ErrArtifactInternalServerErrorMsg
+}
+
+type ErrArtifactTagNotFound struct{}
+
+func (e *ErrArtifactTagNotFound) Error() string {
+	return ErrArtifactTagNotFoundMsg
+}
+
+func handleSwaggerArtifactErrors(in error) error {
+	t, ok := in.(*runtime.APIError)
+	if ok {
+		switch t.Code {
+		case http.StatusBadRequest:
+			return &ErrArtifactBadRequest{}
+		case http.StatusUnauthorized:
+			return &ErrArtifactUnauthorized{}
+		case http.StatusInternalServerError:
+			return &ErrArtifactInternalServerError{}
+		}
+	}
+
+	switch in.(type) {
+	case *artifact.ListArtifactsInternalServerError:
+		return &ErrArtifactInternalServerError{}
+	case *artifact.ListArtifactsBadRequest:
+		return &ErrArtifactBadRequest{}
+	case *artifact.ListArtifactsUnauthorized:
+		return &ErrArtifactUnauthorized{}
+	case *artifact.CreateTagNotFound:
+		return &ErrArtifactTagNotFound{}
+	default:
+		return in
+	}
+}

--- a/apiv2/artifact/artifact_test.go
+++ b/apiv2/artifact/artifact_test.go
@@ -1,0 +1,271 @@
+// +build !integration
+
+package artifact
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client/artifact"
+	"github.com/mittwald/goharbor-client/v4/apiv2/mocks"
+	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
+)
+
+var (
+	authInfo             = runtimeclient.BasicAuth("foo", "bar")
+	projectName          = "project"
+	repositoryName       = "repository/foo-bar"
+	int64One       int64 = 1
+	emptyStr             = ""
+	falsePtr             = false
+)
+
+func BuildV2ClientWithMocks(artifact *mocks.MockArtifactClientService) *v2client.Harbor {
+	return &v2client.Harbor{
+		Artifact: artifact,
+	}
+}
+
+func TestRESTClient_GetArtifact(t *testing.T) {
+	a := &mocks.MockArtifactClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	getArtifactParams := &artifact.GetArtifactParams{
+		XAcceptVulnerabilities: &emptyStr,
+		Page:                   &int64One,
+		PageSize:               &int64One,
+		ProjectName:            projectName,
+		Reference:              "",
+		RepositoryName:         url.QueryEscape(repositoryName),
+		WithImmutableStatus:    &falsePtr,
+		WithLabel:              &falsePtr,
+		WithScanOverview:       &falsePtr,
+		WithSignature:          &falsePtr,
+		WithTag:                &falsePtr,
+		Context:                ctx,
+	}
+
+	getOpts := ParamOptions{
+		PageSize:               1,
+		ProjectName:            projectName,
+		RepositoryName:         repositoryName,
+		Reference:              "",
+		WithScanOverview:       false,
+		WithLabel:              false,
+		WithSignature:          false,
+		WithTag:                false,
+		WithImmutableStatus:    false,
+		XAcceptVulnerabilities: "",
+	}
+
+	a.On("GetArtifact", getArtifactParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.GetArtifactOK{}, nil)
+
+	_, err := cl.GetArtifact(ctx, getOpts)
+
+	require.NoError(t, err)
+
+	a.AssertExpectations(t)
+}
+
+func TestRESTClient_ListArtifacts(t *testing.T) {
+	a := &mocks.MockArtifactClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	listArtifactParams := &artifact.ListArtifactsParams{
+		XAcceptVulnerabilities: &emptyStr,
+		Page:                   &int64One,
+		PageSize:               &int64One,
+		ProjectName:            projectName,
+		RepositoryName:         url.QueryEscape(repositoryName),
+		WithImmutableStatus:    &falsePtr,
+		WithLabel:              &falsePtr,
+		WithScanOverview:       &falsePtr,
+		WithSignature:          &falsePtr,
+		WithTag:                &falsePtr,
+		Context:                ctx,
+		Q:                      &emptyStr,
+	}
+
+	listOpts := ParamOptions{
+		PageSize:               1,
+		ProjectName:            projectName,
+		RepositoryName:         repositoryName,
+		Reference:              "",
+		WithScanOverview:       false,
+		WithLabel:              false,
+		WithSignature:          false,
+		WithTag:                false,
+		WithImmutableStatus:    false,
+		XAcceptVulnerabilities: "",
+	}
+
+	a.On("ListArtifacts", listArtifactParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.ListArtifactsOK{}, nil)
+
+	_, err := cl.ListArtifacts(ctx, listOpts)
+
+	require.NoError(t, err)
+
+	a.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteArtifact(t *testing.T) {
+	a := &mocks.MockArtifactClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	deleteParams := &artifact.DeleteArtifactParams{
+		ProjectName:    projectName,
+		RepositoryName: url.QueryEscape(repositoryName),
+		Context:        ctx,
+	}
+
+	deleteOpts := ParamOptions{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+	}
+
+	a.On("DeleteArtifact", deleteParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.DeleteArtifactOK{}, nil)
+
+	err := cl.DeleteArtifact(ctx, deleteOpts)
+
+	require.NoError(t, err)
+
+	a.AssertExpectations(t)
+}
+
+func TestRESTClient_CreateTag(t *testing.T) {
+	a := &mocks.MockArtifactClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	createTagParams := &artifact.CreateTagParams{
+		ProjectName:    projectName,
+		Reference:      "",
+		RepositoryName: url.QueryEscape(repositoryName),
+		Tag: &modelv2.Tag{
+			ArtifactID:   1,
+			Immutable:    true,
+			Name:         "v1.0.0",
+			RepositoryID: 1,
+			Signed:       false,
+		},
+		Context: ctx,
+	}
+
+	createOpts := ParamOptions{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Tag: &modelv2.Tag{
+			ArtifactID:   1,
+			Immutable:    true,
+			Name:         "v1.0.0",
+			RepositoryID: 1,
+			Signed:       false,
+		},
+	}
+
+	a.On("CreateTag", createTagParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.CreateTagCreated{}, nil)
+
+	err := cl.CreateTag(ctx, createOpts)
+
+	require.NoError(t, err)
+
+	a.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteTag(t *testing.T) {
+	a := &mocks.MockArtifactClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	deleteTagParams := &artifact.DeleteTagParams{
+		ProjectName:    projectName,
+		Reference:      "",
+		RepositoryName: url.QueryEscape(repositoryName),
+		TagName:        "v1.0.0",
+		Context:        ctx,
+	}
+
+	deleteOpts := ParamOptions{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Tag:            &modelv2.Tag{Name: "v1.0.0"},
+	}
+
+	a.On("DeleteTag", deleteTagParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.DeleteTagOK{}, nil)
+
+	err := cl.DeleteTag(ctx, deleteOpts)
+
+	require.NoError(t, err)
+
+	a.AssertExpectations(t)
+}
+
+func TestRESTClient_GetVulnerabilitiesAddition(t *testing.T) {
+	a := &mocks.MockArtifactClientService{}
+
+	v2Client := BuildV2ClientWithMocks(a)
+
+	cl := NewClient(v2Client, authInfo)
+
+	ctx := context.Background()
+
+	v := string(MIMETypeV10) + "," + string(MIMETypeV11)
+
+	getVulnerabilitiesAdditionParams := &artifact.GetVulnerabilitiesAdditionParams{
+		XAcceptVulnerabilities: &v,
+		ProjectName:            projectName,
+		Reference:              "",
+		RepositoryName:         url.QueryEscape(repositoryName),
+		Context:                ctx,
+	}
+
+	strings.Join([]string{string(MIMETypeV10), string(MIMETypeV11)}, ",")
+	m := []MIMEType{
+		MIMETypeV10,
+		MIMETypeV11,
+	}
+
+	a.On("GetVulnerabilitiesAddition", getVulnerabilitiesAdditionParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.GetVulnerabilitiesAdditionOK{}, nil)
+
+	_, err := cl.GetRepositoryVulnerabilities(ctx, projectName, repositoryName, "", m)
+
+	require.NoError(t, err)
+
+	a.AssertExpectations(t)
+}

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/mittwald/goharbor-client/v4/apiv2/artifact"
 	"github.com/mittwald/goharbor-client/v4/apiv2/auditlog"
 	"github.com/mittwald/goharbor-client/v4/apiv2/gc"
 	modelv2 "github.com/mittwald/goharbor-client/v4/apiv2/model"
@@ -30,6 +31,7 @@ import (
 const v2URLSuffix string = "/v2.0"
 
 type Client interface {
+	artifact.Client
 	user.Client
 	project.Client
 	registry.Client
@@ -42,6 +44,7 @@ type Client interface {
 
 // RESTClient implements the Client interface as a REST client
 type RESTClient struct {
+	artifact    *artifact.RESTClient
 	auditlog    *auditlog.RESTClient
 	user        *user.RESTClient
 	project     *project.RESTClient
@@ -57,6 +60,7 @@ type RESTClient struct {
 // NewRESTClient constructs a new REST client containing each sub client.
 func NewRESTClient(legacyClient *client.Harbor, v2Client *v2client.Harbor, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
 	return &RESTClient{
+		artifact:    artifact.NewClient(v2Client, authInfo),
 		auditlog:    auditlog.NewClient(v2Client, authInfo),
 		user:        user.NewClient(legacyClient, v2Client, authInfo),
 		project:     project.NewClient(legacyClient, v2Client, authInfo),
@@ -422,4 +426,37 @@ func (c *RESTClient) UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) e
 // ListAuditLogs wraps the ListAuditLogs method of the auditlog sub-package.
 func (c *RESTClient) ListAuditLogs(ctx context.Context, pageSize *int64, query *string) ([]*modelv2.AuditLog, error) {
 	return c.auditlog.ListAuditLogs(ctx, pageSize, query)
+}
+
+// Artifact Client
+
+// GetArtifact wraps the GetArtifact method of the artifact sub-package.
+func (c *RESTClient) GetArtifact(ctx context.Context, options artifact.ParamOptions) (*modelv2.Artifact, error) {
+	return c.artifact.GetArtifact(ctx, options)
+}
+
+// ListArtifacts wraps the ListArtifacts method of the artifact sub-package.
+func (c *RESTClient) ListArtifacts(ctx context.Context, options artifact.ParamOptions) ([]*modelv2.Artifact, error) {
+	return c.artifact.ListArtifacts(ctx, options)
+}
+
+// DeleteArtifact wraps the DeleteArtifact method of the artifact sub-package.
+func (c *RESTClient) DeleteArtifact(ctx context.Context, options artifact.ParamOptions) error {
+	return c.artifact.DeleteArtifact(ctx, options)
+}
+
+// CreateTag wraps the CreateTag method of the artifact sub-package.
+func (c *RESTClient) CreateTag(ctx context.Context, options artifact.ParamOptions) error {
+	return c.artifact.CreateTag(ctx, options)
+}
+
+// DeleteTag wraps the DeleteTag method of the artifact sub-package.
+func (c *RESTClient) DeleteTag(ctx context.Context, options artifact.ParamOptions) error {
+	return c.artifact.DeleteTag(ctx, options)
+}
+
+// GetRepositoryVulnerabilities wraps the GetRepositoryVulnerabilities method of the artifact sub-package.
+func (c *RESTClient) GetRepositoryVulnerabilities(ctx context.Context, projectName, repositoryName, reference string,
+	MIMETypes []artifact.MIMEType) (string, error) {
+	return c.artifact.GetRepositoryVulnerabilities(ctx, projectName, repositoryName, reference, MIMETypes)
 }


### PR DESCRIPTION
Fixes #106 
This PR adds the `artifact` client, supporting operations on repository artifacts such as tags or vulnerabilities.