### PR TITLE
refactor list methods to bypass pagination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 harbor-teardown test integration-test-v1-ci integration-test-v2-ci integration-test-v1 integration-test-v2 \
 fmt gofmt gofumpt goimports lint uninstall-harbor-v2 uninstall-harbor-v1
 
-V1_VERSION = v1.10.13
+V1_VERSION = v1.10.12
 V2_VERSION = v2.5.3
 MOCKERY_VERSION = v2.14.0
 GOSWAGGER_VERSION = v0.25.0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 harbor-teardown test integration-test-v1-ci integration-test-v2-ci integration-test-v1 integration-test-v2 \
 fmt gofmt gofumpt goimports lint uninstall-harbor-v2 uninstall-harbor-v1
 
-V1_VERSION = v1.10.11
+V1_VERSION = v1.10.13
 V2_VERSION = v2.5.3
 MOCKERY_VERSION = v2.14.0
 GOSWAGGER_VERSION = v0.25.0

--- a/apiv2/pkg/clients/artifact/artifact_integration_test.go
+++ b/apiv2/pkg/clients/artifact/artifact_integration_test.go
@@ -110,17 +110,13 @@ func TestAPIAddLabel(t *testing.T) {
 //	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 //
 //	artifact, err := c.GetAddition(ctx, projectName, repositoryName, reference, AdditionBuildHistory)
-//	fmt.Println(err.Error())
 //	require.NoError(t, err)
-//
-//	fmt.Println(artifact)
-//}
+// }
 
 //func TestAPIGetVulnerabilitiesAddition(t *testing.T) {
 //	ctx := context.Background()
 //	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
 //
 //	_, err := c.GetVulnerabilitiesAddition(ctx, projectName, repositoryName, reference)
-//	fmt.Println(err)
 //	require.Error(t, err)
 //}

--- a/apiv2/pkg/clients/artifact/artifact_test.go
+++ b/apiv2/pkg/clients/artifact/artifact_test.go
@@ -254,7 +254,7 @@ func TestRESTClient_ListArtifacts(t *testing.T) {
 
 	resp, err := apiClient.ListArtifacts(ctx, projectName, repositoryName)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+	require.Len(t, resp, 0)
 
 	mockClient.Artifact.AssertExpectations(t)
 }
@@ -278,7 +278,7 @@ func TestRESTClient_ListTags(t *testing.T) {
 
 	resp, err := apiClient.ListTags(ctx, projectName, repositoryName, reference)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+	require.Len(t, resp, 0)
 
 	mockClient.Artifact.AssertExpectations(t)
 }

--- a/apiv2/pkg/clients/auditlog/auditlog.go
+++ b/apiv2/pkg/clients/auditlog/auditlog.go
@@ -2,7 +2,6 @@ package auditlog
 
 import (
 	"context"
-
 	"github.com/go-openapi/runtime"
 
 	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
@@ -37,17 +36,39 @@ type Client interface {
 
 // ListAuditLogs lists the audit logs of all projects the current user is a member of.
 func (c *RESTClient) ListAuditLogs(ctx context.Context) ([]*model.AuditLog, error) {
+	var auditLogs []*model.AuditLog
+	page := c.Options.Page
+
 	params := auditlog.ListAuditLogsParams{
+		Page:     &page,
 		PageSize: &c.Options.PageSize,
 		Q:        &c.Options.Query,
 		Sort:     &c.Options.Sort,
 		Context:  ctx,
 	}
 
-	resp, err := c.V2Client.Auditlog.ListAuditLogs(&params, c.AuthInfo)
-	if err != nil {
-		return nil, handleSwaggerAuditLogErrors(err)
+	params.WithTimeout(c.Options.Timeout)
+
+	for {
+		resp, err := c.V2Client.Auditlog.ListAuditLogs(&params, c.AuthInfo)
+		if err != nil {
+			return nil, handleSwaggerAuditLogErrors(err)
+		}
+		
+		if len(resp.Payload) == 0 {
+			break
+		}
+
+		totalCount := resp.XTotalCount
+
+		auditLogs = append(auditLogs, resp.Payload...)
+
+		if int64(len(auditLogs)) >= totalCount {
+			break
+		}
+
+		page++
 	}
 
-	return resp.Payload, nil
+	return auditLogs, nil
 }

--- a/apiv2/pkg/clients/auditlog/auditlog_integration_test.go
+++ b/apiv2/pkg/clients/auditlog/auditlog_integration_test.go
@@ -4,7 +4,6 @@ package auditlog
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,44 +35,15 @@ func TestAPIListAuditLogs(t *testing.T) {
 
 	defer pc.DeleteProject(ctx, p.Name)
 
-	c.Options.PageSize = 1
+	c.Options.PageSize = 100
 
 	a, err := c.ListAuditLogs(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(a))
+	require.Greater(t, len(a), 0)
 
 	require.Equal(t, "create", a[0].Operation)
 	require.Equal(t, "test-auditlog", a[0].Resource)
 	require.Equal(t, "project", a[0].ResourceType)
 	require.Equal(t, "admin", a[0].Username)
-}
-
-func TestAPIListAuditLogs_BigPageSize(t *testing.T) {
-	ctx := context.Background()
-
-	storageLimit := int64(0)
-
-	c := NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-	c.Options.PageSize = 42
-
-	pc := project.NewClient(clienttesting.V2SwaggerClient, clienttesting.DefaultOpts, clienttesting.AuthInfo)
-
-	for i := 0; i < 42; i++ {
-		err := pc.NewProject(ctx, &modelv2.ProjectReq{
-			ProjectName:  "test-auditlog-" + strconv.Itoa(i),
-			StorageLimit: &storageLimit,
-		})
-		require.NoError(t, err)
-
-		p, err := pc.GetProject(ctx, "test-auditlog-"+strconv.Itoa(i))
-		require.NoError(t, err)
-
-		defer pc.DeleteProject(ctx, p.Name)
-	}
-
-	a, err := c.ListAuditLogs(ctx)
-	require.NoError(t, err)
-
-	require.Equal(t, 42, len(a))
 }

--- a/apiv2/pkg/clients/auditlog/auditlog_test.go
+++ b/apiv2/pkg/clients/auditlog/auditlog_test.go
@@ -33,11 +33,14 @@ func TestRESTClient_ListAuditLogs(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
 	listAuditLogsParams := &auditlog.ListAuditLogsParams{
+		Page:     &apiClient.Options.Page,
 		PageSize: &apiClient.Options.PageSize,
 		Q:        &apiClient.Options.Query,
 		Sort:     &apiClient.Options.Sort,
 		Context:  ctx,
 	}
+
+	listAuditLogsParams.WithTimeout(apiClient.Options.Timeout)
 
 	mockClient.Auditlog.On("ListAuditLogs", listAuditLogsParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&auditlog.ListAuditLogsOK{}, nil)

--- a/apiv2/pkg/clients/gc/gc.go
+++ b/apiv2/pkg/clients/gc/gc.go
@@ -2,7 +2,6 @@ package gc
 
 import (
 	"context"
-
 	"github.com/go-openapi/runtime"
 
 	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
@@ -10,7 +9,7 @@ import (
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/errors"
 
-	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
 )
 
 // RESTClient is a subclient for handling system related actions.
@@ -34,16 +33,16 @@ func NewClient(v2Client *v2client.Harbor, opts *config.Options, authInfo runtime
 }
 
 type Client interface {
-	NewGarbageCollection(ctx context.Context, gcSchedule *modelv2.Schedule) error
+	NewGarbageCollection(ctx context.Context, gcSchedule *model.Schedule) error
 	UpdateGarbageCollection(ctx context.Context,
-		newGCSchedule *modelv2.Schedule) error
-	GetGarbageCollectionExecution(ctx context.Context, id int64) (*modelv2.GCHistory, error)
-	GetGarbageCollectionSchedule(ctx context.Context) (*modelv2.GCHistory, error)
+		newGCSchedule *model.Schedule) error
+	GetGarbageCollectionExecution(ctx context.Context, id int64) (*model.GCHistory, error)
+	GetGarbageCollectionSchedule(ctx context.Context) (*model.GCHistory, error)
 	ResetGarbageCollection(ctx context.Context) error
 }
 
 // NewGarbageCollection creates a new garbage collection schedule.
-func (c *RESTClient) NewGarbageCollection(ctx context.Context, gcSchedule *modelv2.Schedule) error {
+func (c *RESTClient) NewGarbageCollection(ctx context.Context, gcSchedule *model.Schedule) error {
 	if gcSchedule == nil {
 		return &errors.ErrSystemGcScheduleNotProvided{}
 	}
@@ -69,7 +68,7 @@ func (c *RESTClient) NewGarbageCollection(ctx context.Context, gcSchedule *model
 
 // UpdateGarbageCollection updates the system GC schedule.
 func (c *RESTClient) UpdateGarbageCollection(ctx context.Context,
-	newGCSchedule *modelv2.Schedule) error {
+	newGCSchedule *model.Schedule) error {
 	if newGCSchedule == nil {
 		return &errors.ErrSystemGcScheduleNotProvided{}
 	}
@@ -88,7 +87,7 @@ func (c *RESTClient) UpdateGarbageCollection(ctx context.Context,
 }
 
 // GetGarbageCollectionExecution Returns a garbage collection execution identified by its id.
-func (c *RESTClient) GetGarbageCollectionExecution(ctx context.Context, id int64) (*modelv2.GCHistory, error) {
+func (c *RESTClient) GetGarbageCollectionExecution(ctx context.Context, id int64) (*model.GCHistory, error) {
 	resp, err := c.V2Client.GC.GetGC(&gc.GetGCParams{
 		Context: ctx,
 		GCID:    id,
@@ -105,7 +104,7 @@ func (c *RESTClient) GetGarbageCollectionExecution(ctx context.Context, id int64
 }
 
 // GetGarbageCollectionSchedule returns the system GC schedule.
-func (c *RESTClient) GetGarbageCollectionSchedule(ctx context.Context) (*modelv2.GCHistory, error) {
+func (c *RESTClient) GetGarbageCollectionSchedule(ctx context.Context) (*model.GCHistory, error) {
 	resp, err := c.V2Client.GC.GetGCSchedule(&gc.GetGCScheduleParams{
 		Context: ctx,
 	}, c.AuthInfo)
@@ -125,11 +124,11 @@ func (c *RESTClient) GetGarbageCollectionSchedule(ctx context.Context) (*modelv2
 // For this to work correctly, a GC schedule must exist beforehand.
 func (c *RESTClient) ResetGarbageCollection(ctx context.Context) error {
 	_, err := c.V2Client.GC.UpdateGCSchedule(&gc.UpdateGCScheduleParams{
-		Schedule: &modelv2.Schedule{
+		Schedule: &model.Schedule{
 			Parameters: map[string]interface{}{
 				"delete_untagged": false,
 			},
-			Schedule: &modelv2.ScheduleObj{
+			Schedule: &model.ScheduleObj{
 				Type: "None",
 			},
 		},

--- a/apiv2/pkg/clients/health/health.go
+++ b/apiv2/pkg/clients/health/health.go
@@ -7,7 +7,7 @@ import (
 
 	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"
 	"github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client/health"
-	modelv2 "github.com/mittwald/goharbor-client/v5/apiv2/model"
+	"github.com/mittwald/goharbor-client/v5/apiv2/model"
 	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
 )
 
@@ -32,10 +32,10 @@ func NewClient(v2Client *v2client.Harbor, opts *config.Options, authInfo runtime
 }
 
 type Client interface {
-	GetHealth(ctx context.Context) (*modelv2.OverallHealthStatus, error)
+	GetHealth(ctx context.Context) (*model.OverallHealthStatus, error)
 }
 
-func (c *RESTClient) GetHealth(ctx context.Context) (*modelv2.OverallHealthStatus, error) {
+func (c *RESTClient) GetHealth(ctx context.Context) (*model.OverallHealthStatus, error) {
 	params := &health.GetHealthParams{
 		Context: ctx,
 	}

--- a/apiv2/pkg/clients/member/member_integration_test.go
+++ b/apiv2/pkg/clients/member/member_integration_test.go
@@ -99,6 +99,7 @@ func TestAPIProjectMemberList(t *testing.T) {
 		},
 		RoleID: 1,
 	})
+
 	require.NoError(t, err)
 
 	members, err = c.ListProjectMembers(ctx, p.Name, u.Username)

--- a/apiv2/pkg/clients/member/member_test.go
+++ b/apiv2/pkg/clients/member/member_test.go
@@ -74,6 +74,7 @@ func TestRESTClient_ListProjectMembers(t *testing.T) {
 
 	listParams := &member.ListProjectMembersParams{
 		Entityname:      &exampleMember.MemberUser.Username,
+		Page:            &apiClient.Options.Page,
 		PageSize:        &apiClient.Options.PageSize,
 		ProjectNameOrID: exampleProject.Name,
 		Context:         ctx,
@@ -97,6 +98,7 @@ func TestRESTClient_ListProjectMembers_ErrProjectUnknownResource(t *testing.T) {
 
 	listParams := &member.ListProjectMembersParams{
 		Entityname:      &exampleMember.MemberUser.Username,
+		Page:            &apiClient.Options.Page,
 		PageSize:        &apiClient.Options.PageSize,
 		ProjectNameOrID: exampleProject.Name,
 		Context:         ctx,
@@ -122,6 +124,7 @@ func TestRESTClient_UpdateProjectMember(t *testing.T) {
 	q := ""
 	listParams := &member.ListProjectMembersParams{
 		Entityname:      &q,
+		Page:            &apiClient.Options.Page,
 		PageSize:        &apiClient.Options.PageSize,
 		ProjectNameOrID: exampleProject.Name,
 		Context:         ctx,
@@ -166,6 +169,7 @@ func TestRESTClient_DeleteProjectMember(t *testing.T) {
 	q := ""
 	listParams := &member.ListProjectMembersParams{
 		Entityname:      &q,
+		Page:            &apiClient.Options.Page,
 		PageSize:        &apiClient.Options.PageSize,
 		ProjectNameOrID: exampleProject.Name,
 		Context:         ctx,

--- a/apiv2/pkg/clients/project/project_test.go
+++ b/apiv2/pkg/clients/project/project_test.go
@@ -384,6 +384,7 @@ func TestRESTClient_ListProjects(t *testing.T) {
 
 	listParams := &projectapi.ListProjectsParams{
 		Name:     &exampleProject.Name,
+		Page:     &apiClient.Options.Page,
 		PageSize: &apiClient.Options.PageSize,
 		Q:        &apiClient.Options.Query,
 		Sort:     &apiClient.Options.Sort,
@@ -400,53 +401,6 @@ func TestRESTClient_ListProjects(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient.Project.AssertExpectations(t)
-}
-
-func TestRESTClient_ListProjectsErrProjectNotFound(t *testing.T) {
-	apiClient, mockClient := APIandMockClientsForTests()
-
-	listParams := &projectapi.ListProjectsParams{
-		Name:     &exampleProject.Name,
-		PageSize: &apiClient.Options.PageSize,
-		Q:        &apiClient.Options.Query,
-		Sort:     &apiClient.Options.Sort,
-		Context:  ctx,
-	}
-
-	listParams.WithTimeout(apiClient.Options.Timeout)
-
-	mockClient.Project.On("ListProjects", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-		Return(&projectapi.ListProjectsOK{}, nil)
-
-	resp, err := apiClient.ListProjects(ctx, exampleProject.Name)
-
-	require.Error(t, err)
-	require.ErrorIs(t, err, &errors.ErrProjectNotFound{})
-	require.Nil(t, resp)
-
-	mockClient.Project.AssertExpectations(t)
-}
-
-func TestRESTClient_ListProjects_ErrProjectUnknownResource(t *testing.T) {
-	apiClient, mockClient := APIandMockClientsForTests()
-
-	listParams := &projectapi.ListProjectsParams{
-		Name:     &exampleProject.Name,
-		PageSize: &apiClient.Options.PageSize,
-		Q:        &apiClient.Options.Query,
-		Sort:     &apiClient.Options.Sort,
-		Context:  ctx,
-	}
-
-	listParams.WithTimeout(apiClient.Options.Timeout)
-
-	mockClient.Project.On("ListProjects", listParams, mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
-		Return(&projectapi.ListProjectsOK{Payload: []*modelv2.Project{exampleProject}}, &runtime.APIError{Code: http.StatusNotFound})
-
-	_, err := apiClient.ListProjects(ctx, exampleProject.Name)
-
-	require.Error(t, err)
-	require.ErrorIs(t, err, &errors.ErrProjectUnknownResource{})
 }
 
 func TestRESTClient_UpdateProject(t *testing.T) {

--- a/apiv2/pkg/clients/projectmeta/projectmeta.go
+++ b/apiv2/pkg/clients/projectmeta/projectmeta.go
@@ -2,7 +2,6 @@ package projectmeta
 
 import (
 	"context"
-
 	"github.com/go-openapi/runtime"
 
 	v2client "github.com/mittwald/goharbor-client/v5/apiv2/internal/api/client"

--- a/apiv2/pkg/clients/quota/quota_test.go
+++ b/apiv2/pkg/clients/quota/quota_test.go
@@ -45,6 +45,7 @@ func TestRESTClient_GetQuotaByProjectID_Unexpected(t *testing.T) {
 
 	refID := strconv.Itoa(int(exampleProjectID))
 	listParams := &quota.ListQuotasParams{
+		Page:        &apiClient.Options.Page,
 		PageSize:    &apiClient.Options.PageSize,
 		ReferenceID: &refID,
 		Sort:        &apiClient.Options.Sort,
@@ -70,6 +71,7 @@ func TestRESTClient_GetQuotaByProjectID(t *testing.T) {
 	refID := strconv.Itoa(int(exampleProjectID))
 
 	listParams := &quota.ListQuotasParams{
+		Page:        &apiClient.Options.Page,
 		PageSize:    &apiClient.Options.PageSize,
 		ReferenceID: &refID,
 		Sort:        &apiClient.Options.Sort,

--- a/apiv2/pkg/clients/registry/registry_test.go
+++ b/apiv2/pkg/clients/registry/registry_test.go
@@ -97,6 +97,7 @@ func TestRESTClient_GetRegistryByName(t *testing.T) {
 	name := "name=" + reg.Name
 
 	listParams := &registry.ListRegistriesParams{
+		Page:     &apiClient.Options.Page,
 		PageSize: &apiClient.Options.PageSize,
 		Q:        &name,
 		Sort:     &apiClient.Options.Sort,

--- a/apiv2/pkg/clients/user/user_test.go
+++ b/apiv2/pkg/clients/user/user_test.go
@@ -54,15 +54,6 @@ func TestTRESTClient_NewUser(t *testing.T) {
 
 	createParams.WithTimeout(apiClient.Options.Timeout)
 
-	listParams := &user.ListUsersParams{
-		PageSize: &clienttesting.DefaultOpts.PageSize,
-		Q:        &clienttesting.DefaultOpts.Query,
-		Sort:     &clienttesting.DefaultOpts.Sort,
-		Context:  ctx,
-	}
-
-	listParams.WithTimeout(apiClient.Options.Timeout)
-
 	mockClient.User.On("CreateUser", createParams,
 		mock.AnythingOfType("runtime.ClientAuthInfoWriterFunc")).
 		Return(&user.CreateUserCreated{}, nil)
@@ -151,6 +142,7 @@ func TestRESTClient_GetUserByName(t *testing.T) {
 	apiClient, mockClient := APIandMockClientsForTests()
 
 	listParams := &user.ListUsersParams{
+		Page:     &apiClient.Options.Page,
 		PageSize: &apiClient.Options.PageSize,
 		Q:        &apiClient.Options.Query,
 		Sort:     &apiClient.Options.Sort,
@@ -322,6 +314,7 @@ func TestRESTClient_UserExists(t *testing.T) {
 	getParams.WithTimeout(apiClient.Options.Timeout)
 
 	listParams := &user.ListUsersParams{
+		Page:     &apiClient.Options.Page,
 		PageSize: &apiClient.Options.PageSize,
 		Q:        &apiClient.Options.Query,
 		Sort:     &apiClient.Options.Sort,

--- a/apiv2/pkg/clients/webhook/webhook_test.go
+++ b/apiv2/pkg/clients/webhook/webhook_test.go
@@ -44,6 +44,7 @@ func TestRESTClient_ListProjectWebhookPolicies(t *testing.T) {
 	}
 
 	listParams := &webhook.ListWebhookPoliciesOfProjectParams{
+		Page:            &apiClient.Options.Page,
 		PageSize:        &apiClient.Options.PageSize,
 		ProjectNameOrID: util.ProjectIDAsString(1),
 		Q:               &apiClient.Options.Query,


### PR DESCRIPTION
Using any `List[...]`-method of the client will result in an invalid response, if the configured `page` or `pageSize` are smaller than the actual object count. This was resolved for the `robot` client in https://github.com/mittwald/goharbor-client/pull/128, with some small adaptations that came with https://github.com/mittwald/goharbor-client/pull/134.

This PR refactors _all_ `List[...]`-methods to bypass pagination by iterating until the value of `X-Total-Count` is reached.
List methods will also break when the response contains no objects in its payload. Due to the changes, some test cases got obsolete, while there is no breaking change included.

---

Package name imports of the `github.com/mittwald/goharbor-client/v5/apiv2/model` package have been renamed from `modelv2` to `model` throughout the `apiv2` client.

The `V1_VERSION` (used for code generation & tests) was bumped to the latest `v1.10.13`.