### PR TITLE
do not require the old user password on updates

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -425,8 +425,8 @@ func (c *RESTClient) UpdateUserProfile(ctx context.Context, id int64, profile *m
 	return c.user.UpdateUserProfile(ctx, id, profile)
 }
 
-func (c *RESTClient) UpdateUserPassword(ctx context.Context, userID int64, old, new string) error {
-	return c.user.UpdateUserPassword(ctx, userID, old, new)
+func (c *RESTClient) UpdateUserPassword(ctx context.Context, userID int64, passwordRequest *modelv2.PasswordReq) error {
+	return c.user.UpdateUserPassword(ctx, userID, passwordRequest)
 }
 
 func (c *RESTClient) UserExists(ctx context.Context, idOrName intstr.IntOrString) (bool, error) {

--- a/apiv2/pkg/clients/user/user_integration_test.go
+++ b/apiv2/pkg/clients/user/user_integration_test.go
@@ -158,7 +158,7 @@ func TestAPIUserDelete(t *testing.T) {
 	require.Nil(t, usr)
 }
 
-func TestAPIUserUpdate(t *testing.T) {
+func TestAPIUserUpdate_Profile(t *testing.T) {
 	ctx := context.Background()
 
 	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
@@ -187,4 +187,27 @@ func TestAPIUserUpdate(t *testing.T) {
 	require.Equal(t, usr.Email, "foo@baz.com")
 	require.Equal(t, usr.Comment, "Some other comment")
 	require.Equal(t, usr.Realname, "Foo Baz")
+}
+
+func TestAPIUserUpdate_Password(t *testing.T) {
+	ctx := context.Background()
+
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+	err := c.NewUser(ctx, username, email, realname, password, comments)
+	require.NoError(t, err)
+
+	usr, err := c.GetUserByName(ctx, username)
+	require.NoError(t, err)
+
+	require.NotNil(t, usr)
+
+	defer func() {
+		_ = c.DeleteUser(ctx, usr.UserID)
+	}()
+
+	err = c.UpdateUserPassword(ctx, usr.UserID, &modelv2.PasswordReq{
+		NewPassword: password + "1",
+		OldPassword: "",
+	})
+	require.NoError(t, err)
 }

--- a/apiv2/pkg/clients/user/user_test.go
+++ b/apiv2/pkg/clients/user/user_test.go
@@ -253,22 +253,11 @@ func TestRESTClient_UpdateUserPassword(t *testing.T) {
 			mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 			Return(&user.UpdateUserPasswordOK{}, nil)
 
-		err := apiClient.UpdateUserPassword(ctx, exampleUserID, "foo", "bar")
+		err := apiClient.UpdateUserPassword(ctx, exampleUserID, &modelv2.PasswordReq{
+			NewPassword: "bar",
+			OldPassword: "foo",
+		})
 		require.NoError(t, err)
-	})
-
-	t.Run("NoOldPassword", func(t *testing.T) {
-		mockClient.User.On("GetUser", getParams,
-			mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-			Return(&user.GetUserOK{Payload: &modelv2.UserResp{UserID: exampleUserID}}, nil)
-
-		mockClient.User.On("UpdateUserPassword", updatePWParams,
-			mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-			Return(&user.UpdateUserPasswordOK{}, nil)
-
-		err := apiClient.UpdateUserPassword(ctx, exampleUserID, "", "bar")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "no old password provided")
 	})
 
 	t.Run("NoNewPassword", func(t *testing.T) {
@@ -280,7 +269,10 @@ func TestRESTClient_UpdateUserPassword(t *testing.T) {
 			mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 			Return(&user.UpdateUserPasswordOK{}, nil)
 
-		err := apiClient.UpdateUserPassword(ctx, exampleUserID, "foo", "")
+		err := apiClient.UpdateUserPassword(ctx, exampleUserID, &modelv2.PasswordReq{
+			NewPassword: "",
+			OldPassword: "foo",
+		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no new password provided")
 	})


### PR DESCRIPTION
The old password of a user is not required as of [Goharbor's swagger spec](https://github.com/goharbor/harbor/blob/main/api/v2.0/swagger.yaml#L5097), so we shouldn't fail if omitted.
The `UpdateUserPassword()` method now accepts the model of the upstream `PasswordReq` instead.