### PR TITLE
support get and update on system cve allowlist

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -341,6 +341,16 @@ func (c *RESTClient) Health(ctx context.Context) (*legacymodel.OverallHealthStat
 	return c.system.Health(ctx)
 }
 
+// GetSystemCVEAllowList wraps the GetSystemCVEAllowList method of the system sub-package.
+func (c *RESTClient) GetSystemCVEAllowList(ctx context.Context) (*legacymodel.CVEAllowlist, error) {
+	return c.system.GetSystemCVEAllowList(ctx)
+}
+
+// UpdateSystemCVEAllowList wraps the UpdateSystemCVEAllowList method of the system sub-package.
+func (c *RESTClient) UpdateSystemCVEAllowList(ctx context.Context, CVEs []string, expiresAt int64) error {
+	return c.system.UpdateSystemCVEAllowList(ctx, CVEs, expiresAt)
+}
+
 // Retention Client
 
 // NewRetentionPolicy wraps the NewRetentionPolicy method of the retention sub-package.

--- a/apiv2/system/system_integration_test.go
+++ b/apiv2/system/system_integration_test.go
@@ -9,10 +9,11 @@ import (
 
 	runtimeclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
 	v2client "github.com/mittwald/goharbor-client/v4/apiv2/internal/api/client"
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"
 	integrationtest "github.com/mittwald/goharbor-client/v4/apiv2/testing"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -27,5 +28,14 @@ func TestAPIHealth(t *testing.T) {
 	c := NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
 
 	_, err := c.Health(ctx)
+	require.NoError(t, err)
+}
+
+func TestAPIUpdateSystemCVEAllowList(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(legacySwaggerClient, v2SwaggerClient, authInfo)
+
+	err := c.UpdateSystemCVEAllowList(ctx, []string{"CVE-1999-0095"}, 1640995200)
+
 	require.NoError(t, err)
 }

--- a/apiv2/system/system_test.go
+++ b/apiv2/system/system_test.go
@@ -4,16 +4,16 @@ package system
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	legacyclient "github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client"
 	"github.com/mittwald/goharbor-client/v4/apiv2/internal/legacyapi/client/products"
 	"github.com/mittwald/goharbor-client/v4/apiv2/mocks"
 	legacymodel "github.com/mittwald/goharbor-client/v4/apiv2/model/legacy"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 var authInfo = runtimeclient.BasicAuth("foo", "bar")
@@ -42,12 +42,12 @@ func TestRESTClient_Health(t *testing.T) {
 
 	_, err := cl.Health(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	p.AssertExpectations(t)
 }
 
-func TestRESTClient_Health_Error(t *testing.T) {
+func TestRESTClient_GetSystemCVEAllowList(t *testing.T) {
 	p := &mocks.MockProductsClientService{}
 
 	legacyClient := BuildLegacyClientWithMock(p)
@@ -56,19 +56,47 @@ func TestRESTClient_Health_Error(t *testing.T) {
 
 	ctx := context.Background()
 
-	healthParams := &products.GetHealthParams{
+	getParams := &products.GetSystemCVEAllowlistParams{
 		Context: ctx,
 	}
 
-	p.On("GetHealth", healthParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-		Return(&products.GetHealthOK{Payload: &legacymodel.OverallHealthStatus{}},
-			errors.New("err"))
+	p.On("GetSystemCVEAllowlist", getParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.GetSystemCVEAllowlistOK{}, nil)
 
-	_, err := cl.Health(ctx)
+	_, err := cl.GetSystemCVEAllowList(ctx)
 
-	if assert.Error(t, err) {
-		assert.Equal(t, errors.New("err"), err)
+	require.NoError(t, err)
+
+	p.AssertExpectations(t)
+}
+
+func TestRESTClient_UpdateSystemCVEAllowList(t *testing.T) {
+	p := &mocks.MockProductsClientService{}
+
+	legacyClient := BuildLegacyClientWithMock(p)
+
+	cl := NewClient(legacyClient, nil, authInfo)
+
+	ctx := context.Background()
+
+	putParams := &products.PutSystemCVEAllowlistParams{
+		Allowlist: &legacymodel.CVEAllowlist{
+			ExpiresAt: 1640995200,
+			ID:        0,
+			Items: []*legacymodel.CVEAllowlistItem{{
+				CveID: "CVE-1999-0095",
+			}},
+			ProjectID: 0,
+		},
+		Context: ctx,
 	}
+
+	p.On("PutSystemCVEAllowlist", putParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&products.PutSystemCVEAllowlistOK{}, nil)
+
+	err := cl.UpdateSystemCVEAllowList(ctx, []string{"CVE-1999-0095"}, 1640995200)
+
+	require.NoError(t, err)
 
 	p.AssertExpectations(t)
 }


### PR DESCRIPTION
Fixes #108 
This PR adds new functionality to the system client, enabling users to get and update the system-wide CVE allowlist.