### PR TITLE
refactor NewRobotAccount and ListRobotAccounts (robot client V2)

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -335,7 +335,7 @@ func (c *RESTClient) GetRobotAccountByID(ctx context.Context, id int64) (*modelv
 	return c.robot.GetRobotAccountByID(ctx, id)
 }
 
-func (c *RESTClient) NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) error {
+func (c *RESTClient) NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) (*modelv2.RobotCreated, error) {
 	return c.robot.NewRobotAccount(ctx, r)
 }
 

--- a/apiv2/pkg/clients/robot/robot.go
+++ b/apiv2/pkg/clients/robot/robot.go
@@ -59,7 +59,7 @@ type Client interface {
 	ListRobotAccounts(ctx context.Context) ([]*modelv2.Robot, error)
 	GetRobotAccountByName(ctx context.Context, name string) (*modelv2.Robot, error)
 	GetRobotAccountByID(ctx context.Context, id int64) (*modelv2.Robot, error)
-	NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) error
+	NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) (*modelv2.RobotCreated, error)
 	DeleteRobotAccountByName(ctx context.Context, name string) error
 	DeleteRobotAccountByID(ctx context.Context, id int64) error
 	UpdateRobotAccount(ctx context.Context, r *modelv2.Robot) error
@@ -128,16 +128,16 @@ func (c *RESTClient) GetRobotAccountByID(ctx context.Context, id int64) (*modelv
 }
 
 // NewRobotAccount creates a new robot account from the specification of 'r' and returns a 'RobotCreated' response.
