### PR TITLE
Add `Deletion` parameter on create replication policy

### DIFF
--- a/apiv2/pkg/clients/registry/registry.go
+++ b/apiv2/pkg/clients/registry/registry.go
@@ -87,10 +87,10 @@ func (c *RESTClient) GetRegistryByName(ctx context.Context, name string) (*model
 	}
 
 	switch nregistries := len(registries); {
-		case nregistries > 1:
-			return nil, &errors.ErrMultipleResults{}
-		case nregistries == 0:
-			return nil, &errors.ErrRegistryNotFound{}
+	case nregistries > 1:
+		return nil, &errors.ErrMultipleResults{}
+	case nregistries == 0:
+		return nil, &errors.ErrRegistryNotFound{}
 	}
 	return registries[0], nil
 }

--- a/apiv2/pkg/clients/replication/replication.go
+++ b/apiv2/pkg/clients/replication/replication.go
@@ -64,6 +64,7 @@ func (c *RESTClient) NewReplicationPolicy(ctx context.Context, destRegistry, src
 			Name:                      name,
 			Override:                  override,
 			ReplicateDeletion:         replicateDeletion,
+			Deletion:                  replicateDeletion,
 			SrcRegistry:               srcRegistry,
 			Trigger:                   trigger,
 		},

--- a/apiv2/pkg/clients/replication/replication_test.go
+++ b/apiv2/pkg/clients/replication/replication_test.go
@@ -33,6 +33,7 @@ var (
 	destNamespace     = ns
 	replication       = &modelv2.ReplicationPolicy{
 		ReplicateDeletion: replicateDeletion,
+		Deletion:          replicateDeletion,
 		Description:       description,
 		DestNamespace:     destNamespace,
 		DestRegistry:      destRegistry,


### PR DESCRIPTION
By adding the `deletion` param on the` CreateReplicationPolicyParams{}` we ensure retrocompatibility with Harbor API.

close #182 