### PR TITLE
feat: Add customer auth func

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -130,6 +130,23 @@ func NewRESTClientForHost(u, username, password string, opts *config.Options) (*
 	return NewRESTClient(v2SwaggerClient, opts, authInfo), nil
 }
 
+// NewRESTClientWithAuthFunc constructs a new REST client containing a swagger API client using the defined
+// host string and basePath, the additional Harbor v2 API suffix as well as a custom auth func, e.g. basic auth or token auth.
+func NewRESTClientWithAuthFunc(u string, authFunc runtime.ClientAuthInfoWriterFunc, opts *config.Options) (*RESTClient, error) {
+	if !strings.HasSuffix(u, v2URLSuffix) {
+		u += v2URLSuffix
+	}
+
+	harborURL, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	v2SwaggerClient := v2client.New(runtimeclient.New(harborURL.Host, harborURL.Path, []string{harborURL.Scheme}), strfmt.Default)
+
+	return NewRESTClient(v2SwaggerClient, opts, authFunc), nil
+}
+
 // AuditLog Client
 
 func (c *RESTClient) ListAuditLogs(ctx context.Context) ([]*modelv2.AuditLog, error) {

--- a/apiv2/client_test.go
+++ b/apiv2/client_test.go
@@ -4,6 +4,7 @@ package apiv2
 
 import (
 	"context"
+	"github.com/go-openapi/runtime"
 	"net/url"
 
 	"github.com/mittwald/goharbor-client/v5/apiv2/model"
@@ -109,6 +110,30 @@ func ExampleNewRESTClient_withOptions() {
 
 func ExampleRESTClient_NewUser() {
 	err := harborClient.NewUser(ctx, "test-user", "foo@example.com", "test user", "password", "a test user")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ExampleNewRESTClientWithAuthFunc() {
+	// This example constructs a new goharbor-client for a goharbor instance
+	// and create an example project.
+	ctx := context.Background()
+	apiURL := "harbor.mydomain.com/api"
+	tokenAuthFunc := func() runtime.ClientAuthInfoWriterFunc {
+		return runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
+			return r.SetHeaderParam("Authorization", "Bearer 123456")
+		})
+	}
+	harborClient, err := NewRESTClientWithAuthFunc(apiURL, tokenAuthFunc(), nil)
+	if err != nil {
+		panic(err)
+	}
+
+	err = harborClient.NewProject(ctx, &model.ProjectReq{
+		ProjectName: "my-project",
+	})
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Signed-off-by: lengrongfu <1275177125@qq.com>

Add a method `NewRESTClientWithAuthFunc` to initialize `Client` through a custom authentication function;
Our `Harbor` uses `OIDC` authentication, cannot use `basic auth`, and needs to use `Auth token`.