-func (c *RESTClient) NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) error {
-	_, err := c.V2Client.Robot.CreateRobot(&robot.CreateRobotParams{
+func (c *RESTClient) NewRobotAccount(ctx context.Context, r *modelv2.RobotCreate) (*modelv2.RobotCreated, error) {
+	resp, err := c.V2Client.Robot.CreateRobot(&robot.CreateRobotParams{
 		Robot:   r,
 		Context: ctx,
 	}, c.AuthInfo)
 	if err != nil {
-		return handleSwaggerRobotErrors(err)
+		return nil, handleSwaggerRobotErrors(err)
 	}
 
-	return nil
+	return resp.Payload, nil
 }
 
 // DeleteRobotAccountByName deletes a robot account identified by its 'name'.

--- a/apiv2/pkg/clients/robot/robot.go
+++ b/apiv2/pkg/clients/robot/robot.go
@@ -87,14 +87,31 @@ func (in AccessAction) String() string {
 
 // ListRobotAccounts ListProjectRobots returns a list of all robot accounts.
 func (c *RESTClient) ListRobotAccounts(ctx context.Context) ([]*modelv2.Robot, error) {
-	resp, err := c.V2Client.Robot.ListRobot(&robot.ListRobotParams{
-		Context: ctx,
-	}, c.AuthInfo)
-	if err != nil {
-		return nil, handleSwaggerRobotErrors(err)
+	var robotAccounts []*modelv2.Robot
+	var page int64 = c.Options.Page
+	var pageSize int64 = c.Options.PageSize
+
+	for {
+		resp, err := c.V2Client.Robot.ListRobot(&robot.ListRobotParams{
+			Context:  ctx,
+			Page:     &page,
+			PageSize: &pageSize,
+		}, c.AuthInfo)
+		if err != nil {
+			return nil, handleSwaggerRobotErrors(err)
+		}
+
+		robotAccounts = append(robotAccounts, resp.Payload...)
+
+		if (page+1)*pageSize >= resp.XTotalCount {
+			break
+		}
+
+		page += 1
+
 	}
 
-	return resp.Payload, nil
+	return robotAccounts, nil
 }
 
 // GetRobotAccountByName GetRobotByName lists all existing robot accounts and returns the one matching the provided name.

--- a/apiv2/pkg/clients/robot/robot.go
+++ b/apiv2/pkg/clients/robot/robot.go
@@ -89,21 +89,25 @@ func (in AccessAction) String() string {
 func (c *RESTClient) ListRobotAccounts(ctx context.Context) ([]*modelv2.Robot, error) {
 	var robotAccounts []*modelv2.Robot
 	var page int64 = c.Options.Page
-	var pageSize int64 = c.Options.PageSize
+
+	params := &robot.ListRobotParams{
+		Page:     &page,
+		PageSize: &c.Options.PageSize,
+		Q:        &c.Options.Query,
+		Sort:     &c.Options.Sort,
+		Context:  ctx,
+	}
+	params.WithTimeout(c.Options.Timeout)
 
 	for {
-		resp, err := c.V2Client.Robot.ListRobot(&robot.ListRobotParams{
-			Context:  ctx,
-			Page:     &page,
-			PageSize: &pageSize,
-		}, c.AuthInfo)
+		resp, err := c.V2Client.Robot.ListRobot(params, c.AuthInfo)
 		if err != nil {
 			return nil, handleSwaggerRobotErrors(err)
 		}
 
 		robotAccounts = append(robotAccounts, resp.Payload...)
 
-		if (page+1)*pageSize >= resp.XTotalCount {
+		if (page+1)*c.Options.PageSize >= resp.XTotalCount {
 			break
 		}
 

--- a/apiv2/pkg/clients/robot/robot_integration_test.go
+++ b/apiv2/pkg/clients/robot/robot_integration_test.go
@@ -35,8 +35,10 @@ func TestAPINewRobotAccount(t *testing.T) {
 
 	defer c.DeleteRobotAccountByName(ctx, "test-robot")
 
-	err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	robotCreated, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
 	require.NoError(t, err)
+	require.NotNil(t, robotCreated)
+
 	r, err := c.GetRobotAccountByName(ctx, testRobotAccountCreate.Name)
 	require.NoError(t, err)
 
@@ -49,7 +51,7 @@ func TestAPIListRobots(t *testing.T) {
 
 	defer c.DeleteRobotAccountByName(ctx, "test-robot")
 
-	err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
 	require.NoError(t, err)
 
 	robots, err := c.ListRobotAccounts(ctx)
@@ -65,7 +67,7 @@ func TestAPIGetRobotByName(t *testing.T) {
 
 	defer c.DeleteRobotAccountByName(ctx, "test-robot")
 
-	err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
 	require.NoError(t, err)
 
 	robot, err := c.GetRobotAccountByName(ctx, "test-robot")
@@ -79,7 +81,7 @@ func TestAPIUpdateRobotAccount(t *testing.T) {
 
 	defer c.DeleteRobotAccountByName(ctx, "test-robot")
 
-	err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
 	require.NoError(t, err)
 
 	r, err := c.GetRobotAccountByName(ctx, "test-robot")
@@ -117,7 +119,7 @@ func TestAPIRefreshRobotAccountSecret(t *testing.T) {
 
 	defer c.DeleteRobotAccountByName(ctx, "test-robot")
 
-	err := c.NewRobotAccount(ctx, testRobotAccountCreate)
+	_, err := c.NewRobotAccount(ctx, testRobotAccountCreate)
 	require.NoError(t, err)
 
 	r, err := c.GetRobotAccountByName(ctx, "test-robot")

--- a/apiv2/pkg/clients/robot/robot_test.go
+++ b/apiv2/pkg/clients/robot/robot_test.go
@@ -131,7 +131,7 @@ func TestRESTClient_NewRobotAccount(t *testing.T) {
 			Secret:    exampleRobotCreate.Secret,
 		}}, nil)
 
-	err := apiClient.NewRobotAccount(ctx, exampleRobotCreate)
+	_, err := apiClient.NewRobotAccount(ctx, exampleRobotCreate)
 	require.NoError(t, err)
 
 	mockClient.Robot.AssertExpectations(t)

--- a/apiv2/pkg/clients/robot/robot_test.go
+++ b/apiv2/pkg/clients/robot/robot_test.go
@@ -62,8 +62,10 @@ var (
 			Namespace: "library",
 		}},
 	}
-	exampleSec = "aVeryL0000ngSecret"
-	ctx        = context.Background()
+	exampleSec       = "aVeryL0000ngSecret"
+	ctx              = context.Background()
+	page       int64 = 0
+	pageSize   int64 = 10
 )
 
 func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
@@ -81,7 +83,7 @@ func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
 func TestRESTClient_ListRobotAccounts(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx},
+	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize},
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
@@ -96,7 +98,7 @@ func TestRESTClient_ListRobotAccounts(t *testing.T) {
 func TestRESTClient_GetRobotAccountByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
 	rAcc, err := apiClient.GetRobotAccountByName(ctx, "test-robot")
@@ -140,7 +142,7 @@ func TestRESTClient_NewRobotAccount(t *testing.T) {
 func TestRESTClient_DeleteRobotAccountByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
 	mockClient.Robot.On("DeleteRobot", &robot.DeleteRobotParams{Context: ctx, RobotID: exampleRobotAccount.ID}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
@@ -193,7 +195,7 @@ func TestRESTClient_RefreshRobotAccountSecretByID(t *testing.T) {
 func TestRESTClient_RefreshRobotAccountSecretByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
 	mockClient.Robot.On("RefreshSec", &robot.RefreshSecParams{Context: ctx, RobotID: exampleRobotAccount.ID, RobotSec: &modelv2.RobotSec{Secret: exampleSec}}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).

--- a/apiv2/pkg/clients/robot/robot_test.go
+++ b/apiv2/pkg/clients/robot/robot_test.go
@@ -62,10 +62,8 @@ var (
 			Namespace: "library",
 		}},
 	}
-	exampleSec       = "aVeryL0000ngSecret"
-	ctx              = context.Background()
-	page       int64 = 0
-	pageSize   int64 = 10
+	exampleSec = "aVeryL0000ngSecret"
+	ctx        = context.Background()
 )
 
 func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
@@ -83,7 +81,16 @@ func APIandMockClientsForTests() (*RESTClient, *clienttesting.MockClients) {
 func TestRESTClient_ListRobotAccounts(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize},
+	listRobotParams := &robot.ListRobotParams{
+		Page:     &apiClient.Options.Page,
+		PageSize: &apiClient.Options.PageSize,
+		Q:        &apiClient.Options.Query,
+		Sort:     &apiClient.Options.Sort,
+		Context:  ctx,
+	}
+	listRobotParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Robot.On("ListRobot", listRobotParams,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
@@ -98,7 +105,16 @@ func TestRESTClient_ListRobotAccounts(t *testing.T) {
 func TestRESTClient_GetRobotAccountByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+	listRobotParams := &robot.ListRobotParams{
+		Page:     &apiClient.Options.Page,
+		PageSize: &apiClient.Options.PageSize,
+		Q:        &apiClient.Options.Query,
+		Sort:     &apiClient.Options.Sort,
+		Context:  ctx,
+	}
+	listRobotParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Robot.On("ListRobot", listRobotParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
 	rAcc, err := apiClient.GetRobotAccountByName(ctx, "test-robot")
@@ -142,7 +158,16 @@ func TestRESTClient_NewRobotAccount(t *testing.T) {
 func TestRESTClient_DeleteRobotAccountByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+	listRobotParams := &robot.ListRobotParams{
+		Page:     &apiClient.Options.Page,
+		PageSize: &apiClient.Options.PageSize,
+		Q:        &apiClient.Options.Query,
+		Sort:     &apiClient.Options.Sort,
+		Context:  ctx,
+	}
+	listRobotParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Robot.On("ListRobot", listRobotParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
 	mockClient.Robot.On("DeleteRobot", &robot.DeleteRobotParams{Context: ctx, RobotID: exampleRobotAccount.ID}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
@@ -195,7 +220,16 @@ func TestRESTClient_RefreshRobotAccountSecretByID(t *testing.T) {
 func TestRESTClient_RefreshRobotAccountSecretByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
-	mockClient.Robot.On("ListRobot", &robot.ListRobotParams{Context: ctx, Page: &page, PageSize: &pageSize}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
+	listRobotParams := &robot.ListRobotParams{
+		Page:     &apiClient.Options.Page,
+		PageSize: &apiClient.Options.PageSize,
+		Q:        &apiClient.Options.Query,
+		Sort:     &apiClient.Options.Sort,
+		Context:  ctx,
+	}
+	listRobotParams.WithTimeout(apiClient.Options.Timeout)
+
+	mockClient.Robot.On("ListRobot", listRobotParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&robot.ListRobotOK{Payload: []*modelv2.Robot{exampleRobotAccount}}, nil)
 
 	mockClient.Robot.On("RefreshSec", &robot.RefreshSecParams{Context: ctx, RobotID: exampleRobotAccount.ID, RobotSec: &modelv2.RobotSec{Secret: exampleSec}}, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).


### PR DESCRIPTION
- `NewRobotAccount` method should return an additional `RobotCreated` in the result. Because the `Secret` of the created Robot Account could not retrieve later by Get methods, so, we need to know it after this method call.
  This resolve: #127 

- `ListRobotAccounts` method should return all robot accounts for the working correctly of `GetRobotAccountByName`, `DeleteRobotAccountByName` and `RefreshRobotAccountSecretByName` methods
  This resolve: #129 