### PR TITLE
Added missing method to get the list of the latest GC executions

### DIFF
--- a/apiv2/client.go
+++ b/apiv2/client.go
@@ -86,7 +86,7 @@ type RESTClient struct {
 	configure   *configure.RESTClient
 	gc          *gc.RESTClient
 	health      *health.RESTClient
-	immutable	*immutable.RESTClient
+	immutable   *immutable.RESTClient
 	label       *label.RESTClient
 	member      *member.RESTClient
 	ping        *ping.RESTClient
@@ -265,6 +265,10 @@ func (c *RESTClient) NewGarbageCollection(ctx context.Context, gcSchedule *model
 
 func (c *RESTClient) UpdateGarbageCollection(ctx context.Context, newGCSchedule *modelv2.Schedule) error {
 	return c.gc.UpdateGarbageCollection(ctx, newGCSchedule)
+}
+
+func (c *RESTClient) GetGarbageCollectionExecutions(ctx context.Context) ([]*modelv2.GCHistory, error) {
+	return c.gc.GetGarbageCollectionExecutions(ctx)
 }
 
 func (c *RESTClient) GetGarbageCollectionExecution(ctx context.Context, id int64) (*modelv2.GCHistory, error) {

--- a/apiv2/pkg/clients/gc/gc.go
+++ b/apiv2/pkg/clients/gc/gc.go
@@ -37,6 +37,7 @@ type Client interface {
 	NewGarbageCollection(ctx context.Context, gcSchedule *model.Schedule) error
 	UpdateGarbageCollection(ctx context.Context,
 		newGCSchedule *model.Schedule) error
+	GetGarbageCollectionExecutions(ctx context.Context) ([]*model.GCHistory, error)
 	GetGarbageCollectionExecution(ctx context.Context, id int64) (*model.GCHistory, error)
 	GetGarbageCollectionSchedule(ctx context.Context) (*model.GCHistory, error)
 	ResetGarbageCollection(ctx context.Context) error
@@ -86,6 +87,18 @@ func (c *RESTClient) UpdateGarbageCollection(ctx context.Context,
 	}, c.AuthInfo)
 
 	return handleSwaggerSystemErrors(err)
+}
+
+// GetGarbageCollectionExecutions Returns the garbage collection executions.
+func (c *RESTClient) GetGarbageCollectionExecutions(ctx context.Context) ([]*model.GCHistory, error) {
+	resp, err := c.V2Client.GC.GetGCHistory(&gc.GetGCHistoryParams{
+		Context: ctx,
+	}, c.AuthInfo)
+	if err != nil {
+		return nil, handleSwaggerSystemErrors(err)
+	}
+
+	return resp.Payload, nil
 }
 
 // GetGarbageCollectionExecution Returns a garbage collection execution identified by its id.


### PR DESCRIPTION
This PR adds a missing method to the client to get the list of the latest GC executions