### PR TITLE
Use upstream struct as argument in NewProject()

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -170,8 +170,8 @@ func (c *RESTClient) DeleteProjectMember(ctx context.Context, projectNameOrID st
 
 // Project Client
 
-func (c *RESTClient) NewProject(ctx context.Context, name string, storageLimit *int64) error {
-	return c.project.NewProject(ctx, name, storageLimit)
+func (c *RESTClient) NewProject(ctx context.Context, projectRequest *modelv2.ProjectReq) error {
+	return c.project.NewProject(ctx, projectRequest)
 }
 
 func (c *RESTClient) DeleteProject(ctx context.Context, nameOrID string) error {

--- a/apiv2/pkg/clients/auditlog/auditlog_integration_test.go
+++ b/apiv2/pkg/clients/auditlog/auditlog_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/project"
 
 	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
@@ -24,7 +25,10 @@ func TestAPIListAuditLogs(t *testing.T) {
 
 	pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := pc.NewProject(ctx, "test-auditlog", &storageLimit)
+	err := pc.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  "test-auditlog",
+		StorageLimit: &storageLimit,
+	})
 	require.NoError(t, err)
 
 	p, err := pc.GetProject(ctx, "test-auditlog")
@@ -56,7 +60,10 @@ func TestAPIListAuditLogs_BigPageSize(t *testing.T) {
 	pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
 	for i := 0; i < 42; i++ {
-		err := pc.NewProject(ctx, "test-auditlog-"+strconv.Itoa(i), &storageLimit)
+		err := pc.NewProject(ctx, &modelv2.ProjectReq{
+			ProjectName:  "test-auditlog-" + strconv.Itoa(i),
+			StorageLimit: &storageLimit,
+		})
 		require.NoError(t, err)
 
 		p, err := pc.GetProject(ctx, "test-auditlog-"+strconv.Itoa(i))

--- a/apiv2/pkg/clients/member/member_integration_test.go
+++ b/apiv2/pkg/clients/member/member_integration_test.go
@@ -31,7 +31,10 @@ func TestAPIProjectUserMemberAdd(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -64,7 +67,10 @@ func TestAPIProjectMemberList(t *testing.T) {
 	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -107,7 +113,10 @@ func TestAPIProjectUserMemberUpdate(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -158,7 +167,10 @@ func TestAPIProjectUserMemberDelete(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)

--- a/apiv2/pkg/clients/project/project_test.go
+++ b/apiv2/pkg/clients/project/project_test.go
@@ -33,9 +33,15 @@ var (
 	pReq3 = &modelv2.ProjectReq{
 		ProjectName:  "example-project",
 		StorageLimit: &exampleStorageLimitNegative,
+		RegistryID:   int64Ptr(0),
 	}
 	ctx = context.Background()
 )
+
+// int64Ptr returns a pointer to the given int64 value.
+func int64Ptr(i int64) *int64 {
+	return &i
+}
 
 func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
 	desiredMockClients := &clienttesting.MockClients{
@@ -69,7 +75,10 @@ func TestRESTClient_NewProject(t *testing.T) {
 	mockClient.Project.On("CreateProject", postParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&projectapi.CreateProjectCreated{}, nil)
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitPositive)
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitPositive,
+	})
 
 	require.NoError(t, err)
 
@@ -96,7 +105,11 @@ func TestRESTClient_NewProject_UnlimitedStorage(t *testing.T) {
 	mockClient.Project.On("CreateProject", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&projectapi.CreateProjectCreated{}, nil)
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitNegative)
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitNegative,
+		RegistryID:   int64Ptr(0),
+	})
 
 	require.NoError(t, err)
 
@@ -116,7 +129,10 @@ func TestRESTClient_NewProject_ErrProjectUnauthorized(t *testing.T) {
 	mockClient.Project.On("CreateProject", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&projectapi.CreateProjectCreated{}, &runtime.APIError{Code: http.StatusUnauthorized})
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitPositive)
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitPositive,
+	})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, &errors.ErrUnauthorized{})
@@ -165,7 +181,10 @@ func TestRESTClient_NewProject_ErrProjectUnknownResource(t *testing.T) {
 	mockClient.Project.On("CreateProject", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(nil, &errors.ErrProjectUnknownResource{})
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitPositive)
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitPositive,
+	})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, &errors.ErrProjectUnknownResource{})
@@ -186,8 +205,10 @@ func TestRESTClient_NewProject_ErrProjectInternalErrors(t *testing.T) {
 	mockClient.Project.On("CreateProject", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&projectapi.CreateProjectCreated{}, &runtime.APIError{Code: http.StatusInternalServerError})
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitPositive)
-
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitPositive,
+	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, &errors.ErrProjectInternalErrors{})
 
