### PR TITLE
Added param to fetch artifact accessories when getting an artifact.

### DIFF
--- a/apiv2/pkg/clients/artifact/artifact.go
+++ b/apiv2/pkg/clients/artifact/artifact.go
@@ -165,6 +165,7 @@ func (c *RESTClient) GetArtifact(ctx context.Context, projectName, repositoryNam
 	params.WithReference(reference)
 	params.WithContext(ctx)
 	params.WithWithLabel(util.BoolPtr(true))
+	params.WithWithAccessory(util.BoolPtr(true))
 
 	resp, err := c.V2Client.Artifact.GetArtifact(params, c.AuthInfo)
 	if err != nil {

--- a/apiv2/pkg/clients/artifact/artifact_test.go
+++ b/apiv2/pkg/clients/artifact/artifact_test.go
@@ -225,6 +225,7 @@ func TestRESTClient_GetArtifact(t *testing.T) {
 	getParams.WithReference(reference)
 	getParams.WithContext(ctx)
 	getParams.WithWithLabel(util.BoolPtr(true))
+	getParams.WithWithAccessory(util.BoolPtr(true))
 
 	getParams.WithTimeout(apiClient.Options.Timeout)
 


### PR DESCRIPTION
The current method doesn't allow us to get an artifact accessories. By adding this param, we return the artifact accessories when getting the artifact