### PR TITLE
FIX: Add error control on  the `GetReplicationPolicyByName()`

### DIFF
--- a/apiv2/pkg/clients/replication/replication.go
+++ b/apiv2/pkg/clients/replication/replication.go
@@ -93,8 +93,11 @@ func (c *RESTClient) GetReplicationPolicyByName(ctx context.Context, name string
 		return nil, err
 	}
 
-	if len(policies) > 1 {
+	switch {
+	case len(policies) > 1:
 		return nil, &errors.ErrMultipleResults{}
+	case len(policies) == 0:
+		return nil, &errors.ErrNotFound{}
 	}
 
 	return policies[0], nil


### PR DESCRIPTION
Return `ErrNotFound` on the `GetReplicationPolicyByName()` when there are no Replications defined on the server. Otherwise, the client fails.

Close #177