@@ -207,8 +228,10 @@ func TestRESTClient_NewProject_ErrProjectIDNotExists(t *testing.T) {
 	mockClient.Project.On("CreateProject", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&projectapi.CreateProjectCreated{}, &runtime.APIError{Code: http.StatusNotFound})
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitPositive)
-
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitPositive,
+	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, &errors.ErrProjectUnknownResource{})
 
@@ -228,7 +251,10 @@ func TestRESTClient_NewProject_ErrProjectNameAlreadyExists(t *testing.T) {
 	mockClient.Project.On("CreateProject", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&projectapi.CreateProjectCreated{}, &projectapi.CreateProjectConflict{})
 
-	err := apiClient.NewProject(ctx, exampleProject.Name, &exampleStorageLimitPositive)
+	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  exampleProject.Name,
+		StorageLimit: &exampleStorageLimitPositive,
+	})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, &errors.ErrProjectNameAlreadyExists{})

--- a/apiv2/pkg/clients/projectmeta/projectmeta_integration_test.go
+++ b/apiv2/pkg/clients/projectmeta/projectmeta_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/project"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/common"
 
@@ -31,7 +32,10 @@ func TestAPIProjectMetadataAdd(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -59,7 +63,10 @@ func TestAPIProjectMetadataGet(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -80,7 +87,10 @@ func TestAPIProjectMetadataGetInvalidKey(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -102,7 +112,10 @@ func TestAPIProjectMetadataList(t *testing.T) {
 	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -139,7 +152,10 @@ func TestAPIProjectMetadataUpdate(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)
@@ -165,7 +181,10 @@ func TestAPIProjectMetadataDelete(t *testing.T) {
 
 	projectClient := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := projectClient.NewProject(ctx, projectName, &storageLimitPositive)
+	err := projectClient.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	p, err := projectClient.GetProject(ctx, projectName)

--- a/apiv2/pkg/clients/quota/quota_integration_test.go
+++ b/apiv2/pkg/clients/quota/quota_integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/project"
 
 	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
@@ -28,7 +29,10 @@ func TestAPIGetQuotaByProjectID_PositiveQuota(t *testing.T) {
 	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
 	pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-	err := pc.NewProject(ctx, testProjectName, &storageLimitPositive)
+	err := pc.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  testProjectName,
+		StorageLimit: &storageLimitPositive,
+	})
 	require.NoError(t, err)
 
 	defer pc.DeleteProject(ctx, testProjectName)
@@ -51,7 +55,10 @@ func TestAPIGetQuotaByProjectID_NegativeQuota(t *testing.T) {
 	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
 	pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-	err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+	err := pc.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  testProjectName,
+		StorageLimit: &storageLimitNegative,
+	})
 	require.NoError(t, err)
 	defer pc.DeleteProject(ctx, testProjectName)
 
@@ -72,7 +79,10 @@ func TestAPIUpdateQuotaByProjectID(t *testing.T) {
 	// Updates the projects storage quota to a positive value and compares the observed values.
 	t.Run("PositiveQuota", func(t *testing.T) {
 		pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-		err := pc.NewProject(ctx, testProjectName, &storageLimitPositive)
+		err := pc.NewProject(ctx, &modelv2.ProjectReq{
+			ProjectName:  testProjectName,
+			StorageLimit: &storageLimitPositive,
+		})
 		require.NoError(t, err)
 		defer pc.DeleteProject(ctx, testProjectName)
 
@@ -92,7 +102,10 @@ func TestAPIUpdateQuotaByProjectID(t *testing.T) {
 	// Updates the projects storage quota to a negative value and compares the observed values.
 	t.Run("NegativeQuota", func(t *testing.T) {
 		pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-		err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+		err := pc.NewProject(ctx, &modelv2.ProjectReq{
+			ProjectName:  testProjectName,
+			StorageLimit: &storageLimitNegative,
+		})
 		defer pc.DeleteProject(ctx, testProjectName)
 
 		project, err := pc.GetProject(ctx, testProjectName)
@@ -112,7 +125,10 @@ func TestAPIUpdateQuotaByProjectID(t *testing.T) {
 	// which is expected to result in the quota being implicitly set to '-1'.
 	t.Run("NegativeQuota_2", func(t *testing.T) {
 		pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-		err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+		err := pc.NewProject(ctx, &modelv2.ProjectReq{
+			ProjectName:  testProjectName,
+			StorageLimit: &storageLimitNegative,
+		})
 		require.NoError(t, err)
 
 		defer pc.DeleteProject(ctx, testProjectName)
@@ -134,7 +150,10 @@ func TestAPIUpdateQuotaByProjectID(t *testing.T) {
 	// which is expected to result in the quota being implicitly set to '-1'.
 	t.Run("NullQuota", func(t *testing.T) {
 		pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-		err := pc.NewProject(ctx, testProjectName, &storageLimitNegative)
+		err := pc.NewProject(ctx, &modelv2.ProjectReq{
+			ProjectName:  testProjectName,
+			StorageLimit: &storageLimitNegative,
+		})
 		require.NoError(t, err)
 		defer pc.DeleteProject(ctx, testProjectName)
 

--- a/apiv2/pkg/clients/retention/retention.go
+++ b/apiv2/pkg/clients/retention/retention.go
@@ -138,7 +138,7 @@ func (c *RESTClient) GetRetentionPolicyByProject(ctx context.Context, projectNam
 	return c.GetRetentionPolicyByID(ctx, id)
 }
 
-// GetRetentionPolicyByID returns a retention policy identified by it's id.
+// GetRetentionPolicyByID returns a retention policy identified by its id.
 func (c *RESTClient) GetRetentionPolicyByID(ctx context.Context, id int64) (*modelv2.RetentionPolicy, error) {
 	params := &retention.GetRetentionParams{
 		ID:      id,
@@ -149,7 +149,6 @@ func (c *RESTClient) GetRetentionPolicyByID(ctx context.Context, id int64) (*mod
 
 	resp, err := c.V2Client.Retention.GetRetention(params, c.AuthInfo)
 	if err != nil {
-		fmt.Println()
 		return nil, handleSwaggerRetentionErrors(err)
 	}
 

--- a/apiv2/pkg/clients/retention/retention_integration_test.go
+++ b/apiv2/pkg/clients/retention/retention_integration_test.go
@@ -63,7 +63,10 @@ func TestAPIRetentionNew(t *testing.T) {
 
 	pc := pc.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := pc.NewProject(ctx, projectName, &storageLimit)
+	err := pc.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimit,
+	})
 	require.NoError(t, err)
 
 	p, err := pc.GetProject(ctx, projectName)
@@ -89,7 +92,10 @@ func TestAPIRetentionUpdate(t *testing.T) {
 
 	pc := pc.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := pc.NewProject(ctx, projectName, &storageLimit)
+	err := pc.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimit,
+	})
 	require.NoError(t, err)
 
 	p, err := pc.GetProject(ctx, projectName)
@@ -149,7 +155,10 @@ func TestAPIRetentionDelete(t *testing.T) {
 
 	pc := pc.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 
-	err := pc.NewProject(ctx, projectName, &storageLimit)
+	err := pc.NewProject(ctx, &modelv2.ProjectReq{
+		ProjectName:  projectName,
+		StorageLimit: &storageLimit,
+	})
 	require.NoError(t, err)
 
 	p, err := pc.GetProject(ctx, projectName)


### PR DESCRIPTION
This PR changes the arguments of `NewProject()` to accept a more generic `ProjectReq` struct (as generated from the upstream swagger spec).
This enables users to further specify project details on creation, such as referencing an existing registry - which would make the project serve as a ["Proxy Cache"](https://goharbor.io/docs/2.4.0/administration/configure-proxy-cache/) project.