### PR TITLE
Add another method to create a REST Client using a configurable http.client object

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -2,6 +2,7 @@ package apiv2
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -145,6 +146,24 @@ func NewRESTClientForHost(u, username, password string, opts *config.Options) (*
 	}
 
 	v2SwaggerClient := v2client.New(runtimeclient.New(harborURL.Host, harborURL.Path, []string{harborURL.Scheme}), strfmt.Default)
+	authInfo := runtimeclient.BasicAuth(username, password)
+
+	return NewRESTClient(v2SwaggerClient, opts, authInfo), nil
+}
+
+// NewRESTClientForHostWithClient constructs a new REST client containing a swagger API client using the defined
+// host string and basePath, the additional Harbor v2 API suffix as well as basic auth info while using provided http client.
+func NewRESTClientForHostWithClient(u, username, password string, opts *config.Options, client *http.Client) (*RESTClient, error) {
+	if !strings.HasSuffix(u, v2URLSuffix) {
+		u += v2URLSuffix
+	}
+
+	harborURL, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	v2SwaggerClient := v2client.New(runtimeclient.NewWithClient(harborURL.Host, harborURL.Path, []string{harborURL.Scheme}, client), strfmt.Default)
 	authInfo := runtimeclient.BasicAuth(username, password)
 
 	return NewRESTClient(v2SwaggerClient, opts, authInfo), nil

--- a/apiv2/client_test.go
+++ b/apiv2/client_test.go
@@ -71,6 +71,42 @@ func ExampleNewRESTClient() {
 	}
 }
 
+func ExampleNewRESTClientWithHttpClient() {
+	// This example constructs a new (goharbor) REST client
+	// and create an example project.
+	ctx := context.Background()
+	apiURL := "harbor.mydomain.com/api"
+	username := "user"
+	password := "password"
+
+	var optsTLS runtimeclient.TLSClientOptions
+	// optsTLS.Certificate = "/path/to/client.crt"
+	// optsTLS.Key = "/path/to/client.Key"
+	// optsTLS.CA = "/path/to/rootca.cert.pem"
+	client, err := runtimeclient.TLSClient(optsTLS)
+	if err != nil {
+		return nil, err
+	}
+
+	harborURL, err := url.Parse(apiURL)
+	if err != nil {
+		panic(err)
+	}
+
+	v2SwaggerClient := v2client.New(runtimeclient.NewWithClient(harborURL.Host, harborURL.Path, []string{harborURL.Scheme}), strfmt.Default)
+	authInfo := runtimeclient.BasicAuth(username, password)
+
+	harborClient := NewRESTClient(v2SwaggerClient, nil, authInfo)
+
+	err = harborClient.NewProject(ctx, &model.ProjectReq{
+		ProjectName: "my-project",
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}
+
 func ExampleNewRESTClient_withOptions() {
 	// This example constructs a new (goharbor) REST client using the provided 'options',
 	// and lists all projects matching the 'options' configuration.


### PR DESCRIPTION
The current methods doesn't allow to configure some of the TLS options, such as to configure certificates/CAs to use (In case these are not available in the default go's lookup paths), to ignore certificate verification, among other ones.