### PR TITLE
add artifact and label client

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
+      - name: Add local harbor host to /etc/hosts
+        run: echo "127.0.0.1 core.harbor.domain" | sudo tee -a /etc/hosts
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ## Table of contents
 - [Repository structure](#repository-structure)
 - [Implementing sub-clients](#implementing-sub-clients)
+- [Testing](#testing)
 - [Code generation](#code-generation)
     - [Client APIs](#client-apis)
     - [API mocks](#api-mocks)
@@ -224,6 +225,49 @@ func (c *RESTClient) GetUserByName(ctx context.Context, username string) (*model
 }
 
 [...]
+```
+
+## Testing
+
+### Unit Tests
+
+Unit tests are marked via the build tag `!integration`.
+
+For running unit tests against the `goharbor-client` package, the following command can be used:
+```
+make test
+```
+
+### Integration Tests
+
+Integration tests are marked via the build tag `integration`.
+
+The scripts contained in this repository can be used to set up an environment using [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+For the Harbor registry component to work properly, an entry in the `/etc/hosts` file is required:
+```shell
+127.0.0.1 core.harbor.domain
+```
+
+For running integration tests against the `goharbor-client` package, the following commands can be used:
+```shell
+# Set up the Harbor helm chart locally (using kind).
+# Note: The setup/test run will only be executed once.
+make integration-test-v[1|2]-ci
+```
+
+The above is intended to be used in a CI environment (such as Github Actions).
+
+Executing the above is equivalent to running the following:
+```shell
+make setup-harbor-v[1|2]
+make integration-test-v[1|2]
+```
+
+The remaining cluster can be deleted using the following command:
+
+```shell
+make uninstall-harbor-v[1|2]
 ```
 
 ## Code generation

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,4 @@ goimports:
 
 lint:
 	docker run --rm -v $(shell pwd):/goharbor-client -w /goharbor-client/. \
-	golangci/golangci-lint:v1.40.0 golangci-lint run --sort-results
+	golangci/golangci-lint:v1.45.2 golangci-lint run --sort-results

--- a/apiv1/project/project.go
+++ b/apiv1/project/project.go
@@ -46,12 +46,10 @@ type Client interface {
 	GetProject(ctx context.Context, name string) (*model.Project, error)
 	ListProjects(ctx context.Context, nameFilter string) ([]*model.Project, error)
 	UpdateProject(ctx context.Context, p *model.Project, countLimit int, storageLimit int) error
-
 	AddProjectMember(ctx context.Context, p *model.Project, u *model.User, roleID int) error
 	ListProjectMembers(ctx context.Context, p *model.Project) ([]*model.ProjectMemberEntity, error)
 	UpdateProjectMemberRole(ctx context.Context, p *model.Project, u *model.User, roleID int) error
 	DeleteProjectMember(ctx context.Context, p *model.Project, u *model.User) error
-
 	AddProjectMetadata(ctx context.Context, p *model.Project, key MetadataKey, value string) error
 	ListProjectMetadata(ctx context.Context, p *model.Project) (*model.ProjectMetadata, error)
 	GetProjectMetadataValue(ctx context.Context, p *model.Project, key MetadataKey) (string, error)

--- a/apiv1/replication/replication.go
+++ b/apiv1/replication/replication.go
@@ -35,7 +35,6 @@ type Client interface {
 	GetReplicationPolicyByID(ctx context.Context, id int64) (*model.ReplicationPolicy, error)
 	DeleteReplicationPolicy(ctx context.Context, r *model.ReplicationPolicy) error
 	UpdateReplicationPolicy(ctx context.Context, r *model.ReplicationPolicy) error
-
 	TriggerReplicationExecution(ctx context.Context, r *model.ReplicationExecution) error
 	GetReplicationExecutions(ctx context.Context, r *model.ReplicationExecution) ([]*model.ReplicationExecution, error)
 	GetReplicationExecutionsByID(ctx context.Context,
@@ -194,7 +193,6 @@ func (c *RESTClient) TriggerReplicationExecution(ctx context.Context, r *model.R
 // Specifying the property "policy_id" will return executions of the specified policy.
 func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 	r *model.ReplicationExecution) ([]*model.ReplicationExecution, error) {
-
 	resp, err := c.Client.Products.GetReplicationExecutions(
 		&products.GetReplicationExecutionsParams{
 			PolicyID: &r.PolicyID,
@@ -210,9 +208,7 @@ func (c *RESTClient) GetReplicationExecutions(ctx context.Context,
 }
 
 // GetReplicationExecutionByID returns a replication execution specified by ID.
-func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context,
-	id int64) (*model.ReplicationExecution, error) {
-
+func (c *RESTClient) GetReplicationExecutionByID(ctx context.Context, id int64) (*model.ReplicationExecution, error) {
 	resp, err := c.Client.Products.GetReplicationExecutionsID(
 		&products.GetReplicationExecutionsIDParams{
 			ID:      id,

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -213,8 +213,8 @@ func (c *RESTClient) GetLabelByID(ctx context.Context, id int64) (*modelv2.Label
 	return c.label.GetLabelByID(ctx, id)
 }
 
-func (c *RESTClient) ListLabels(ctx context.Context, name string, projectID *int64, scope label.Scope) ([]*modelv2.Label, error) {
-	return c.label.ListLabels(ctx, name, projectID, scope)
+func (c *RESTClient) ListLabels(ctx context.Context, name string, projectID *int64) ([]*modelv2.Label, error) {
+	return c.label.ListLabels(ctx, name, projectID)
 }
 
 func (c *RESTClient) DeleteLabel(ctx context.Context, id int64) error {

--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -5,6 +5,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/label"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/artifact"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
@@ -38,8 +42,10 @@ const v2URLSuffix string = "/v2.0"
 
 type Client interface {
 	auditlog.Client
+	artifact.Client
 	gc.Client
 	health.Client
+	label.Client
 	member.Client
 	project.Client
 	projectmeta.Client
@@ -57,8 +63,10 @@ type Client interface {
 // RESTClient implements the Client interface as a REST client
 type RESTClient struct {
 	auditlog    *auditlog.RESTClient
+	artifact    *artifact.RESTClient
 	gc          *gc.RESTClient
 	health      *health.RESTClient
+	label       *label.RESTClient
 	member      *member.RESTClient
 	project     *project.RESTClient
 	projectmeta *projectmeta.RESTClient
@@ -81,8 +89,10 @@ func NewRESTClient(v2Client *v2client.Harbor, opts *config.Options, authInfo run
 
 	return &RESTClient{
 		auditlog:    auditlog.NewClient(v2Client, opts, authInfo),
+		artifact:    artifact.NewClient(v2Client, opts, authInfo),
 		gc:          gc.NewClient(v2Client, opts, authInfo),
 		health:      health.NewClient(v2Client, opts, authInfo),
+		label:       label.NewClient(v2Client, opts, authInfo),
 		member:      member.NewClient(v2Client, opts, authInfo),
 		project:     project.NewClient(v2Client, opts, authInfo),
 		projectmeta: projectmeta.NewClient(v2Client, opts, authInfo),
@@ -122,6 +132,49 @@ func (c *RESTClient) ListAuditLogs(ctx context.Context) ([]*modelv2.AuditLog, er
 	return c.auditlog.ListAuditLogs(ctx)
 }
 
+// Artifact Client
+
+// TODO: Introduce this, once https://github.com/goharbor/harbor/issues/13468 is resolved.
+//func (c *RESTClient) GetVulnerabilitiesAddition(ctx context.Context, projectName, repositoryName, reference string) (interface{}, error) {
+//	return c.artifact.GetVulnerabilitiesAddition(ctx, projectName, repositoryName, reference)
+//}
+//
+//func (c *RESTClient) GetAddition(ctx context.Context, projectName, repositoryName, reference string, addition artifact.Addition) (interface{}, error) {
+//	return c.artifact.GetAddition(ctx, projectName, repositoryName, reference, addition)
+//}
+
+func (c *RESTClient) AddArtifactLabel(ctx context.Context, projectName, repositoryName, reference string, label *modelv2.Label) error {
+	return c.artifact.AddArtifactLabel(ctx, projectName, repositoryName, reference, label)
+}
+
+func (c *RESTClient) CopyArtifact(ctx context.Context, from *artifact.CopyReference, projectName, repositoryName string) error {
+	return c.artifact.CopyArtifact(ctx, from, projectName, repositoryName)
+}
+
+func (c *RESTClient) CreateTag(ctx context.Context, projectName, repositoryName, reference string, tag *modelv2.Tag) error {
+	return c.artifact.CreateTag(ctx, projectName, repositoryName, reference, tag)
+}
+
+func (c *RESTClient) DeleteTag(ctx context.Context, projectName, repositoryName, reference, tagName string) error {
+	return c.artifact.DeleteTag(ctx, projectName, repositoryName, reference, tagName)
+}
+
+func (c *RESTClient) GetArtifact(ctx context.Context, projectName, repositoryName, reference string) (*modelv2.Artifact, error) {
+	return c.artifact.GetArtifact(ctx, projectName, repositoryName, reference)
+}
+
+func (c *RESTClient) ListArtifacts(ctx context.Context, projectName, repositoryName string) ([]*modelv2.Artifact, error) {
+	return c.artifact.ListArtifacts(ctx, projectName, repositoryName)
+}
+
+func (c *RESTClient) ListTags(ctx context.Context, projectName, repositoryName, reference string) ([]*modelv2.Tag, error) {
+	return c.artifact.ListTags(ctx, projectName, repositoryName, reference)
+}
+
+func (c *RESTClient) RemoveLabel(ctx context.Context, projectName, repositoryName, reference string, id int64) error {
+	return c.artifact.RemoveLabel(ctx, projectName, repositoryName, reference, id)
+}
+
 // GC Client
 
 func (c *RESTClient) NewGarbageCollection(ctx context.Context, gcSchedule *modelv2.Schedule) error {
@@ -148,6 +201,28 @@ func (c *RESTClient) ResetGarbageCollection(ctx context.Context) error {
 
 func (c *RESTClient) GetHealth(ctx context.Context) (*modelv2.OverallHealthStatus, error) {
 	return c.health.GetHealth(ctx)
+}
+
+// Label Client
+
+func (c *RESTClient) CreateLabel(ctx context.Context, l *modelv2.Label) error {
+	return c.label.CreateLabel(ctx, l)
+}
+
+func (c *RESTClient) GetLabelByID(ctx context.Context, id int64) (*modelv2.Label, error) {
+	return c.label.GetLabelByID(ctx, id)
+}
+
+func (c *RESTClient) ListLabels(ctx context.Context, name string, projectID *int64, scope label.Scope) ([]*modelv2.Label, error) {
+	return c.label.ListLabels(ctx, name, projectID, scope)
+}
+
+func (c *RESTClient) DeleteLabel(ctx context.Context, id int64) error {
+	return c.label.DeleteLabel(ctx, id)
+}
+
+func (c *RESTClient) UpdateLabel(ctx context.Context, id int64, l *modelv2.Label) error {
+	return c.label.UpdateLabel(ctx, id, l)
 }
 
 // Member Client

--- a/apiv2/client_test.go
+++ b/apiv2/client_test.go
@@ -6,16 +6,14 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+
 	runtimeclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
 	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
 )
-
-func int64ptr(in int64) *int64 {
-	return &in
-}
 
 var (
 	harborClient, _ = NewRESTClientForHost("", "", "", nil)
@@ -35,7 +33,10 @@ func ExampleNewRESTClientForHost() {
 		panic(err)
 	}
 
-	err = harborClient.NewProject(ctx, "test-project", int64ptr(-1))
+	err = harborClient.NewProject(ctx, &model.ProjectReq{
+		ProjectName: "my-project",
+	})
+
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +60,10 @@ func ExampleNewRESTClient() {
 
 	harborClient := NewRESTClient(v2SwaggerClient, nil, authInfo)
 
-	err = harborClient.NewProject(ctx, "test-project", int64ptr(-1))
+	err = harborClient.NewProject(ctx, &model.ProjectReq{
+		ProjectName: "my-project",
+	})
+
 	if err != nil {
 		panic(err)
 	}

--- a/apiv2/pkg/clients/artifact/artifact.go
+++ b/apiv2/pkg/clients/artifact/artifact.go
@@ -1,0 +1,269 @@
+package artifact
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-openapi/runtime"
+	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/artifact"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
+)
+
+// RESTClient is a subclient for handling artifact related actions.
+type RESTClient struct {
+	// Options contains optional configuration when making API calls.
+	Options *config.Options
+
+	// The new client of the harbor v2 API
+	V2Client *v2client.Harbor
+
+	// AuthInfo contains the auth information that is provided on API calls.
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func NewClient(v2Client *v2client.Harbor, opts *config.Options, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
+	return &RESTClient{
+		Options:  opts,
+		V2Client: v2Client,
+		AuthInfo: authInfo,
+	}
+}
+
+type Client interface {
+	AddArtifactLabel(ctx context.Context, projectName, repositoryName, reference string, label *model.Label) error
+	CopyArtifact(ctx context.Context, from *CopyReference, projectName, repositoryName string) error
+	CreateTag(ctx context.Context, projectName, repositoryName, reference string, tag *model.Tag) error
+	DeleteTag(ctx context.Context, projectName, repositoryName, reference, tagName string) error
+	GetArtifact(ctx context.Context, projectName, repositoryName, reference string) (*model.Artifact, error)
+	ListArtifacts(ctx context.Context, projectName, repositoryName string) ([]*model.Artifact, error)
+	ListTags(ctx context.Context, projectName, repositoryName, reference string) ([]*model.Tag, error)
+	RemoveLabel(ctx context.Context, projectName, repositoryName, reference string, id int64) error
+	// TODO: Introduce this, once https://github.com/goharbor/harbor/issues/13468 is resolved.
+	// GetAddition(ctx context.Context, projectName, repositoryName, reference string, addition Addition) (string, error)
+	// GetVulnerabilitiesAddition(ctx context.Context, projectName, repositoryName, reference string) (string, error)
+}
+
+// ToString returns a string representation of a CopyReference.
+// Possible formats are "project/repository:tag" or "project/repository@digest".
+// Returns an error if neither tag nor digest is set.
+func (in CopyReference) toString() (string, error) {
+	var suffix string
+
+	if in.Digest == "" && in.Tag == "" {
+		return "", fmt.Errorf("no tag or digest specified")
+	}
+
+	if in.Digest != "" {
+		suffix = "@" + in.Digest
+	}
+	if in.Tag != "" {
+		suffix = ":" + in.Tag
+	}
+
+	return in.ProjectName + "/" + in.RepositoryName + suffix, nil
+}
+
+// CopyReference defines the parameters needed for an artifact copy.
+type CopyReference struct {
+	ProjectName    string
+	RepositoryName string
+	Tag            string
+	Digest         string
+}
+
+type Addition string
+
+const (
+	AdditionBuildHistory Addition = "build_history"
+	AdditionValuesYAML   Addition = "values.yaml"
+	AdditionReadme       Addition = "readme.md"
+	AdditionDependencies Addition = "dependencies"
+)
+
+// TODO: Introduce this, once https://github.com/goharbor/harbor/issues/13468 is resolved.
+//func (in Addition) string() string {
+//	return string(in)
+//}
+
+func (c *RESTClient) AddArtifactLabel(ctx context.Context, projectName, repositoryName, reference string, label *model.Label) error {
+	params := &artifact.AddLabelParams{
+		Label:          label,
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Artifact.AddLabel(params, c.AuthInfo)
+
+	return handleSwaggerArtifactErrors(err)
+}
+
+func (c *RESTClient) CopyArtifact(ctx context.Context, from *CopyReference, projectName, repositoryName string) error {
+	f, err := from.toString()
+	if err != nil {
+		return err
+	}
+
+	params := &artifact.CopyArtifactParams{
+		From:           f,
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err = c.V2Client.Artifact.CopyArtifact(params, c.AuthInfo)
+
+	return handleSwaggerArtifactErrors(err)
+}
+
+func (c *RESTClient) CreateTag(ctx context.Context, projectName, repositoryName, reference string, tag *model.Tag) error {
+	params := &artifact.CreateTagParams{
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		Tag:            tag,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Artifact.CreateTag(params, c.AuthInfo)
+
+	return handleSwaggerArtifactErrors(err)
+}
+
+func (c *RESTClient) DeleteTag(ctx context.Context, projectName, repositoryName, reference, tagName string) error {
+	params := &artifact.DeleteTagParams{
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		TagName:        tagName,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Artifact.DeleteTag(params, c.AuthInfo)
+	return handleSwaggerArtifactErrors(err)
+}
+
+func (c *RESTClient) GetArtifact(ctx context.Context, projectName, repositoryName, reference string) (*model.Artifact, error) {
+	params := artifact.NewGetArtifactParams()
+	params.WithTimeout(c.Options.Timeout)
+	params.WithPage(&c.Options.Page)
+	params.WithPageSize(&c.Options.PageSize)
+	params.WithProjectName(projectName)
+	params.WithRepositoryName(repositoryName)
+	params.WithReference(reference)
+	params.WithContext(ctx)
+
+	resp, err := c.V2Client.Artifact.GetArtifact(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerArtifactErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+func (c *RESTClient) ListArtifacts(ctx context.Context, projectName, repositoryName string) ([]*model.Artifact, error) {
+	params := artifact.NewListArtifactsParams()
+	params.WithContext(ctx)
+	params.WithTimeout(c.Options.Timeout)
+	params.Page = &c.Options.Page
+	params.PageSize = &c.Options.PageSize
+	params.Q = &c.Options.Query
+	params.Sort = &c.Options.Sort
+	params.WithProjectName(projectName)
+	params.WithRepositoryName(repositoryName)
+
+	resp, err := c.V2Client.Artifact.ListArtifacts(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerArtifactErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+func (c *RESTClient) ListTags(ctx context.Context, projectName, repositoryName, reference string) ([]*model.Tag, error) {
+	params := artifact.NewListTagsParams()
+	params.Page = &c.Options.Page
+	params.PageSize = &c.Options.PageSize
+	params.WithProjectName(projectName)
+	params.WithRepositoryName(repositoryName)
+	params.WithReference(reference)
+	params.Q = &c.Options.Query
+	params.Sort = &c.Options.Sort
+	params.WithContext(ctx)
+	params.WithTimeout(c.Options.Timeout)
+
+	resp, err := c.V2Client.Artifact.ListTags(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerArtifactErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+func (c *RESTClient) RemoveLabel(ctx context.Context, projectName, repositoryName, reference string, id int64) error {
+	params := &artifact.RemoveLabelParams{
+		LabelID:        id,
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Reference:      reference,
+		Context:        ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Artifact.RemoveLabel(params, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerArtifactErrors(err)
+	}
+
+	return nil
+}
+
+// TODO: Introduce this, once https://github.com/goharbor/harbor/issues/13468 is resolved.
+//func (c *RESTClient) GetAddition(ctx context.Context, projectName, repositoryName, reference string, addition Addition) (interface{}, error) {
+//	params := &artifact.GetAdditionParams{
+//		ProjectName:    projectName,
+//		RepositoryName: repositoryName,
+//		Reference:      reference,
+//		Addition:       addition.String(),
+//		Context:        ctx,
+//	}
+//
+//	params.WithTimeout(c.Options.Timeout)
+//
+//	resp, err := c.V2Client.Artifact.GetAddition(params, c.AuthInfo)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	return resp.Payload, nil
+//}
+
+//func (c *RESTClient) GetVulnerabilitiesAddition(ctx context.Context, projectName, repositoryName, reference string) (interface{}, error) {
+//	params := artifact.NewGetVulnerabilitiesAdditionParams()
+//	params.ProjectName = projectName
+//	params.RepositoryName = repositoryName
+//	params.Reference = reference
+//	params.Context = ctx
+//	params.WithTimeout(c.Options.Timeout)
+//	xAcceptVulnerabilities := "application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+//	params.WithXAcceptVulnerabilities(&xAcceptVulnerabilities)
+//
+//	resp, err := c.V2Client.Artifact.GetVulnerabilitiesAddition(params, c.AuthInfo)
+//	if err != nil {
+//		return nil, handleSwaggerArtifactErrors(err)
+//	}
+//
+//	return resp.Payload, nil
+//}

--- a/apiv2/pkg/clients/artifact/artifact_errors.go
+++ b/apiv2/pkg/clients/artifact/artifact_errors.go
@@ -1,0 +1,35 @@
+package artifact
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/errors"
+)
+
+// handleSwaggerArtifactErrors takes a swagger generated error as input,
+// which usually does not contain any form of error message,
+// and outputs a new error with a proper message.
+func handleSwaggerArtifactErrors(in error) error {
+	t, ok := in.(*runtime.APIError)
+	if ok {
+		switch t.Code {
+		// As per documentation '200' should be the status code for success,
+		// yet the API returns status code '201' when creating a GC schedule succeeds.
+		case http.StatusCreated:
+			return nil
+		case http.StatusBadRequest:
+			return &errors.ErrBadRequest{}
+		case http.StatusUnauthorized:
+			return &errors.ErrUnauthorized{}
+		case http.StatusForbidden:
+			return &errors.ErrForbidden{}
+		case http.StatusConflict:
+			return &errors.ErrConflict{}
+		case http.StatusInternalServerError:
+			return &errors.ErrInternalErrors{}
+		}
+	}
+
+	return in
+}

--- a/apiv2/pkg/clients/artifact/artifact_integration_test.go
+++ b/apiv2/pkg/clients/artifact/artifact_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package artifact
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/label"
+	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	projectName    = "library"
+	repositoryName = "image"
+	reference      = "test"
+)
+
+func TestAPICreateTag(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	tag := &model.Tag{
+		Name: "v1.0.0",
+	}
+
+	err := c.CreateTag(ctx, projectName, repositoryName, reference, tag)
+
+	defer c.DeleteTag(ctx, projectName, repositoryName, reference, tag.Name)
+
+	require.NoError(t, err)
+}
+
+func TestAPIDeleteTag(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	tag := &model.Tag{
+		Name: "v1.0.0",
+	}
+
+	err := c.CreateTag(ctx, projectName, repositoryName, reference, tag)
+	require.NoError(t, err)
+
+	err = c.DeleteTag(ctx, projectName, repositoryName, reference, tag.Name)
+	require.NoError(t, err)
+}
+
+func TestAPIGetArtifact(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	artifact, err := c.GetArtifact(ctx, projectName, repositoryName, reference)
+	require.NoError(t, err)
+	require.NotNil(t, artifact)
+}
+
+func TestAPIListArtifacts(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	artifacts, err := c.ListArtifacts(ctx, projectName, repositoryName)
+	require.NoError(t, err)
+	require.NotNil(t, artifacts)
+	require.Equal(t, 1, len(artifacts))
+	require.Equal(t, "IMAGE", artifacts[0].Type)
+}
+
+func TestAPIListTags(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	resp, err := c.ListTags(ctx, projectName, repositoryName, reference)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resp))
+	require.Equal(t, "test", resp[0].Name)
+}
+
+func TestAPIAddLabel(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	lc := label.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	err := lc.CreateLabel(ctx, &model.Label{
+		// Hexadecimal color code
+		Color:     "#0072bc",
+		Name:      "test",
+		Scope:     label.ScopeProject.String(),
+		ProjectID: 1,
+	})
+	require.NoError(t, err)
+
+	labels, err := lc.ListLabels(ctx, "test", util.Int64Ptr(1), label.ScopeProject)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(labels))
+
+	err = c.AddArtifactLabel(ctx, projectName, repositoryName, reference, labels[0])
+	require.NoError(t, err)
+
+	defer lc.DeleteLabel(ctx, labels[0].ID)
+}
+
+// TODO: Introduce this, once https://github.com/goharbor/harbor/issues/13468 is resolved.
+//func TestAPIGetAddition(t *testing.T) {
+//	ctx := context.Background()
+//	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+//
+//	artifact, err := c.GetAddition(ctx, projectName, repositoryName, reference, AdditionBuildHistory)
+//	fmt.Println(err.Error())
+//	require.NoError(t, err)
+//
+//	fmt.Println(artifact)
+//}
+
+//func TestAPIGetVulnerabilitiesAddition(t *testing.T) {
+//	ctx := context.Background()
+//	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+//
+//	_, err := c.GetVulnerabilitiesAddition(ctx, projectName, repositoryName, reference)
+//	fmt.Println(err)
+//	require.Error(t, err)
+//}

--- a/apiv2/pkg/clients/artifact/artifact_integration_test.go
+++ b/apiv2/pkg/clients/artifact/artifact_integration_test.go
@@ -94,7 +94,7 @@ func TestAPIAddLabel(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	labels, err := lc.ListLabels(ctx, "test", util.Int64Ptr(1), label.ScopeProject)
+	labels, err := lc.ListLabels(ctx, "test", util.Int64Ptr(1))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(labels))
 

--- a/apiv2/pkg/clients/artifact/artifact_test.go
+++ b/apiv2/pkg/clients/artifact/artifact_test.go
@@ -1,0 +1,306 @@
+//go:build !integration
+
+package artifact
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/artifact"
+	"github.com/mittwald/goharbor-client/v5/apiv2/mocks"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	ctx            = context.Background()
+	projectName    = "test-project"
+	repositoryName = "test-repository"
+	reference      = "test-artifact"
+	label          = model.Label{
+		Color:       "#000000",
+		Description: "test",
+		Name:        "test-label",
+	}
+)
+
+func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
+	desiredMockClients := &clienttesting.MockClients{
+		Artifact: mocks.MockArtifactClientService{},
+	}
+
+	v2Client := clienttesting.BuildV2ClientWithMocks(desiredMockClients)
+
+	cl := NewClient(v2Client, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	return cl, desiredMockClients
+}
+
+func TestRESTClient_AddArtifactLabel(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	addParams := &artifact.AddLabelParams{
+		Label:          &label,
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	addParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("AddLabel", addParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.AddLabelOK{}, nil)
+
+	err := apiClient.AddArtifactLabel(ctx, projectName, repositoryName, reference, &label)
+
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_CopyArtifact(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	from := CopyReference{
+		ProjectName:    "some-other-project",
+		RepositoryName: "some-repo",
+		Tag:            "v1.0.0",
+		Digest:         "sha256:1234567890",
+	}
+
+	copyParams := &artifact.CopyArtifactParams{
+		From:           "some-other-project/some-repo:v1.0.0",
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	copyParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("CopyArtifact", copyParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.CopyArtifactCreated{}, nil)
+
+	err := apiClient.CopyArtifact(ctx, &from, projectName, repositoryName)
+
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_CopyArtifact_WithDigest(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	from := CopyReference{
+		ProjectName:    "some-other-project",
+		RepositoryName: "some-repo",
+	}
+
+	from.Digest = "sha256:1234567890"
+
+	copyParams := &artifact.CopyArtifactParams{
+		From:           "some-other-project/some-repo@sha256:1234567890",
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	copyParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("CopyArtifact", copyParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.CopyArtifactCreated{}, nil)
+
+	err := apiClient.CopyArtifact(ctx, &from, projectName, repositoryName)
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_CopyArtifact_WithoutTagOrDigest(t *testing.T) {
+	apiClient, _ := APIandMockClientsForTests()
+
+	from := CopyReference{
+		ProjectName:    "some-other-project",
+		RepositoryName: "some-repo",
+	}
+
+	from.Tag = ""
+	from.Digest = ""
+	err := apiClient.CopyArtifact(ctx, &from, projectName, repositoryName)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no tag or digest specified")
+}
+
+func TestRESTClient_CopyArtifact_WithTag(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	from := CopyReference{
+		ProjectName:    "some-other-project",
+		RepositoryName: "some-repo",
+	}
+
+	from.Tag = "v1.0.0"
+
+	copyParams := &artifact.CopyArtifactParams{
+		From:           "some-other-project/some-repo:v1.0.0",
+		ProjectName:    projectName,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	copyParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("CopyArtifact", copyParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.CopyArtifactCreated{}, nil)
+
+	err := apiClient.CopyArtifact(ctx, &from, projectName, repositoryName)
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_CreateTag(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	tag := &model.Tag{
+		Name: "v1.0.0",
+	}
+
+	createParams := &artifact.CreateTagParams{
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		Tag:            tag,
+		Context:        ctx,
+	}
+
+	createParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("CreateTag", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.CreateTagCreated{}, nil)
+
+	err := apiClient.CreateTag(ctx, projectName, repositoryName, reference, tag)
+
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteTag(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	deleteParams := &artifact.DeleteTagParams{
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		TagName:        "v1.0.0",
+		Context:        ctx,
+	}
+
+	deleteParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("DeleteTag", deleteParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.DeleteTagOK{}, nil)
+
+	err := apiClient.DeleteTag(ctx, projectName, repositoryName, reference, "v1.0.0")
+
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_GetArtifact(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	getParams := artifact.NewGetArtifactParams()
+
+	getParams.WithTimeout(apiClient.Options.Timeout)
+	getParams.WithPage(&apiClient.Options.Page)
+	getParams.WithPageSize(&apiClient.Options.PageSize)
+	getParams.WithProjectName(projectName)
+	getParams.WithRepositoryName(repositoryName)
+	getParams.WithReference(reference)
+	getParams.WithContext(ctx)
+
+	getParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("GetArtifact", getParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.GetArtifactOK{Payload: &model.Artifact{}}, nil)
+
+	resp, err := apiClient.GetArtifact(ctx, projectName, repositoryName, reference)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_ListArtifacts(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	listParams := artifact.NewListArtifactsParams()
+	listParams.WithProjectName(projectName)
+	listParams.WithRepositoryName(repositoryName)
+	listParams.WithContext(ctx)
+	listParams.WithPage(&apiClient.Options.Page)
+	listParams.WithPageSize(&apiClient.Options.PageSize)
+	listParams.WithSort(&apiClient.Options.Sort)
+	listParams.WithQ(&apiClient.Options.Query)
+	listParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("ListArtifacts", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.ListArtifactsOK{Payload: []*model.Artifact{}}, nil)
+
+	resp, err := apiClient.ListArtifacts(ctx, projectName, repositoryName)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_ListTags(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	listParams := artifact.NewListTagsParams()
+	listParams.WithProjectName(projectName)
+	listParams.WithRepositoryName(repositoryName)
+	listParams.WithReference(reference)
+	listParams.WithTimeout(apiClient.Options.Timeout)
+	listParams.WithContext(ctx)
+	listParams.WithPage(&apiClient.Options.Page)
+	listParams.WithPageSize(&apiClient.Options.PageSize)
+	listParams.WithSort(&apiClient.Options.Sort)
+	listParams.WithQ(&apiClient.Options.Query)
+
+	mockClient.Artifact.On("ListTags", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.ListTagsOK{Payload: []*model.Tag{}}, nil)
+
+	resp, err := apiClient.ListTags(ctx, projectName, repositoryName, reference)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	mockClient.Artifact.AssertExpectations(t)
+}
+
+func TestRESTClient_RemoveLabel(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	removeParams := &artifact.RemoveLabelParams{
+		LabelID:        1,
+		ProjectName:    projectName,
+		Reference:      reference,
+		RepositoryName: repositoryName,
+		Context:        ctx,
+	}
+
+	removeParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Artifact.On("RemoveLabel", removeParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&artifact.RemoveLabelOK{}, nil)
+
+	err := apiClient.RemoveLabel(ctx, projectName, repositoryName, reference, 1)
+	require.NoError(t, err)
+
+	mockClient.Artifact.AssertExpectations(t)
+}

--- a/apiv2/pkg/clients/auditlog/auditlog_test.go
+++ b/apiv2/pkg/clients/auditlog/auditlog_test.go
@@ -6,7 +6,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/auditlog"
@@ -43,7 +44,7 @@ func TestRESTClient_ListAuditLogs(t *testing.T) {
 
 	_, err := apiClient.ListAuditLogs(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.Auditlog.AssertExpectations(t)
 }

--- a/apiv2/pkg/clients/gc/gc_test.go
+++ b/apiv2/pkg/clients/gc/gc_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
@@ -15,7 +17,6 @@ import (
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/errors"
 	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mittwald/goharbor-client/v5/apiv2/mocks"
@@ -40,7 +41,7 @@ var (
 
 func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
 	desiredMockClients := &clienttesting.MockClients{
-		Project: mocks.MockProjectClientService{},
+		GC: mocks.MockGcClientService{},
 	}
 
 	v2Client := clienttesting.BuildV2ClientWithMocks(desiredMockClients)
@@ -58,7 +59,7 @@ func TestRESTClient_NewGarbageCollection(t *testing.T) {
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -71,9 +72,8 @@ func TestRESTClient_NewGarbageCollection_ErrSystemInvalidSchedule(t *testing.T) 
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemInvalidSchedule{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemInvalidSchedule{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -86,9 +86,8 @@ func TestRESTClient_NewGarbageCollection_StatusUnauthorized(t *testing.T) {
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemUnauthorized{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemUnauthorized{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -101,9 +100,8 @@ func TestRESTClient_NewGarbageCollection_ErrSystemGcInProgress(t *testing.T) {
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemGcInProgress{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemGcInProgress{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -116,9 +114,8 @@ func TestRESTClient_NewGarbageCollection_ErrSystemInternalErrors(t *testing.T) {
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemInternalErrors{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemInternalErrors{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -131,9 +128,8 @@ func TestRESTClient_NewGarbageCollection_ErrSystemGcInProgress_2(t *testing.T) {
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemGcInProgress{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemGcInProgress{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -146,9 +142,8 @@ func TestRESTClient_NewGarbageCollection_ErrSystemInvalidSchedule_2(t *testing.T
 
 	err := apiClient.NewGarbageCollection(ctx, schedule)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemInvalidSchedule{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemInvalidSchedule{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -168,10 +163,10 @@ func TestRESTClient_GetGarbageCollection(t *testing.T) {
 
 	gc, err := apiClient.GetGarbageCollectionSchedule(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.IsType(t, &modelv2.GCHistory{}, gc)
-	assert.Equal(t, gc.Schedule, schedule.Schedule)
+	require.IsType(t, &modelv2.GCHistory{}, gc)
+	require.Equal(t, gc.Schedule, schedule.Schedule)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -188,9 +183,8 @@ func TestRESTClient_GetGarbageCollectionSchedule_ScheduleNil(t *testing.T) {
 
 	_, err := apiClient.GetGarbageCollectionSchedule(ctx)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemGcScheduleUndefined{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemGcScheduleUndefined{}, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -222,7 +216,7 @@ func TestRESTClient_UpdateGarbageCollection(t *testing.T) {
 
 	err := apiClient.UpdateGarbageCollection(ctx, newGcReq)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.GC.AssertExpectations(t)
 }
@@ -232,9 +226,8 @@ func TestRESTClient_UpdateGarbageCollection_ScheduleNil(t *testing.T) {
 
 	err := apiClient.UpdateGarbageCollection(ctx, nil)
 
-	if assert.Error(t, err) {
-		assert.IsType(t, &errors.ErrSystemGcScheduleNotProvided{}, err)
-	}
+	require.Error(t, err)
+	require.IsType(t, &errors.ErrSystemGcScheduleNotProvided{}, err)
 }
 
 func TestRESTClient_ResetGarbageCollection(t *testing.T) {
@@ -257,7 +250,7 @@ func TestRESTClient_ResetGarbageCollection(t *testing.T) {
 
 	err := apiClient.ResetGarbageCollection(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.GC.AssertExpectations(t)
 }

--- a/apiv2/pkg/clients/label/label.go
+++ b/apiv2/pkg/clients/label/label.go
@@ -1,0 +1,157 @@
+package label
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-openapi/runtime"
+	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
+	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/label"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/util"
+)
+
+// RESTClient is a subclient for handling label related actions.
+type RESTClient struct {
+	// Options contains optional configuration when making API calls.
+	Options *config.Options
+
+	// The new client of the harbor v2 API
+	V2Client *v2client.Harbor
+
+	// AuthInfo contains the auth information that is provided on API calls.
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func NewClient(v2Client *v2client.Harbor, opts *config.Options, authInfo runtime.ClientAuthInfoWriter) *RESTClient {
+	return &RESTClient{
+		Options:  opts,
+		V2Client: v2Client,
+		AuthInfo: authInfo,
+	}
+}
+
+type Client interface {
+	CreateLabel(ctx context.Context, l *model.Label) error
+	GetLabelByID(ctx context.Context, id int64) (*model.Label, error)
+	ListLabels(ctx context.Context, name string, projectID *int64, scope Scope) ([]*model.Label, error)
+	DeleteLabel(ctx context.Context, id int64) error
+	UpdateLabel(ctx context.Context, id int64, l *model.Label) error
+}
+
+type Scope string
+
+const (
+	ScopeGlobal  Scope = "g"
+	ScopeProject Scope = "p"
+)
+
+func (in Scope) String() string {
+	return string(in)
+}
+
+func (c *RESTClient) CreateLabel(ctx context.Context, l *model.Label) error {
+	params := &label.CreateLabelParams{
+		Label:   l,
+		Context: ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Label.CreateLabel(params, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerLabelErrors(err)
+	}
+
+	return nil
+}
+
+func (c *RESTClient) GetLabelByID(ctx context.Context, id int64) (*model.Label, error) {
+	params := &label.GetLabelByIDParams{
+		LabelID: id,
+		Context: ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	resp, err := c.V2Client.Label.GetLabelByID(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerLabelErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+func (c *RESTClient) ListLabels(ctx context.Context, name string, projectID *int64, scope Scope) ([]*model.Label, error) {
+	switch scope {
+	default:
+		return nil, fmt.Errorf("invalid scope: %s", scope)
+	case ScopeGlobal:
+		if projectID != nil {
+			return nil, fmt.Errorf("projectID must be nil for global scope")
+		}
+	case ScopeProject:
+		if projectID == nil {
+			return nil, fmt.Errorf("projectID must be set for project scope")
+		}
+	}
+
+	params := &label.ListLabelsParams{
+		Name:      &name,
+		Page:      &c.Options.Page,
+		PageSize:  &c.Options.PageSize,
+		ProjectID: projectID,
+		Q:         &c.Options.Query,
+		Scope:     util.StringPtr(scope.String()),
+		Sort:      &c.Options.Sort,
+		Context:   ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	resp, err := c.V2Client.Label.ListLabels(params, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerLabelErrors(err)
+	}
+
+	return resp.Payload, nil
+}
+
+func (c *RESTClient) DeleteLabel(ctx context.Context, id int64) error {
+	params := &label.DeleteLabelParams{
+		LabelID: id,
+		Context: ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Label.DeleteLabel(params, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerLabelErrors(err)
+	}
+
+	return nil
+}
+
+func (c *RESTClient) UpdateLabel(ctx context.Context, id int64, l *model.Label) error {
+	// Name is the only required field for a label update
+	if l.Name == "" {
+		return fmt.Errorf("label name must be set")
+	}
+
+	params := &label.UpdateLabelParams{
+		Label:   l,
+		LabelID: id,
+		Context: ctx,
+	}
+
+	params.WithTimeout(c.Options.Timeout)
+
+	_, err := c.V2Client.Label.UpdateLabel(params, c.AuthInfo)
+	if err != nil {
+		return handleSwaggerLabelErrors(err)
+	}
+
+	return nil
+}

--- a/apiv2/pkg/clients/label/label.go
+++ b/apiv2/pkg/clients/label/label.go
@@ -83,18 +83,12 @@ func (c *RESTClient) GetLabelByID(ctx context.Context, id int64) (*model.Label, 
 	return resp.Payload, nil
 }
 
-func (c *RESTClient) ListLabels(ctx context.Context, name string, projectID *int64, scope Scope) ([]*model.Label, error) {
-	switch scope {
-	default:
-		return nil, fmt.Errorf("invalid scope: %s", scope)
-	case ScopeGlobal:
-		if projectID != nil {
-			return nil, fmt.Errorf("projectID must be nil for global scope")
-		}
-	case ScopeProject:
-		if projectID == nil {
-			return nil, fmt.Errorf("projectID must be set for project scope")
-		}
+func (c *RESTClient) ListLabels(ctx context.Context, name string, projectID *int64) ([]*model.Label, error) {
+	var scope Scope
+	if projectID == nil {
+		scope = ScopeGlobal
+	} else {
+		scope = ScopeProject
 	}
 
 	params := &label.ListLabelsParams{

--- a/apiv2/pkg/clients/label/label_errors.go
+++ b/apiv2/pkg/clients/label/label_errors.go
@@ -1,0 +1,37 @@
+package label
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/errors"
+)
+
+// handleSwaggerLabelErrors takes a swagger generated error as input,
+// which usually does not contain any form of error message,
+// and outputs a new error with a proper message.
+func handleSwaggerLabelErrors(in error) error {
+	t, ok := in.(*runtime.APIError)
+	if ok {
+		switch t.Code {
+		// As per documentation '200' should be the status code for success,
+		// yet the API returns status code '201' when creating a GC schedule succeeds.
+		case http.StatusCreated:
+			return nil
+		case http.StatusBadRequest:
+			return &errors.ErrBadRequest{}
+		case http.StatusUnauthorized:
+			return &errors.ErrUnauthorized{}
+		case http.StatusForbidden:
+			return &errors.ErrForbidden{}
+		case http.StatusConflict:
+			return &errors.ErrConflict{}
+		case http.StatusUnsupportedMediaType:
+			return &errors.ErrUnsupportedMediaType{}
+		case http.StatusInternalServerError:
+			return &errors.ErrInternalErrors{}
+		}
+	}
+
+	return in
+}

--- a/apiv2/pkg/clients/label/label_integration_test.go
+++ b/apiv2/pkg/clients/label/label_integration_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+
+package label
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPICreateLabel(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	err := c.CreateLabel(ctx, &model.Label{
+		Color:       "#0072bc",
+		Description: "test",
+		Name:        "label",
+		Scope:       ScopeGlobal.String(),
+	})
+
+	require.NoError(t, err)
+
+	labels, err := c.ListLabels(ctx, "label", nil, ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(labels))
+
+	defer c.DeleteLabel(ctx, labels[0].ID)
+
+	require.NoError(t, err)
+}
+
+func TestAPIUpdateLabel(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	err := c.CreateLabel(ctx, &model.Label{
+		Color:       "#0072bc",
+		Description: "foo",
+		Name:        "label",
+		Scope:       ScopeGlobal.String(),
+	})
+
+	require.NoError(t, err)
+
+	labels, err := c.ListLabels(ctx, "label", nil, ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(labels))
+
+	update := &model.Label{
+		Color:       "#72bf44",
+		Description: "bar",
+		ID:          labels[0].ID,
+		Name:        labels[0].Name,
+	}
+
+	err = c.UpdateLabel(ctx, labels[0].ID, update)
+	require.NoError(t, err)
+
+	defer c.DeleteLabel(ctx, labels[0].ID)
+
+	require.NoError(t, err)
+}

--- a/apiv2/pkg/clients/label/label_integration_test.go
+++ b/apiv2/pkg/clients/label/label_integration_test.go
@@ -24,11 +24,13 @@ func TestAPICreateLabel(t *testing.T) {
 
 	require.NoError(t, err)
 
-	labels, err := c.ListLabels(ctx, "label", nil, ScopeGlobal)
+	labels, err := c.ListLabels(ctx, "label", nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(labels))
 
-	defer c.DeleteLabel(ctx, labels[0].ID)
+	defer func() {
+		_ = c.DeleteLabel(ctx, labels[0].ID)
+	}()
 
 	require.NoError(t, err)
 }
@@ -46,7 +48,7 @@ func TestAPIUpdateLabel(t *testing.T) {
 
 	require.NoError(t, err)
 
-	labels, err := c.ListLabels(ctx, "label", nil, ScopeGlobal)
+	labels, err := c.ListLabels(ctx, "label", nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(labels))
 
@@ -60,7 +62,9 @@ func TestAPIUpdateLabel(t *testing.T) {
 	err = c.UpdateLabel(ctx, labels[0].ID, update)
 	require.NoError(t, err)
 
-	defer c.DeleteLabel(ctx, labels[0].ID)
+	defer func() {
+		_ = c.DeleteLabel(ctx, labels[0].ID)
+	}()
 
 	require.NoError(t, err)
 }

--- a/apiv2/pkg/clients/label/label_test.go
+++ b/apiv2/pkg/clients/label/label_test.go
@@ -119,11 +119,11 @@ func TestRESTClient_ListLabels_ScopeGlobal(t *testing.T) {
 		}, nil)
 
 	t.Run("ErrProjectIDProvided", func(t *testing.T) {
-		_, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1), ScopeGlobal)
+		_, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1))
 		require.Error(t, err)
 	})
 
-	labels, err := apiClient.ListLabels(ctx, "test", nil, ScopeGlobal)
+	labels, err := apiClient.ListLabels(ctx, "test", nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(labels))
 
@@ -152,11 +152,11 @@ func TestRESTClient_ListLabels_ScopeProject(t *testing.T) {
 		}, nil)
 
 	t.Run("ErrNoProjectIDProvided", func(t *testing.T) {
-		_, err := apiClient.ListLabels(ctx, "test", nil, ScopeProject)
+		_, err := apiClient.ListLabels(ctx, "test", nil)
 		require.Error(t, err)
 	})
 
-	labels, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1), ScopeProject)
+	labels, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(labels))
 

--- a/apiv2/pkg/clients/label/label_test.go
+++ b/apiv2/pkg/clients/label/label_test.go
@@ -118,11 +118,6 @@ func TestRESTClient_ListLabels_ScopeGlobal(t *testing.T) {
 			Payload: []*model.Label{&testLabel},
 		}, nil)
 
-	t.Run("ErrProjectIDProvided", func(t *testing.T) {
-		_, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1))
-		require.Error(t, err)
-	})
-
 	labels, err := apiClient.ListLabels(ctx, "test", nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(labels))
@@ -150,11 +145,6 @@ func TestRESTClient_ListLabels_ScopeProject(t *testing.T) {
 		Return(&label.ListLabelsOK{
 			Payload: []*model.Label{&testLabel},
 		}, nil)
-
-	t.Run("ErrNoProjectIDProvided", func(t *testing.T) {
-		_, err := apiClient.ListLabels(ctx, "test", nil)
-		require.Error(t, err)
-	})
 
 	labels, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1))
 	require.NoError(t, err)

--- a/apiv2/pkg/clients/label/label_test.go
+++ b/apiv2/pkg/clients/label/label_test.go
@@ -1,0 +1,191 @@
+//go:build !integration
+
+package label
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/label"
+	"github.com/mittwald/goharbor-client/v5/apiv2/mocks"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
+	clienttesting "github.com/mittwald/goharbor-client/v5/apiv2/pkg/testing"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/util"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	ctx       = context.Background()
+	testLabel = model.Label{
+		Color:       "#000000",
+		Description: "test",
+		Name:        "test-label",
+	}
+)
+
+func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
+	desiredMockClients := &clienttesting.MockClients{
+		Label: mocks.MockLabelClientService{},
+	}
+
+	v2Client := clienttesting.BuildV2ClientWithMocks(desiredMockClients)
+
+	cl := NewClient(v2Client, clienttesting.DefaultOpts, clienttesting.AuthInfo)
+
+	return cl, desiredMockClients
+}
+
+func TestRESTClient_CreateLabel(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	createParams := &label.CreateLabelParams{
+		Label:   &testLabel,
+		Context: ctx,
+	}
+
+	createParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Label.On("CreateLabel", createParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&label.CreateLabelCreated{}, nil)
+
+	err := apiClient.CreateLabel(ctx, &testLabel)
+	require.NoError(t, err)
+
+	mockClient.Label.AssertExpectations(t)
+}
+
+func TestRESTClient_DeleteLabel(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	deleteParams := &label.DeleteLabelParams{
+		LabelID: 1,
+		Context: ctx,
+	}
+
+	deleteParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Label.On("DeleteLabel", deleteParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&label.DeleteLabelOK{}, nil)
+
+	err := apiClient.DeleteLabel(ctx, 1)
+	require.NoError(t, err)
+
+	mockClient.Label.AssertExpectations(t)
+}
+
+func TestRESTClient_GetLabelByID(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	getParams := &label.GetLabelByIDParams{
+		LabelID: 1,
+		Context: ctx,
+	}
+
+	getParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Label.On("GetLabelByID", getParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&label.GetLabelByIDOK{
+			Payload: &testLabel,
+		}, nil)
+
+	l, err := apiClient.GetLabelByID(ctx, 1)
+
+	require.NoError(t, err)
+	require.Equal(t, testLabel, *l)
+
+	mockClient.Label.AssertExpectations(t)
+}
+
+func TestRESTClient_ListLabels_ScopeGlobal(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	listParams := &label.ListLabelsParams{
+		Name:      util.StringPtr("test"),
+		Page:      &apiClient.Options.Page,
+		PageSize:  &apiClient.Options.PageSize,
+		ProjectID: nil,
+		Q:         &apiClient.Options.Query,
+		Scope:     util.StringPtr(ScopeGlobal.String()),
+		Sort:      &apiClient.Options.Sort,
+		Context:   ctx,
+	}
+
+	listParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Label.On("ListLabels", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&label.ListLabelsOK{
+			Payload: []*model.Label{&testLabel},
+		}, nil)
+
+	t.Run("ErrProjectIDProvided", func(t *testing.T) {
+		_, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1), ScopeGlobal)
+		require.Error(t, err)
+	})
+
+	labels, err := apiClient.ListLabels(ctx, "test", nil, ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(labels))
+
+	mockClient.Label.AssertExpectations(t)
+}
+
+func TestRESTClient_ListLabels_ScopeProject(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	listParams := &label.ListLabelsParams{
+		Name:      util.StringPtr("test"),
+		Page:      &apiClient.Options.Page,
+		PageSize:  &apiClient.Options.PageSize,
+		ProjectID: util.Int64Ptr(1),
+		Q:         &apiClient.Options.Query,
+		Scope:     util.StringPtr(ScopeProject.String()),
+		Sort:      &apiClient.Options.Sort,
+		Context:   ctx,
+	}
+
+	listParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Label.On("ListLabels", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&label.ListLabelsOK{
+			Payload: []*model.Label{&testLabel},
+		}, nil)
+
+	t.Run("ErrNoProjectIDProvided", func(t *testing.T) {
+		_, err := apiClient.ListLabels(ctx, "test", nil, ScopeProject)
+		require.Error(t, err)
+	})
+
+	labels, err := apiClient.ListLabels(ctx, "test", util.Int64Ptr(1), ScopeProject)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(labels))
+
+	mockClient.Label.AssertExpectations(t)
+}
+
+func TestRESTClient_UpdateLabel(t *testing.T) {
+	apiClient, mockClient := APIandMockClientsForTests()
+
+	updateParams := &label.UpdateLabelParams{
+		Label:   &testLabel,
+		LabelID: 1,
+		Context: ctx,
+	}
+
+	updateParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Label.On("UpdateLabel", updateParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+		Return(&label.UpdateLabelOK{}, nil)
+
+	t.Run("ErrNoLabelNameProvided", func(t *testing.T) {
+		invalidLabel := testLabel
+		invalidLabel.Name = ""
+		err := apiClient.UpdateLabel(ctx, 1, &invalidLabel)
+		require.Error(t, err)
+	})
+
+	err := apiClient.UpdateLabel(ctx, 1, &testLabel)
+	require.NoError(t, err)
+
+	mockClient.Label.AssertExpectations(t)
+}

--- a/apiv2/pkg/clients/project/project_test.go
+++ b/apiv2/pkg/clients/project/project_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/util"
+
 	"github.com/go-openapi/runtime"
 	"github.com/stretchr/testify/require"
 
@@ -33,15 +35,10 @@ var (
 	pReq3 = &modelv2.ProjectReq{
 		ProjectName:  "example-project",
 		StorageLimit: &exampleStorageLimitNegative,
-		RegistryID:   int64Ptr(0),
+		RegistryID:   util.Int64Ptr(0),
 	}
 	ctx = context.Background()
 )
-
-// int64Ptr returns a pointer to the given int64 value.
-func int64Ptr(i int64) *int64 {
-	return &i
-}
 
 func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
 	desiredMockClients := &clienttesting.MockClients{
@@ -108,7 +105,7 @@ func TestRESTClient_NewProject_UnlimitedStorage(t *testing.T) {
 	err := apiClient.NewProject(ctx, &modelv2.ProjectReq{
 		ProjectName:  exampleProject.Name,
 		StorageLimit: &exampleStorageLimitNegative,
-		RegistryID:   int64Ptr(0),
+		RegistryID:   util.Int64Ptr(0),
 	})
 
 	require.NoError(t, err)

--- a/apiv2/pkg/clients/quota/quota_test.go
+++ b/apiv2/pkg/clients/quota/quota_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/goharbor/harbor/src/pkg/quota/types"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/quota"
 	"github.com/mittwald/goharbor-client/v5/apiv2/mocks"
 	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
@@ -96,11 +94,10 @@ func TestRESTClient_GetQuotaByProjectID(t *testing.T) {
 
 	q, err := apiClient.GetQuotaByProjectID(ctx, exampleProjectID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	if assert.NotNil(t, q) {
-		require.Equal(t, int64(10), q.Hard["storage"])
-	}
+	require.NotNil(t, q)
+	require.Equal(t, int64(10), q.Hard["storage"])
 
 	mockClient.Quota.AssertExpectations(t)
 }
@@ -127,7 +124,7 @@ func TestRESTClient_UpdateStorageQuotaByProjectID(t *testing.T) {
 
 		err := apiClient.UpdateStorageQuotaByProjectID(ctx, exampleProjectID, testStorageLimitPositive)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mockClient.Quota.AssertExpectations(t)
 	})
@@ -151,7 +148,7 @@ func TestRESTClient_UpdateStorageQuotaByProjectID(t *testing.T) {
 
 		err := apiClient.UpdateStorageQuotaByProjectID(ctx, exampleProjectID, testStorageLimitNegative)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mockClient.Quota.AssertExpectations(t)
 	})
@@ -175,7 +172,7 @@ func TestRESTClient_UpdateStorageQuotaByProjectID(t *testing.T) {
 
 		err := apiClient.UpdateStorageQuotaByProjectID(ctx, exampleProjectID, testStorageLimitNull)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mockClient.Quota.AssertExpectations(t)
 	})

--- a/apiv2/pkg/clients/replication/replication.go
+++ b/apiv2/pkg/clients/replication/replication.go
@@ -51,8 +51,8 @@ type Client interface {
 func (c *RESTClient) NewReplicationPolicy(ctx context.Context, destRegistry, srcRegistry *modelv2.Registry,
 	replicateDeletion, override, enablePolicy bool,
 	filters []*modelv2.ReplicationFilter, trigger *modelv2.ReplicationTrigger,
-	destNamespace, description, name string) error {
-
+	destNamespace, description, name string,
+) error {
 	params := &replicationapi.CreateReplicationPolicyParams{
 		Policy: &modelv2.ReplicationPolicy{
 			Description:               description,

--- a/apiv2/pkg/clients/repository/repository_integration_test.go
+++ b/apiv2/pkg/clients/repository/repository_integration_test.go
@@ -20,7 +20,8 @@ func TestAPIRepositoryListAllRepositories(t *testing.T) {
 
 	repositories, err := c.ListAllRepositories(ctx)
 	require.NoError(t, err)
-	require.Empty(t, repositories)
+	// A repository should exist, as the Makefile target `upload-test-image` pushes a test image.
+	require.NotEmpty(t, repositories)
 }
 
 func TestAPIRepositoryListRepositories(t *testing.T) {

--- a/apiv2/pkg/clients/robotv1/robotv1_test.go
+++ b/apiv2/pkg/clients/robotv1/robotv1_test.go
@@ -8,8 +8,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/robotv1"
@@ -62,9 +63,9 @@ func TestRESTClient_ListProjectRobotsV1(t *testing.T) {
 
 	robots, err := apiClient.ListProjectRobotsV1(ctx, strconv.Itoa(exampleProjectID))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, expectedRobot, robots[0])
+	require.Equal(t, expectedRobot, robots[0])
 
 	mockClient.Robotv1.AssertExpectations(t)
 }
@@ -98,7 +99,7 @@ func TestRESTClient_AddProjectRobotV1(t *testing.T) {
 
 	err := apiClient.AddProjectRobotV1(ctx, strconv.Itoa(exampleProjectID), newRobot)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.Robotv1.AssertExpectations(t)
 }
@@ -128,7 +129,7 @@ func TestRESTClient_UpdateProjectRobotV1(t *testing.T) {
 
 	err := apiClient.UpdateProjectRobotV1(ctx, strconv.Itoa(exampleProjectID), exampleRobotID, updateRobot)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.Robotv1.AssertExpectations(t)
 }
@@ -149,7 +150,7 @@ func TestRESTClient_DeleteProjectRobotV1(t *testing.T) {
 
 	err := apiClient.DeleteProjectRobotV1(ctx, strconv.Itoa(exampleProjectID), exampleRobotID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.Robotv1.AssertExpectations(t)
 }

--- a/apiv2/pkg/clients/systeminfo/systeminfo_integration_test.go
+++ b/apiv2/pkg/clients/systeminfo/systeminfo_integration_test.go
@@ -20,5 +20,5 @@ func TestAPIGetSystemInfo(t *testing.T) {
 
 	require.Equal(t, false, *resp.WithChartmuseum)
 	require.Equal(t, false, *resp.WithNotary)
-	require.Equal(t, *resp.RegistryURL, "localhost")
+	require.Equal(t, "core.harbor.domain", *resp.RegistryURL)
 }

--- a/apiv2/pkg/clients/user/user.go
+++ b/apiv2/pkg/clients/user/user.go
@@ -50,12 +50,7 @@ type Client interface {
 	UserExists(ctx context.Context, idOrName intstr.IntOrString) (bool, error)
 }
 
-// NewUser creates and returns a new user, or error in case of failure.
-// Username is a unique username.
-// email is the Email of the user.
-// realname is the fullname of the user.
-// password is the password for this user.
-// comments as a comment attached to the user.
+// NewUser creates a new user with the provided values.
 func (c *RESTClient) NewUser(ctx context.Context, username, email, realname, password, comments string) error {
 	params := &user.CreateUserParams{
 		UserReq: &modelv2.UserCreationReq{

--- a/apiv2/pkg/errors/errors.go
+++ b/apiv2/pkg/errors/errors.go
@@ -9,21 +9,26 @@ type (
 	ErrForbidden struct{}
 	// ErrNotFound describes an error when no corresponding resources could be found.
 	ErrNotFound struct{}
+	// ErrConflict describes an error when a resource already exists.
+	ErrConflict struct{}
 	// ErrMultipleResults describes an error when multiple
 	// resources were found by an API call that should return only one.
 	ErrMultipleResults struct{}
+	// ErrUnsupportedMediaType describes an error when the request contains an unsupported media type.
+	ErrUnsupportedMediaType struct{}
 	// ErrInternalErrors describes a generic error that led to an internal server error.
 	ErrInternalErrors struct{}
 )
 
 const (
-	ErrUnauthorizedMsg = "unauthorized"
-	ErrBadRequestMsg   = "bad request"
-	ErrForbiddenMsg    = "forbidden"
-	ErrNotFoundMsg     = "not found"
-
-	ErrMultipleResultsMsg = "multiple results found"
-	ErrInternalErrorsMsg  = "internal server error"
+	ErrUnauthorizedMsg         = "unauthorized"
+	ErrBadRequestMsg           = "bad request"
+	ErrForbiddenMsg            = "forbidden"
+	ErrConflictMsg             = "conflict"
+	ErrNotFoundMsg             = "not found"
+	ErrMultipleResultsMsg      = "multiple results found"
+	ErrUnsupportedMediaTypeMsg = "unsupported media type"
+	ErrInternalErrorsMsg       = "internal server error"
 )
 
 // Error returns the error message.
@@ -37,6 +42,14 @@ func (e *ErrBadRequest) Error() string {
 
 func (e *ErrForbidden) Error() string {
 	return ErrForbiddenMsg
+}
+
+func (e *ErrConflict) Error() string {
+	return ErrConflictMsg
+}
+
+func (e *ErrUnsupportedMediaType) Error() string {
+	return ErrUnsupportedMediaTypeMsg
 }
 
 func (e *ErrNotFound) Error() string {

--- a/apiv2/pkg/testing/const.go
+++ b/apiv2/pkg/testing/const.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Host     = "http://localhost:30002/api/v2.0"
+	Host     = "http://core.harbor.domain:80/api/v2.0"
 	User     = "admin"
 	Password = "Harbor12345"
 )

--- a/apiv2/pkg/util/pointer.go
+++ b/apiv2/pkg/util/pointer.go
@@ -1,0 +1,9 @@
+package util
+
+func Int64Ptr(in int64) *int64 {
+	return &in
+}
+
+func StringPtr(in string) *string {
+	return &in
+}

--- a/scripts/setup-harbor.sh
+++ b/scripts/setup-harbor.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 CLUSTER_NAME="goharbor-client-integration-tests-${1}"
 HARBOR_VERSION="${1}"
 HARBOR_CHART_VERSION=""
@@ -65,8 +64,9 @@ fi
 echo "Installing Harbor via Helm..."
 helm repo add harbor https://helm.goharbor.io && helm repo update
 helm install harbor harbor/harbor \
-    --set expose.type=nodePort,expose.tls.enabled=false,externalURL=http://localhost \
-    --set trivy.enabled=false,notary.enabled=false,chartmuseum.enabled=false \
+    --set expose.type=nodePort,expose.tls.enabled=false,externalURL=http://core.harbor.domain \
+    --set persistence.enabled=false \
+    --set trivy.enabled=true,notary.enabled=false,chartmuseum.enabled=false \
     --namespace default \
     --kube-context kind-"${CLUSTER_NAME}" \
     --version="${HARBOR_CHART_VERSION}"
@@ -85,23 +85,18 @@ if [[ "$?" -ne "0" ]]; then
 fi
 
 echo "Waiting for Harbor to become ready..."
-API_URL_PREFIX="http://localhost:30002/api"
+
+API_URL_PREFIX="http://core.harbor.domain:80/api"
 if [[ "${HARBOR_VERSION}" =~ ^v2 ]]; then
-    API_URL_PREFIX="http://localhost:30002/api/v2.0"
+    API_URL_PREFIX="http://core.harbor.domain:80/api/v2.0"
 fi
 
-for i in {1..100}; do
-    echo "Pinging Harbor instance ($i/100)..."
-    STATUS="$(curl -s -X GET --connect-timeout 3 "${API_URL_PREFIX}/health" | jq '.status' 2>/dev/null)"
-    if [[ "${STATUS}" == "\"healthy\"" ]]; then
-        echo "Harbor installation finished successfully. Visit at http://localhost:30002"
-        exit 0
-    fi
+until [[ $(curl -s --fail "${API_URL_PREFIX}"/health | jq '.status' 2>/dev/null) == "\"healthy\"" ]]; do
+    printf '.'
     sleep 5
-done
+done; echo ""
 
-HEALTH_STATUS="$(curl -s -X GET --connect-timeout 3 "${API_URL_PREFIX}/health" | jq)"
-
-echo -e "Timeout while waiting for the Harbor installation to finish. Health status:"
-echo "${HEALTH_STATUS}"
-exit 1
+echo -e "Harbor installation finished successfully. Visit at http://localhost:80/
+Alternatively (and when running integration tests locally),
+add the following to your /etc/hosts file:
+  127.0.0.1 core.harbor.domain"

--- a/scripts/swagger-gen.sh
+++ b/scripts/swagger-gen.sh
@@ -62,7 +62,6 @@ swagger_operations+=("GetRetentionsMetadatas")
 swagger_operations+=("PostRetentions")
 swagger_operations+=("GetRetentionsID")
 
-
 for i in "${swagger_operations[@]}"; do
   operation_flags+="--operation=${i} "
 done

--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+WORKDIR /

--- a/testdata/kind-config.yaml
+++ b/testdata/kind-config.yaml
@@ -4,4 +4,5 @@ nodes:
 - role: control-plane
   extraPortMappings:
   - containerPort: 30002
-    hostPort: 30002
+    hostPort: 80
+    listenAddress: "127.0.0.1"


### PR DESCRIPTION
This PR adds two separate clients, one for the `artifact` and one for the `label` endpoint of the harbor API.
Unfortunately, not all features of the `artifact` client can be implemented right now, as https://github.com/goharbor/harbor/issues/13468 is blocking the `GetAddition()` and `GetVulnerabilitiesAddition()` endpoints. 
Affected methods are included in this PR, but only as code comments.

Part of https://github.com/mittwald/goharbor-client/issues/106