### PR TITLE
Fixes retention untagged behaviour in ToTagSelectorExtras

### DIFF
--- a/apiv2/pkg/clients/retention/retention.go
+++ b/apiv2/pkg/clients/retention/retention.go
@@ -206,9 +206,9 @@ func (c *RESTClient) UpdateRetentionPolicy(ctx context.Context, ret *modelv2.Ret
 // Represents the functionality of the 'untagged artifacts' checkbox when editing tag retention rules in the Harbor UI.
 func ToTagSelectorExtras(untagged bool) string {
 	if untagged {
-		return `{"untagged":"true"}`
+		return `{"untagged":true}`
 	}
-	return `{"untagged":"false"}`
+	return `{"untagged":false}`
 }
 
 // evaluateRetentionRuleParams evaluates the provided map of PolicyTemplate by comparing the keys to the pre-defined PolicyTemplates.

--- a/apiv2/pkg/clients/retention/retention_test.go
+++ b/apiv2/pkg/clients/retention/retention_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -215,4 +216,16 @@ func TestRESTClient_DeleteRetentionPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	mockClient.Retention.AssertExpectations(t)
+}
+
+func TestToTagSelectorExtras(t *testing.T) {
+	expectWithUntagged := `{"untagged":true}`
+	actualWithUntagged := ToTagSelectorExtras(true)
+
+	assert.Equal(t, expectWithUntagged, actualWithUntagged)
+
+	expectWithoutUntagged := `{"untagged":false}`
+	actualWithoutUntagged := ToTagSelectorExtras(false)
+
+	assert.Equal(t, expectWithoutUntagged, actualWithoutUntagged)
 }


### PR DESCRIPTION
**Fix**: correct retention behavior for untagged in ToTagSelectorExtras

**Summary**
This PR fixes incorrect handling of untagged artifacts when building selectors in ToTagSelectorExtras. The change ensures that tag filtering behaves as expected and does not introduce side effects for other selector types.

**What was done**

Fixed the logic for handling untagged tags in ToTagSelectorExtras so that filters are applied correctly.

**Testing**

Added/updated unit tests to cover the untagged selector scenario.

**Backward compatibility**

This change does not modify the public
