### PR TITLE
add repository client, bump swagger spec to v2.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ harbor-teardown test integration-test-v1-ci integration-test-v2-ci integration-t
 fmt gofmt gofumpt goimports lint
 
 V1_VERSION = v1.10.9
-V2_VERSION = v2.4.0
+V2_VERSION = v2.4.1
 MOCKERY_VERSION = v2.9.4
 GOSWAGGER_VERSION = v0.25.0
-GOLANGCI_LINT_VERSION = v1.42.1
+GOLANGCI_LINT_VERSION = v1.43.0
 
 # Run all code generation targets
 generate: swagger-generate mock-generate
@@ -76,4 +76,4 @@ goimports:
 
 lint:
 	docker run --rm -v $(shell pwd):/goharbor-client -w /goharbor-client/. \
-	golangci/golangci-lint:v1.40.0 golangci-lint run --sort-results
+	golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run --sort-results

--- a/apiv1/project/project.go
+++ b/apiv1/project/project.go
@@ -46,12 +46,10 @@ type Client interface {
 	GetProject(ctx context.Context, name string) (*model.Project, error)
 	ListProjects(ctx context.Context, nameFilter string) ([]*model.Project, error)
 	UpdateProject(ctx context.Context, p *model.Project, countLimit int, storageLimit int) error
-
 	AddProjectMember(ctx context.Context, p *model.Project, u *model.User, roleID int) error
 	ListProjectMembers(ctx context.Context, p *model.Project) ([]*model.ProjectMemberEntity, error)
 	UpdateProjectMemberRole(ctx context.Context, p *model.Project, u *model.User, roleID int) error
 	DeleteProjectMember(ctx context.Context, p *model.Project, u *model.User) error
-
 	AddProjectMetadata(ctx context.Context, p *model.Project, key MetadataKey, value string) error
 	ListProjectMetadata(ctx context.Context, p *model.Project) (*model.ProjectMetadata, error)
 	GetProjectMetadataValue(ctx context.Context, p *model.Project, key MetadataKey) (string, error)

--- a/apiv1/replication/replication.go
+++ b/apiv1/replication/replication.go
@@ -35,7 +35,6 @@ type Client interface {
 	GetReplicationPolicyByID(ctx context.Context, id int64) (*model.ReplicationPolicy, error)
 	DeleteReplicationPolicy(ctx context.Context, r *model.ReplicationPolicy) error
 	UpdateReplicationPolicy(ctx context.Context, r *model.ReplicationPolicy) error
-
 	TriggerReplicationExecution(ctx context.Context, r *model.ReplicationExecution) error
 	GetReplicationExecutions(ctx context.Context, r *model.ReplicationExecution) ([]*model.ReplicationExecution, error)
 	GetReplicationExecutionsByID(ctx context.Context,
@@ -193,8 +192,8 @@ func (c *RESTClient) TriggerReplicationExecution(ctx context.Context, r *model.R
 // GetReplicationExecutions lists replication executions specified by ID, status or trigger.
 // Specifying the property "policy_id" will return executions of the specified policy.
 func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
-	r *model.ReplicationExecution) ([]*model.ReplicationExecution, error) {
-
+	r *model.ReplicationExecution) ([]*model.ReplicationExecution, error,
+) {
 	resp, err := c.Client.Products.GetReplicationExecutions(
 		&products.GetReplicationExecutionsParams{
 			PolicyID: &r.PolicyID,
@@ -211,8 +210,8 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 
 // GetReplicationExecutionByID returns a replication execution specified by ID.
 func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context,
-	id int64) (*model.ReplicationExecution, error) {
-
+	id int64) (*model.ReplicationExecution, error,
+) {
 	resp, err := c.Client.Products.GetReplicationExecutionsID(
 		&products.GetReplicationExecutionsIDParams{
 			ID:      id,

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/repository"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
@@ -46,6 +48,7 @@ type Client interface {
 	quota.Client
 	registry.Client
 	replication.Client
+	repository.Client
 	retention.Client
 	robot.Client
 	robotv1.Client
@@ -65,6 +68,7 @@ type RESTClient struct {
 	quota       *quota.RESTClient
 	registry    *registry.RESTClient
 	replication *replication.RESTClient
+	repository  *repository.RESTClient
 	retention   *retention.RESTClient
 	robot       *robot.RESTClient
 	robotv1     *robotv1.RESTClient
@@ -89,6 +93,7 @@ func NewRESTClient(v2Client *v2client.Harbor, opts *config.Options, authInfo run
 		quota:       quota.NewClient(v2Client, opts, authInfo),
 		registry:    registry.NewClient(v2Client, opts, authInfo),
 		replication: replication.NewClient(v2Client, opts, authInfo),
+		repository:  repository.NewClient(v2Client, opts, authInfo),
 		retention:   retention.NewClient(v2Client, opts, authInfo),
 		robot:       robot.NewClient(v2Client, opts, authInfo),
 		robotv1:     robotv1.NewClient(v2Client, opts, authInfo),
@@ -297,6 +302,28 @@ func (c *RESTClient) ListReplicationExecutions(ctx context.Context, policyID *in
 
 func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context, id int64) (*modelv2.ReplicationExecution, error) {
 	return c.replication.GetReplicationExecutionByID(ctx, id)
+}
+
+// Repository Client
+
+func (c *RESTClient) GetRepository(ctx context.Context, projectName, repositoryName string) (*modelv2.Repository, error) {
+	return c.repository.GetRepository(ctx, projectName, repositoryName)
+}
+
+func (c *RESTClient) UpdateRepository(ctx context.Context, projectName, repositoryName string, update *modelv2.Repository) error {
+	return c.repository.UpdateRepository(ctx, projectName, repositoryName, update)
+}
+
+func (c *RESTClient) ListAllRepositories(ctx context.Context) ([]*modelv2.Repository, error) {
+	return c.repository.ListAllRepositories(ctx)
+}
+
+func (c *RESTClient) ListRepositories(ctx context.Context, projectName string) ([]*modelv2.Repository, error) {
+	return c.repository.ListRepositories(ctx, projectName)
+}
+
+func (c *RESTClient) DeleteRepository(ctx context.Context, projectName, repositoryName string) error {
+	return c.repository.DeleteRepository(ctx, projectName, repositoryName)
 }
 
 // Retention Client

--- a/apiv2/internal/api/client/artifact/get_artifact_parameters.go
+++ b/apiv2/internal/api/client/artifact/get_artifact_parameters.go
@@ -21,7 +21,7 @@ import (
 // with the default values initialized.
 func NewGetArtifactParams() *GetArtifactParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)
@@ -48,7 +48,7 @@ func NewGetArtifactParams() *GetArtifactParams {
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetArtifactParamsWithTimeout(timeout time.Duration) *GetArtifactParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)
@@ -75,7 +75,7 @@ func NewGetArtifactParamsWithTimeout(timeout time.Duration) *GetArtifactParams {
 // with the default values initialized, and the ability to set a context for a request
 func NewGetArtifactParamsWithContext(ctx context.Context) *GetArtifactParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)
@@ -102,7 +102,7 @@ func NewGetArtifactParamsWithContext(ctx context.Context) *GetArtifactParams {
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetArtifactParamsWithHTTPClient(client *http.Client) *GetArtifactParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)

--- a/apiv2/internal/api/client/artifact/get_vulnerabilities_addition_parameters.go
+++ b/apiv2/internal/api/client/artifact/get_vulnerabilities_addition_parameters.go
@@ -20,7 +20,7 @@ import (
 // with the default values initialized.
 func NewGetVulnerabilitiesAdditionParams() *GetVulnerabilitiesAdditionParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 	)
 	return &GetVulnerabilitiesAdditionParams{
 		XAcceptVulnerabilities: &xAcceptVulnerabilitiesDefault,
@@ -33,7 +33,7 @@ func NewGetVulnerabilitiesAdditionParams() *GetVulnerabilitiesAdditionParams {
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetVulnerabilitiesAdditionParamsWithTimeout(timeout time.Duration) *GetVulnerabilitiesAdditionParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 	)
 	return &GetVulnerabilitiesAdditionParams{
 		XAcceptVulnerabilities: &xAcceptVulnerabilitiesDefault,
@@ -46,7 +46,7 @@ func NewGetVulnerabilitiesAdditionParamsWithTimeout(timeout time.Duration) *GetV
 // with the default values initialized, and the ability to set a context for a request
 func NewGetVulnerabilitiesAdditionParamsWithContext(ctx context.Context) *GetVulnerabilitiesAdditionParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 	)
 	return &GetVulnerabilitiesAdditionParams{
 		XAcceptVulnerabilities: &xAcceptVulnerabilitiesDefault,
@@ -59,7 +59,7 @@ func NewGetVulnerabilitiesAdditionParamsWithContext(ctx context.Context) *GetVul
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetVulnerabilitiesAdditionParamsWithHTTPClient(client *http.Client) *GetVulnerabilitiesAdditionParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 	)
 	return &GetVulnerabilitiesAdditionParams{
 		XAcceptVulnerabilities: &xAcceptVulnerabilitiesDefault,

--- a/apiv2/internal/api/client/artifact/list_artifacts_parameters.go
+++ b/apiv2/internal/api/client/artifact/list_artifacts_parameters.go
@@ -21,7 +21,7 @@ import (
 // with the default values initialized.
 func NewListArtifactsParams() *ListArtifactsParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)
@@ -48,7 +48,7 @@ func NewListArtifactsParams() *ListArtifactsParams {
 // with the default values initialized, and the ability to set a timeout on a request
 func NewListArtifactsParamsWithTimeout(timeout time.Duration) *ListArtifactsParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)
@@ -75,7 +75,7 @@ func NewListArtifactsParamsWithTimeout(timeout time.Duration) *ListArtifactsPara
 // with the default values initialized, and the ability to set a context for a request
 func NewListArtifactsParamsWithContext(ctx context.Context) *ListArtifactsParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)
@@ -102,7 +102,7 @@ func NewListArtifactsParamsWithContext(ctx context.Context) *ListArtifactsParams
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewListArtifactsParamsWithHTTPClient(client *http.Client) *ListArtifactsParams {
 	var (
-		xAcceptVulnerabilitiesDefault = string("application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+		xAcceptVulnerabilitiesDefault = string("application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
 		pageDefault                   = int64(1)
 		pageSizeDefault               = int64(10)
 		withImmutableStatusDefault    = bool(false)

--- a/apiv2/pkg/clients/replication/replication.go
+++ b/apiv2/pkg/clients/replication/replication.go
@@ -51,8 +51,8 @@ type Client interface {
 func (c *RESTClient) NewReplicationPolicy(ctx context.Context, destRegistry, srcRegistry *modelv2.Registry,
 	replicateDeletion, override, enablePolicy bool,
 	filters []*modelv2.ReplicationFilter, trigger *modelv2.ReplicationTrigger,
-	destNamespace, description, name string) error {
-
+	destNamespace, description, name string,
+) error {
 	params := &replicationapi.CreateReplicationPolicyParams{
 		Policy: &modelv2.ReplicationPolicy{
 			Description:               description,

--- a/apiv2/pkg/clients/replication/replication_errors.go
+++ b/apiv2/pkg/clients/replication/replication_errors.go
@@ -150,7 +150,7 @@ func (e *ErrReplicationDisabled) Error() string {
 	return ErrReplicationDisabledMsg
 }
 
-// handleReplicationErrors takes a swagger generated error as input,
+// handleSwaggerReplicationErrors takes a swagger generated error as input,
 // which usually does not contain any form of error message,
 // and outputs a new error with a proper message.
 func handleSwaggerReplicationErrors(in error) error {

--- a/apiv2/pkg/clients/repository/repository.go
+++ b/apiv2/pkg/clients/repository/repository.go
@@ -1,0 +1,143 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/go-openapi/runtime"
+	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/repository"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/errors"
+)
+
+// RESTClient is a subclient for handling repository related actions.
+type RESTClient struct {
+	// Options contains optional configuration when making API calls.
+	Options *config.Options
+
+	// The new client of the harbor v2 API
+	V2Client *v2client.Harbor
+
+	// AuthInfo contains the auth information that is provided on API calls.
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func NewClient(v2Client *v2client.Harbor, opts *config.Options, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
+	return &RESTClient{
+		Options:  opts,
+		V2Client: v2Client,
+		AuthInfo: authInfo,
+	}
+}
+
+type Client interface {
+	GetRepository(ctx context.Context, projectName, repositoryName string) (*model.Repository, error)
+	UpdateRepository(ctx context.Context, projectName, repositoryName string, update *model.Repository) error
+	ListAllRepositories(ctx context.Context) ([]*model.Repository, error)
+	ListRepositories(ctx context.Context, projectName string) ([]*model.Repository, error)
+	DeleteRepository(ctx context.Context, projectName, repositoryName string) error
+}
+
+func (c *RESTClient) GetRepository(ctx context.Context, projectName, repositoryName string) (*model.Repository, error) {
+	params := &repository.GetRepositoryParams{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	resp, err := c.V2Client.Repository.GetRepository(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerRepositoryErrors(err)
+	}
+
+	if resp.Payload != nil {
+		return resp.Payload, nil
+	}
+
+	return nil, &errors.ErrNotFound{}
+}
+
+func (c *RESTClient) UpdateRepository(ctx context.Context, projectName, repositoryName string, update *model.Repository) error {
+	params := &repository.UpdateRepositoryParams{
+		ProjectName:    projectName,
+		Repository:     update,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Repository.UpdateRepository(params, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerRepositoryErrors(err)
+	}
+
+	return nil
+}
+
+func (c *RESTClient) ListAllRepositories(ctx context.Context) ([]*model.Repository, error) {
+	params := &repository.ListAllRepositoriesParams{
+		Page:     &c.Options.Page,
+		PageSize: &c.Options.PageSize,
+		Q:        &c.Options.Query,
+		Sort:     &c.Options.Sort,
+		Context:  ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	resp, err := c.V2Client.Repository.ListAllRepositories(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerRepositoryErrors(err)
+	}
+
+	if resp.Payload != nil {
+		return resp.Payload, nil
+	}
+
+	return nil, &errors.ErrNotFound{}
+}
+
+func (c *RESTClient) ListRepositories(ctx context.Context, projectName string) ([]*model.Repository, error) {
+	params := &repository.ListRepositoriesParams{
+		Page:        &c.Options.Page,
+		PageSize:    &c.Options.PageSize,
+		ProjectName: projectName,
+		Q:           &c.Options.Query,
+		Sort:        &c.Options.Sort,
+		Context:     ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	resp, err := c.V2Client.Repository.ListRepositories(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerRepositoryErrors(err)
+	}
+
+	if resp.Payload != nil {
+		return resp.Payload, nil
+	}
+
+	return nil, &errors.ErrNotFound{}
+}
+
+func (c *RESTClient) DeleteRepository(ctx context.Context, projectName, repositoryName string) error {
+	params := &repository.DeleteRepositoryParams{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Repository.DeleteRepository(params, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerRepositoryErrors(err)
+	}
+
+	return nil
+}

--- a/apiv2/pkg/clients/repository/repository_errors.go
+++ b/apiv2/pkg/clients/repository/repository_errors.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/errors"
+)
+
+// handleSwaggerRepositoryErrors takes a swagger generated error as input,
+// which usually does not contain any form of error message,
+// and outputs a new error with a proper message.
+func handleSwaggerRepositoryErrors(in error) error {
+	t, ok := in.(*runtime.APIError)
+	if ok {
+		switch t.Code {
+		case http.StatusOK:
+			return nil
+		case http.StatusBadRequest:
+			return &errors.ErrBadRequest{}
+		case http.StatusUnauthorized:
+			return &errors.ErrUnauthorized{}
+		case http.StatusForbidden:
+			return &errors.ErrForbidden{}
+		case http.StatusNotFound:
+			return &errors.ErrNotFound{}
+		case http.StatusInternalServerError:
+			return &errors.ErrNotFound{}
+		}
+	}
+
+	return in
+}

--- a/apiv2/pkg/clients/repository/repository_errors.go
+++ b/apiv2/pkg/clients/repository/repository_errors.go
@@ -25,7 +25,7 @@ func handleSwaggerRepositoryErrors(in error) error {
 		case http.StatusNotFound:
 			return &errors.ErrNotFound{}
 		case http.StatusInternalServerError:
-			return &errors.ErrNotFound{}
+			return &errors.ErrInternalErrors{}
 		}
 	}
 

--- a/apiv2/pkg/clients/repository/repository_integration_test.go
+++ b/apiv2/pkg/clients/repository/repository_integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/project"
+	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+var projectName = "test-project"
+
+func TestAPIRepositoryListAllRepositories(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	repositories, err := c.ListAllRepositories(ctx)
+	require.NoError(t, err)
+	require.Empty(t, repositories)
+}
+
+func TestAPIRepositoryListRepositories(t *testing.T) {
+	ctx := context.Background()
+
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+	pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	err := pc.NewProject(ctx, &model.ProjectReq{
+		ProjectName: projectName,
+	})
+	require.NoError(t, err)
+
+	defer pc.DeleteProject(ctx, projectName)
+
+	projectRepositories, err := c.ListRepositories(ctx, projectName)
+	require.NoError(t, err)
+	require.Empty(t, projectRepositories)
+}

--- a/apiv2/pkg/clients/repository/repository_test.go
+++ b/apiv2/pkg/clients/repository/repository_test.go
@@ -1,0 +1,140 @@
+//go:build !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/repository"
+	"github.com/mittwald/goharbor-client/v5/apiv2/mocks"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var ctx = context.Background()
+
+func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
+	desiredMockClients := &clienttesting.MockClients{
+		Repository:      mocks.MockRepositoryClientService{},
+		ProjectMetadata: mocks.MockProject_metadataClientService{},
+	}
+
+	v2Client := clienttesting.BuildV2ClientWithMocks(desiredMockClients)
+
+	cl := NewClient(v2Client, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	return cl, desiredMockClients
+}
+
+var (
+	projectName    = "test-project"
+	repositoryName = "test-repository"
+)
+
+func TestRESTClient_GetRepository(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	getParams := &repository.GetRepositoryParams{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	getParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Repository.On("GetRepository", getParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&repository.GetRepositoryOK{Payload: &model.Repository{}}, nil)
+
+	_, err := apiClient.GetRepository(ctx, projectName, repositoryName)
+	require.NoError(t, err)
+
+	mockClient.Retention.AssertExpectations(t)
+}
+
+func TestRESTClient_UpdateRepository(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	updateParams := &repository.UpdateRepositoryParams{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Repository:     &model.Repository{},
+		Context:        ctx,
+	}
+
+	updateParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Repository.On("UpdateRepository", updateParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&repository.UpdateRepositoryOK{}, nil)
+
+	err := apiClient.UpdateRepository(ctx, projectName, repositoryName, &model.Repository{})
+	require.NoError(t, err)
+
+	mockClient.Retention.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteRepository(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	deleteParams := &repository.DeleteRepositoryParams{
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	deleteParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Repository.On("DeleteRepository", deleteParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&repository.DeleteRepositoryOK{}, nil)
+
+	err := apiClient.DeleteRepository(ctx, projectName, repositoryName)
+	require.NoError(t, err)
+
+	mockClient.Retention.AssertExpectations(t)
+}
+
+func TestRESTClient_ListAllRepositories(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	listParams := &repository.ListAllRepositoriesParams{
+		Page:     &apiClient.Options.Page,
+		PageSize: &apiClient.Options.PageSize,
+		Q:        &apiClient.Options.Query,
+		Sort:     &apiClient.Options.Sort,
+		Context:  ctx,
+	}
+
+	listParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Repository.On("ListAllRepositories", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&repository.ListAllRepositoriesOK{Payload: []*model.Repository{}}, nil)
+
+	_, err := apiClient.ListAllRepositories(ctx)
+	require.NoError(t, err)
+
+	mockClient.Retention.AssertExpectations(t)
+}
+
+func TestRESTClient_ListRepositories(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	listParams := &repository.ListRepositoriesParams{
+		Page:        &apiClient.Options.Page,
+		PageSize:    &apiClient.Options.PageSize,
+		ProjectName: projectName,
+		Q:           &apiClient.Options.Query,
+		Sort:        &apiClient.Options.Sort,
+		Context:     ctx,
+	}
+	listParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Repository.On("ListRepositories", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&repository.ListRepositoriesOK{Payload: []*model.Repository{}}, nil)
+
+	_, err := apiClient.ListRepositories(ctx, projectName)
+	require.NoError(t, err)
+
+	mockClient.Retention.AssertExpectations(t)
+}


### PR DESCRIPTION
This PR adds the `repository` sub-client, supporting client operations on uploaded images, helm charts, etc.
More on Harbor repositories here: https://goharbor.io/docs/2.4.0/working-with-projects/working-with-images/repositories/
The `v2` swagger specification used for code generation has been updated from `v2.4.0` -> `v2.4.1`, too.

Fixes #107 